### PR TITLE
Killed redundant and confusing Event#location

### DIFF
--- a/app/components/event/_event.html.erb
+++ b/app/components/event/_event.html.erb
@@ -28,13 +28,13 @@
         <span class="icon icon--date">📅</span>
         <%= date %>
       </div>
-      <% if place || location %>
+      <% if place || first_address_line %>
         <div class="event__detail event__location">
           <span class="icon icon--place">🏠</span>
           <% if place %>
             <%= link_to place, place_path(place) %>
-          <% elsif location %>
-            <%= location %>
+          <% elsif first_address_line %>
+            <%= first_address_line %>
           <% end %>
         </div>
       <% end %>

--- a/app/components/event/event.yml
+++ b/app/components/event/event.yml
@@ -14,7 +14,9 @@
         :summary: 'Event with a location and neighbourhood turf'
         :dtstart: 2017-10-02 10:30:00
         :dtend: 2017-10-02 14:00:00
-        :location: "Name of room or un-geolocated address"
+        :address: !ruby/object:OpenStruct
+          table:
+           :street_address: "Name of room or un-geolocated address"
         :neighbourhood_turf: !ruby/object:OpenStruct
           table:
             :name: Turfy
@@ -25,7 +27,6 @@
         :summary: 'Event with a Place chooses place over address'
         :dtstart: 2017-10-02 12:00:00
         :dtend: 2017-10-02 14:00:00
-        :location: "Will be ignored"
         :place: Place that PlaceCal knows about
         :neighbourhood_turf: !ruby/object:OpenStruct
           table:

--- a/app/components/event/event_component.rb
+++ b/app/components/event/event_component.rb
@@ -14,10 +14,6 @@ class EventComponent < MountainView::Presenter
     event.place
   end
 
-  def location
-    event.location
-  end
-
   def time
     if event.dtend
       fmt_time(event.dtstart) + ' – ' + fmt_time(event.dtend)
@@ -55,8 +51,8 @@ class EventComponent < MountainView::Presenter
     event.partner.first
   end
 
-  def location
-    event.location&.split(',')&.first&.delete('\\')
+  def first_address_line
+    event.address&.street_address&.delete('\\')
   end
 
   def repeats

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -64,11 +64,6 @@ class Event < ApplicationRecord
     self.rrule = false if rrule.nil? || rrule == []
   end
 
-  # TODO? This hides the accessor for the location column. Is this the intention?
-  def location
-    address.to_s
-  end
-
   # Make sure that setting the event's Place also sets the event's Address. This
   # way we never need to choose between Event#address and Event#place.address
   # This is particularly important for joins for neighbourhood turfs.


### PR DESCRIPTION
Removed Event#location.
* The only place it was called from was the EventComponent UI class.
* Changed EventComponent to use Event#address directly.