### PR TITLE
Switch to using a dokku managed crontab

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,5 +9,11 @@
     "dokku": {
       "postdeploy": "bundle exec rails db:migrate"
     }
-  }
+  },
+  "cron": [
+    {
+      "command": "bundle exec rails import:all_events",
+      "schedule": "*/10 * * * *"
+    }
+  ]
 }


### PR DESCRIPTION
Dokku has the ability to have it's own crontab thing in the `app.json` for actions that are intended to be run using `dokku enter`, since both production and staging have a crontab that has the `import:all_events` action running every ten minutes it's probably better to just stick it into the `app.json` and then any changes we need to make (none, but...) will just automagically sync across production and staging, it's also a 2 second conversion anyway since it's just commenting out the old crontab and adding like 2 or 3 lines to the `app.json` (as you can see here! haha)

it's a 1-1 conversion so there's almost no chance of it actually going wrong, I switched it to using `bundle exec rails import:all_events` because that seemed the most correct modification to it, those should be equivalent inside the Dokku container I think