### PR TITLE
Partner short_description -> summary/description

### DIFF
--- a/app/components/place_partner_preview/place_partner_preview.sass
+++ b/app/components/place_partner_preview/place_partner_preview.sass
@@ -1,6 +1,10 @@
 @import "variables_mixins.sass"
 
+.c
+  color: #fff
+
 .preview
+  color: #fff
   h3
     margin-bottom: 0
     margin-top: 0
@@ -21,6 +25,7 @@
       font-size: 1.33333rem
       align-self: center
       a
+        color: #fff
         text-decoration: none
         &:hover
           text-decoration: underline

--- a/app/components/place_partner_preview/place_partner_preview_component.rb
+++ b/app/components/place_partner_preview/place_partner_preview_component.rb
@@ -17,7 +17,7 @@ class PlacePartnerPreviewComponent < MountainView::Presenter
   end
 
   def description
-    previewee.short_description
+    previewee.summary
   end
 
   def primary_neighbourhood?

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -11,12 +11,11 @@ module Admin
 
       respond_to do |format|
         format.html
-        format.json { render json: PartnerDatatable.new(
-                                     params, 
-                                     view_context: view_context, 
-                                     partners: @partners
-                                   ) 
-                      }
+        format.json {
+          render json: PartnerDatatable.new(params,
+                                            view_context: view_context,
+                                            partners: @partners)
+        }
       end
     end
 
@@ -96,7 +95,7 @@ module Admin
     end
 
     def partner_params
-      attributes = [ :name, :image, :short_description,
+      attributes = [ :name, :image, :summary, :description,
                      :public_name, :public_email, :public_phone,
                      :partner_name, :partner_email, :partner_phone,
                      :address_id, :url, :facebook_link, :twitter_handle,
@@ -113,6 +112,5 @@ module Admin
     def setup_params
       params.require(:partner).permit(:name, address_attributes: %i[street_address postcode])
     end
-
   end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -38,6 +38,16 @@ class Partner < ApplicationRecord
               minimum: 5,
               too_short: 'must be at least 5 characters long'
             }
+  validates :summary,
+            length: {
+              maximum: 200,
+              too_long: 'maxmimum length is 200 characters'
+            }
+  validates :summary,
+            presence: {
+              if: ->(p) { !p.description.nil? },
+              message: 'cannot have a description without a summary'
+            }
   validates :url,
             format: { with: URL_REGEX, message: 'is invalid' },
             allow_blank: true

--- a/app/policies/partner_policy.rb
+++ b/app/policies/partner_policy.rb
@@ -21,7 +21,7 @@ class PartnerPolicy < ApplicationPolicy
     return true if user.root?
 
     user.neighbourhood_ids.include?(record.neighbourhood_id) ||
-    user.partner_ids.include?(record.id)
+      user.partner_ids.include?(record.id)
   end
 
   def edit?
@@ -40,7 +40,7 @@ class PartnerPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    attrs = [ :name, :image, :short_description,
+    attrs = [ :name, :image, :summary, :description,
               :public_name, :public_email, :public_phone,
               :partner_name, :partner_email, :partner_phone,
               :address_id, :url, :facebook_link, :twitter_handle,

--- a/app/views/admin/pages/home.html.erb
+++ b/app/views/admin/pages/home.html.erb
@@ -30,7 +30,7 @@
           title: partner.name,
           subtitle: "<span class='badge badge-secondary small'>#{partner&.address&.neighbourhood&.name}</span> #{pluralize(partner.events_this_week, 'event')} this week",
           image: partner.image.url,
-          description: partner.short_description,
+          description: partner.summary,
           link: edit_admin_partner_path(partner),
           last_updated: partner.updated_at
       %>

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -6,8 +6,10 @@
 
   <%= f.input :name, class: "form-control" %>
   <%= f.input :slug, class: "form-control" if policy(@partner).permitted_attributes.include? :slug %>
-  <%= f.input :short_description, class: "form-control", label: 'Short Description', input_html: { rows: 7 } %>
 
+  <%= f.input :summary, class: "form-control", label: 'Summary' %>
+
+  <%= f.input :description, class: "form-control", label: 'Description', input_html: { rows: 7 } %>
 
   <div class="row">
     <div class="col-md-6">

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, @partner.name %>
-<% if @partner.short_description %>
-  <% content_for :description, @partner.short_description %>
+<% if @partner.summary %>
+  <% content_for :description, @partner.summary %>
 <% end %>
 <% content_for :permalink, @partner.permalink %>
 
@@ -15,9 +15,12 @@
 
     <div class="g g--partner">
       <div class="gi gi__3-5">
-        <% if @partner.short_description %>
+        <% if @partner.summary %>
           <div class="first-ele-lg" property="description">
-            <%= markdown @partner.short_description %>
+            <%= markdown @partner.summary %>
+            <% if @partner.description %>
+              <%= markdown @partner.description %>
+            <% end %>
           </div>
         <% end %>
 
@@ -72,8 +75,8 @@
       <h2 class="place__title"><%= link_to place.name, partner_path(place), class: 'udl udl--red' %></h2>
       <div class="g g--place-list">
         <div class="gi gi__1-2">
-          <% if place.short_description %>
-            <%= markdown place.short_description %>
+          <% if place.summary %>
+            <%= markdown place.summary %>
           <% end %>
         </div>
         <div class="gi gi__1-2">

--- a/db/migrate/20220106150818_add_summary_description_to_partners.rb
+++ b/db/migrate/20220106150818_add_summary_description_to_partners.rb
@@ -1,0 +1,29 @@
+class AddSummaryDescriptionToPartners < ActiveRecord::Migration[6.1]
+  def up
+    add_column :partners, :summary, :string
+    add_column :partners, :description, :text
+
+    Partner.find_each do |partner|
+      next unless !partner.short_description.nil?
+
+      summary, *description = partner.short_description.split(/\r\n\r\n/)
+      partner.summary = summary
+      partner.description = description.join("\r\n\r\n")
+      partner.save
+    end
+
+    remove_column :partners, :short_description, :text
+  end
+
+  def down
+    add_column :partners, :short_description, :text
+
+    Partner.find_each do |partner|
+      partner.short_description = "#{partner.summary}\r\n\r\n#{partner.description}"
+      partner.save
+    end
+
+    remove_column :partners, :summary, :string
+    remove_column :partners, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_05_161548) do
+ActiveRecord::Schema.define(version: 2022_01_06_150818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,7 +153,6 @@ ActiveRecord::Schema.define(version: 2022_01_05_161548) do
     t.string "public_email"
     t.string "admin_name"
     t.string "admin_email"
-    t.text "short_description"
     t.integer "address_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -172,6 +171,8 @@ ActiveRecord::Schema.define(version: 2022_01_05_161548) do
     t.text "accessibility_info"
     t.string "twitter_handle"
     t.string "facebook_link"
+    t.string "summary"
+    t.text "description"
     t.index ["address_id"], name: "index_partners_on_address_id"
     t.index ["slug"], name: "index_partners_on_slug", unique: true
   end

--- a/test/factories/partner.rb
+++ b/test/factories/partner.rb
@@ -14,7 +14,8 @@ FactoryBot.define do
     partner_name { 'Addy Minny Strator' }
     partner_phone { '0161 0000001' }
 
-    short_description { 'A cool garden centre' }
+    summary { 'A cool garden centre' }
+    description { 'Our cool garden centre is a very cool and neat garden centre. Come to our events. Now.' }
     url { 'http://example.com' }
 
     address
@@ -26,7 +27,39 @@ FactoryBot.define do
       association :address, factory: :ashton_address
     end
 
-    opening_times { "[\r\n  {\r\n    \"@type\": \"OpeningHoursSpecification\",\r\n    \"closes\": \"20:00:00\",\r\n    \"dayOfWeek\": \"http://schema.org/Monday\",\r\n    \"opens\": \"09:00:00\"\r\n  },\r\n  {\r\n    \"@type\": \"OpeningHoursSpecification\",\r\n    \"closes\": \"17:00:00\",\r\n    \"dayOfWeek\": \"http://schema.org/Tuesday\",\r\n    \"opens\": \"09:00:00\"\r\n  },\r\n  {\r\n    \"@type\": \"OpeningHoursSpecification\",\r\n    \"closes\": \"17:00:00\",\r\n    \"dayOfWeek\": \"http://schema.org/Wednesday\",\r\n    \"opens\": \"09:00:00\"\r\n  },\r\n  {\r\n    \"@type\": \"OpeningHoursSpecification\",\r\n    \"closes\": \"17:00:00\",\r\n    \"dayOfWeek\": \"http://schema.org/Thursday\",\r\n    \"opens\": \"09:00:00\"\r\n  },\r\n  {\r\n    \"@type\": \"OpeningHoursSpecification\",\r\n    \"closes\": \"17:00:00\",\r\n    \"dayOfWeek\": \"http://schema.org/Friday\",\r\n    \"opens\": \"09:00:00\"\r\n  },\r\n  {\r\n    \"@type\": \"OpeningHoursSpecification\",\r\n    \"closes\": \"13:00:00\",\r\n    \"dayOfWeek\": \"http://schema.org/Saturday\",\r\n    \"opens\": \"09:00:00\"\r\n  }\r\n]" }
+    opening_times {
+      '[ { "@type": "OpeningHoursSpecification",'\
+      '    "closes": "20:00:00",'\
+      '    "dayOfWeek": "http://schema.org/Monday",'\
+      '    "opens": "09:00:00"'\
+      '  },'\
+      '  { "@type": "OpeningHoursSpecification",'\
+      '    "closes": "17:00:00",'\
+      '    "dayOfWeek": "http://schema.org/Tuesday",'\
+      '    "opens": "09:00:00"'\
+      '  },'\
+      '  { "@type": "OpeningHoursSpecification",'\
+      '    "closes": "17:00:00",'\
+      '    "dayOfWeek": "http://schema.org/Wednesday",'\
+      '    "opens": "09:00:00"'\
+      '  },'\
+      '  { "@type": "OpeningHoursSpecification",'\
+      '    "closes": "17:00:00",'\
+      '    "dayOfWeek": "http://schema.org/Thursday",'\
+      '    "opens": "09:00:00"'\
+      '  },'\
+      '  { "@type": "OpeningHoursSpecification",'\
+      '    "closes": "17:00:00",'\
+      '    "dayOfWeek": "http://schema.org/Friday",'\
+      '    "opens": "09:00:00"'\
+      '  },'\
+      '  { "@type": "OpeningHoursSpecification",'\
+      '    "closes": "13:00:00",'\
+      '    "dayOfWeek": "http://schema.org/Saturday",'\
+      '    "opens": "09:00:00"'\
+      '  }'\
+      ']'
+    }
 
     factory :place do
       sequence(:name) do |n|

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -23,7 +23,8 @@ class AdminPartnerIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_select 'h2', text: 'Basic Information'
     assert_select 'label', text: 'Name *'
-    assert_select 'label', text: 'Short Description'
+    assert_select 'label', text: 'Summary'
+    assert_select 'label', text: 'Description'
     assert_select 'label', text: 'Image'
     assert_select 'label', text: 'Website address'
     assert_select 'label', text: 'Facebook link'

--- a/test/integration/partner_integration_test.rb
+++ b/test/integration/partner_integration_test.rb
@@ -15,7 +15,8 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'title', count: 1, text: "#{@partner.name} | #{@default_site.name}"
     assert_select 'div.hero h4', text: 'The Community Calendar'
     assert_select 'div.hero h1', @partner.name
-    assert_select 'p', @partner.short_description
+    assert_select 'p', @partner.summary
+    assert_select 'p', @partner.description
     assert_select 'p', /123 Moss Ln E/
     assert_select 'p', /Manchester/
     assert_select 'p', /M15 5DD/


### PR DESCRIPTION
Fixes #840 

- Make some page text visible (Not all, needs to be separate issue/PR)
- Clean up some small formatting errors
  - Notably, split opening_times JSON from one long line into multiple
    joined strings
- Split short_description property of Partner into summary/description
  - Migrate from short_description to summary/description
  - Alter og:description elements to display summary
  - Validate summary not longer than 200 / exists if description exists
  - Add appropriate form control elements for admin edit page
  - Add tests for new validation, merge name length validation tests