### PR TITLE
Explicitly test /find-placecal endpoint

### DIFF
--- a/test/factories/site.rb
+++ b/test/factories/site.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     domain { name.parameterize }
     slug { name.parameterize }
     theme { :pink }
+    is_published { true }
 
     association :site_admin, factory: :user
 

--- a/test/factories/sites_neighbourhood.rb
+++ b/test/factories/sites_neighbourhood.rb
@@ -2,8 +2,10 @@
 
 FactoryBot.define do
   factory :sites_neighbourhood do
-    tag_id { 1 }
-    site_id { 1 }
-    relation_type { 'MyString' }
+    relation_type { 'Primary' }
+
+    neighbourhood
+
+    site
   end
 end

--- a/test/integration/sites_integration_test.rb
+++ b/test/integration/sites_integration_test.rb
@@ -8,6 +8,9 @@ class SitesIntegrationTest < ActionDispatch::IntegrationTest
     @root = create(:root)
     @site_admin = create(:user)
     @site = create(:site, slug: 'hulme', site_admin: @site_admin)
+    @sites_neighbourhood = create(:sites_neighbourhood,
+                                  site: @site,
+                                  neighbourhood: create(:neighbourhood))
   end
 
   test 'load different pages based on subdomain' do
@@ -34,5 +37,11 @@ class SitesIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'h3', 'Getting Online'
     assert_select 'h3', 'PlaceCal Support'
     assert_select 'p', 'Information about getting online coming soon.'
+  end
+
+  test 'find placecal page shows sites with primary neighbourhood' do
+    get find_placecal_url
+    assert_select '.find-ward__title', @site.name
+    assert_equal assert_select('.find-ward').first['href'], @site.domain
   end
 end


### PR DESCRIPTION
Fixes #877 
- Rename site_turves to sites_neighbourhood and correct factory model
- Add find_placecal test in sites_integration_test.rb