### PR TITLE
Feature/configure neighbourhoods for default site

### DIFF
--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -37,6 +37,7 @@ module Admin
       if @site.update_attributes(site_params)
         redirect_to admin_sites_path
       else
+        set_variables_for_sites_neighbourhoods_selection
         render 'edit'
       end
     end
@@ -56,9 +57,9 @@ module Admin
     end
 
     def set_variables_for_sites_neighbourhoods_selection
-      @all_neighbourhoods = Neighbourhood.all
+      @all_neighbourhoods = Neighbourhood.all.order(:name)
       begin
-        @site = Site.friendly.find(params[:id])
+        set_site
       rescue ActiveRecord::RecordNotFound
         @primary_neighbourhood_id = nil
         @secondary_neighbourhood_ids = []

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,10 +65,26 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Get an object representing the requested site.
+  # Side effects:
+  # - If the requested site is invalid then redirect to the home page of the
+  #   default site.
   def current_site
-    subdomain = request.subdomain
-    subdomain = 'placecal-default-site' if subdomain.blank?
-    Site.find_by(slug: subdomain)
+
+    site_slug =
+      if request.subdomain == 'www'
+        if request.subdomains.second
+          request.subdomains.second
+        end
+      elsif request.subdomain.present?
+        request.subdomain
+      end
+    site_slug ||= 'default-site'
+
+    site = Site.find_by(slug: site_slug)
+    redirect_to( root_url( :subdomain => false ) ) unless site
+
+    site
   end
 
   def set_primary_neighbourhood

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,7 +66,9 @@ class ApplicationController < ActionController::Base
   end
 
   def current_site
-    Site.find_by(slug: request.subdomain)
+    subdomain = request.subdomain
+    subdomain = 'placecal-default-site' if subdomain.blank?
+    Site.find_by(slug: subdomain)
   end
 
   def set_primary_neighbourhood
@@ -160,7 +162,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_site
-    @site = Site.find_by(slug: request.subdomain)
+    @site = current_site
   end
 
   protected

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -10,12 +10,7 @@ class PartnersController < ApplicationController
   # GET /partners
   # GET /partners.json
   def index
-    if current_site
-      @partners = Partner.for_site(current_site).order(:name)
-    else # this is the canonical site.
-      @partners = Partner.all.order(:name)
-    end
-
+    @partners = Partner.for_site(current_site).order(:name)
     @map = generate_points(@partners) if @partners.detect(&:address)
   end
 

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -10,12 +10,7 @@ class PlacesController < ApplicationController
   before_action :set_title, only: %i[index show]
 
   def index
-    if current_site
-      @places = Place.for_site(current_site).order(:name)
-    else # this is the canonical site.
-      @places = Place.all.order(:name)
-    end
-
+    @places = Place.for_site(current_site).order(:name)
     @map = generate_points(@places)
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -99,7 +99,7 @@ class Event < ApplicationRecord
 
   # Make sure that setting the event's Place also sets the event's Address. This
   # way we never need to choose between Event#address and Event#place.address
-  # This is particularly important for joins for neighbourhood turfs.
+  # This is particularly important for joins for neighbourhoods.
   def set_address_from_place
     self.address_id = self.place.address_id if self.place_id
   end

--- a/db/migrate/20181001150453_add_default_site.rb
+++ b/db/migrate/20181001150453_add_default_site.rb
@@ -1,0 +1,18 @@
+class AddDefaultSite < ActiveRecord::Migration[5.1]
+  def up
+    execute(
+%(insert into sites
+(name, domain, slug, created_at, updated_at)
+values
+('PlaceCal default site', 'placecal.org', 'placecal-default-site', now(), now()) ;)
+    )
+  end
+
+  def down
+    execute(
+%(delete from sites_neighbourhoods where site_id =
+(select id from sites where slug = 'placecal-default-site');)
+    )
+    execute( "delete from sites where slug = 'placecal-default-site';" )
+  end
+end

--- a/db/migrate/20181001150453_add_default_site.rb
+++ b/db/migrate/20181001150453_add_default_site.rb
@@ -4,15 +4,15 @@ class AddDefaultSite < ActiveRecord::Migration[5.1]
 %(insert into sites
 (name, domain, slug, created_at, updated_at)
 values
-('PlaceCal default site', 'placecal.org', 'placecal-default-site', now(), now()) ;)
+('Default site (no subdomain)', 'placecal.org', 'default-site', now(), now()) ;)
     )
   end
 
   def down
     execute(
 %(delete from sites_neighbourhoods where site_id =
-(select id from sites where slug = 'placecal-default-site');)
+(select id from sites where slug = 'default-site');)
     )
-    execute( "delete from sites where slug = 'placecal-default-site';" )
+    execute( "delete from sites where slug = 'default-site';" )
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180926032437) do
+ActiveRecord::Schema.define(version: 20181001150453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -8,8 +8,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     # Deliberately saving address twice. (create + save) Second time overwrites neighbourhood.
     addresses = neighbourhoods.map {|n| a=create(:address); a.neighbourhood=n; a.save; a}
     @events = addresses.map { |a| e=build(:event); e.address=a; e.dtstart=Time.now; e.dtend=Time.now+1; e.save; e }
-    default_site = build(:site)
-    default_site.slug = 'default-site'
+    default_site = create_default_site
     default_site.neighbourhoods.append(neighbourhoods)
     default_site.save
     @site = build(:site)

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -8,6 +8,10 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     # Deliberately saving address twice. (create + save) Second time overwrites neighbourhood.
     addresses = neighbourhoods.map {|n| a=create(:address); a.neighbourhood=n; a.save; a}
     @events = addresses.map { |a| e=build(:event); e.address=a; e.dtstart=Time.now; e.dtend=Time.now+1; e.save; e }
+    default_site = build(:site)
+    default_site.slug = 'default-site'
+    default_site.neighbourhoods.append(neighbourhoods)
+    default_site.save
     @site = build(:site)
     @site.neighbourhoods.append(neighbourhoods.first)
     @site.neighbourhoods.append(neighbourhoods.second)
@@ -28,8 +32,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get index with invalid subdomain' do
     get url_for controller: :events, subdomain: "notaknownsubdomain"
-    assert_response :success
-    assert_select "ol.events li", 3
+    assert_response :redirect
   end
 
   test 'should show event' do

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -3,6 +3,10 @@
 require 'test_helper'
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    create_default_site
+  end
+
   test 'should get join page' do
     get join_url
     assert_response :success

--- a/test/controllers/partners_controller_test.rb
+++ b/test/controllers/partners_controller_test.rb
@@ -8,8 +8,7 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
     # Deliberately saving address twice. (create + save) Second time overwrites neighbourhood.
     addresses = neighbourhoods.map {|n| a=create(:address); a.neighbourhood=n; a.save; a}
     @partners = addresses.map {|a| pa=build(:partner); pa.address=a; pa.save; pa}
-    default_site = build(:site)
-    default_site.slug = 'default-site'
+    default_site = create_default_site
     default_site.neighbourhoods.append(neighbourhoods)
     default_site.save
     @site = build(:site)

--- a/test/controllers/partners_controller_test.rb
+++ b/test/controllers/partners_controller_test.rb
@@ -8,6 +8,10 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
     # Deliberately saving address twice. (create + save) Second time overwrites neighbourhood.
     addresses = neighbourhoods.map {|n| a=create(:address); a.neighbourhood=n; a.save; a}
     @partners = addresses.map {|a| pa=build(:partner); pa.address=a; pa.save; pa}
+    default_site = build(:site)
+    default_site.slug = 'default-site'
+    default_site.neighbourhoods.append(neighbourhoods)
+    default_site.save
     @site = build(:site)
     @site.neighbourhoods.append(neighbourhoods.first)
     @site.save
@@ -27,8 +31,7 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get index with unknown subdomain' do
     get url_for controller: "partners", subdomain: "notaknownsubdomain"
-    assert_response :success
-    assert_select "ul.partners li", 2
+    assert_response :redirect
   end
 
   test 'should show partner' do

--- a/test/controllers/places_controller_test.rb
+++ b/test/controllers/places_controller_test.rb
@@ -8,8 +8,7 @@ class PlacesControllerTest < ActionDispatch::IntegrationTest
     # Deliberately saving address twice. (create + save) Second time overwrites neighbourhood.
     addresses = neighbourhoods.map {|n| a=create(:address); a.neighbourhood=n; a.save; a}
     @places = addresses.map {|a| pl=build(:place); pl.address=a; pl.save; pl}
-    default_site = build(:site)
-    default_site.slug = 'default-site'
+    default_site = create_default_site
     default_site.neighbourhoods.append(neighbourhoods)
     default_site.save
     @site = build(:site)

--- a/test/controllers/places_controller_test.rb
+++ b/test/controllers/places_controller_test.rb
@@ -8,6 +8,10 @@ class PlacesControllerTest < ActionDispatch::IntegrationTest
     # Deliberately saving address twice. (create + save) Second time overwrites neighbourhood.
     addresses = neighbourhoods.map {|n| a=create(:address); a.neighbourhood=n; a.save; a}
     @places = addresses.map {|a| pl=build(:place); pl.address=a; pl.save; pl}
+    default_site = build(:site)
+    default_site.slug = 'default-site'
+    default_site.neighbourhoods.append(neighbourhoods)
+    default_site.save
     @site = build(:site)
     @site.neighbourhoods.append(neighbourhoods.first)
     @site.save
@@ -27,8 +31,7 @@ class PlacesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get index with unknown subdomain' do
     get url_for controller: "places", subdomain: "notaknownsubdomain"
-    assert_response :success
-    assert_select "ul.places li", 2
+    assert_response :redirect
   end
 
   test 'should show place' do

--- a/test/integration/partners_integration_test.rb
+++ b/test/integration/partners_integration_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class PartnersIntegrationTest < ActionDispatch::IntegrationTest
   setup do
+    create_default_site
     @partner = create(:partner)
   end
 

--- a/test/integration/places_integration_test.rb
+++ b/test/integration/places_integration_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class PlacesIntegrationTest < ActionDispatch::IntegrationTest
   setup do
+    create_default_site
     @place = create(:place)
   end
 

--- a/test/integration/sites_integration_test.rb
+++ b/test/integration/sites_integration_test.rb
@@ -11,14 +11,12 @@ class SitesIntegrationTest < ActionDispatch::IntegrationTest
 
   test 'load different pages based on subdomain' do
 
-    skip("Skip while we figure out the default site stuff")
-
     # Default: get home page
     get 'http://lvh.me'
     assert_template 'pages/home'
     # If there's no site, also get home
     get 'http://no-site-set.lvh.me'
-    assert_template 'pages/home'
+    assert_redirected_to 'http://lvh.me/'
     # If there's a match, display a custom homepage
     get 'http://hulme.lvh.me'
     assert_template 'sites/default.html.erb'

--- a/test/integration/sites_integration_test.rb
+++ b/test/integration/sites_integration_test.rb
@@ -4,11 +4,15 @@ require 'test_helper'
 
 class SitesIntegrationTest < ActionDispatch::IntegrationTest
   setup do
+    create_default_site
     @admin = create(:user)
     @site = create(:site, slug: 'hulme', site_admin: @admin)
   end
 
   test 'load different pages based on subdomain' do
+
+    skip("Skip while we figure out the default site stuff")
+
     # Default: get home page
     get 'http://lvh.me'
     assert_template 'pages/home'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,3 +57,16 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.allow_http_connections_when_no_cassette = true
 end
+
+# Create the default site.
+# Required for all tests that navigate to a URL without a subdomain.
+# Assumptions:
+#   FactoryBot is available.
+# Returns:
+#   The default site just created.
+def create_default_site
+  default_site = build(:site)
+  default_site.slug = 'default-site'
+  default_site.save
+  default_site
+end


### PR DESCRIPTION
Added a default site entry. This allows the neighbourhoods for the default site to be manually managed.