### PR TITLE
Fixed admin subdomain redirecting to default site.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,10 +66,13 @@ class ApplicationController < ActionController::Base
   end
 
   # Get an object representing the requested site.
+  # Note:
+  #   The admin sub-site does not have a Site object.
   # Side effects:
-  # - If the requested site is invalid then redirect to the home page of the
+  #   If the requested site is invalid then redirect to the home page of the
   #   default site.
   def current_site
+    return if request.subdomain == 'admin'
 
     site_slug =
       if request.subdomain == 'www'


### PR DESCRIPTION
Any action that called current_site on the admin site could trigger a redirect. Have now prevented this.