### PR TITLE
Use cocoon selector on partners form

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ To run Placecal locally you will need:
   - [ruby-build](https://github.com/rbenv/ruby-build)
   - [rbenv-gemset](https://github.com/jf/rbenv-gemset) (optional)
 - ImageMagick
+- node JS
+  - And yarn
 
 ## Quickstart
 

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -130,22 +130,6 @@ module Admin
       redirect_to admin_partners_url
     end
 
-    def partner_params
-      attributes = [ :name, :image, :summary, :description,
-                     :public_name, :public_email, :public_phone,
-                     :partner_name, :partner_email, :partner_phone,
-                     :address_id, :url, :facebook_link, :twitter_handle,
-                     :opening_times,
-                     calendars_attributes: %i[id name source strategy place_id partner_id _destroy],
-                     address_attributes: %i[street_address street_address2 street_address3 city postcode],
-                     service_areas_attributes: %i[id neighbourhood_id],
-                     tag_ids: [] ]
-
-      attributes << :slug if current_user.root?
-
-      params.require(:partner).permit(attributes)
-    end
-
     def setup_params
       params.require(:partner).permit(:name, address_attributes: %i[street_address postcode])
     end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 module PartnersHelper
-  def options_for_partners
-    policy_scope(Partner).all.order(:name).pluck(:name, :id)
-  end
 
-  def options_for_neighbourhoods
-    Neighbourhood.all.order(:name).pluck(:name, :id)
+  def options_for_service_area_neighbourhoods
+    # Remove the primary neighbourhood from the list
+    @all_neighbourhoods.filter { |e| e.name != '' }
+                       .collect { |e| { name: e.contextual_name, id: e.id } }
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -15,4 +15,12 @@ module UsersHelper
     str += button_tag('?', class: "btn btn-secondary", data: { toggle: "tooltip", placement: "top"  }, title: title)
     sanitize(str, tags: %w(button), attributes: %w(class type data-toggle data-placement title))
   end
+
+  def options_for_partners
+    policy_scope(Partner).all.order(:name).pluck(:name, :id)
+  end
+
+  def options_for_neighbourhoods
+    policy_scope(Neighbourhood).all.order(:name).pluck(:name, :id)
+  end
 end

--- a/app/javascript/src/behaviors/behaviors.partner.js
+++ b/app/javascript/src/behaviors/behaviors.partner.js
@@ -4,12 +4,20 @@ jQuery.extend(Behaviors, {
       init: function() {
         var map = [];
         
-        $( ".select2" ).select2({
-          multiple: true
+        console.log('partners sites thingy happening');
+
+        /* service area bits */
+
+        // Attach select2 to the current select2 nodes
+        $('.select2').each(function () { $(this).select2({ multiple: false }); });
+
+        // Attach select2 to all future select2 nodes
+        $('.sites_neighbourhoods').bind('cocoon:after-insert', function (_, element) {
+          $('.select2', element).select2({ multiple: false });
         });
 
-        $('.select-search').select2()
-
+        /* */
+        
         var preview = $(".brand_image");
         
         $("#partner_image").change(function(event){

--- a/app/javascript/src/behaviors/behaviors.partner.js
+++ b/app/javascript/src/behaviors/behaviors.partner.js
@@ -4,8 +4,6 @@ jQuery.extend(Behaviors, {
       init: function() {
         var map = [];
         
-        console.log('partners sites thingy happening');
-
         /* service area bits */
 
         // Attach select2 to the current select2 nodes

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -139,7 +139,7 @@
       <%= f.submit "Save Partner", class: "btn btn-primary h1" %><br><br>
       <br>
       <% if policy(@partner).destroy? && !@partner.new_record? %>
-        <%= link_to "Destroy Partner", @partner, method: :delete, class: "btn btn-danger" %>
+        <%= link_to "Destroy Partner", @partner, method: :delete, class: "btn btn-danger", id: 'destroy-partner'  %>
       <% end %>
     </div>
   </div>

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -24,23 +24,14 @@
 
   <h2>Service Areas</h2>
   
-  <div class="partner__service_areas">
-    <% @all_neighbourhoods.each do |neighbourhood| %>
-      <%= fields_for "partner[service_areas_attributes][#{neighbourhood.id}]" do |sna|%>
-        <label>
-          <%- if (@service_area_id_map.include?(neighbourhood.id)) %>
-            <%= sna.hidden_field :id, value: @service_area_id_map[neighbourhood.id] %>
-            <%# if box is unchecked, this will result in the removal of the association %>
-            <%= sna.check_box :_destroy, {checked: true}, false, true %>
-
-          <% else %>
-            <%= sna.check_box :neighbourhood_id, { include_hidden: false, checked: false }, neighbourhood.id %>
-          <% end %>
-
-          <%= neighbourhood.name %>
-        </label><br>
-      <% end %>
+  <div class="sites_neighbourhoods">
+    <%= f.simple_fields_for :service_areas do |neighbourhood| %>
+      <%= render 'service_area_fields', :f => neighbourhood %>
     <% end %>
+    <div class="links">
+      <%= link_to_add_association 'Add Service Area', f, :service_areas, class: "btn btn-primary btn-sm" %>
+    </div>
+    <br></br>
   </div>
 
   <br>

--- a/app/views/admin/partners/_service_area_fields.html.erb
+++ b/app/views/admin/partners/_service_area_fields.html.erb
@@ -1,0 +1,13 @@
+<fieldset class="input-group nested-fields p-0">
+    <%# The style width setting here is applied to dynamically created elements, we do not know why. %>
+    <%# TODO: Fix the dynamic styling so that width does not get applied, so we can remove this smell %>
+    <%= f.input :neighbourhood_id, collection: options_for_service_area_neighbourhoods, include_blank: false,
+        value_method: ->(obj) { obj[:id] },
+        label_method: ->(obj) { obj[:name] },
+        input_html: { class: 'form-control select2', style: "width: 599.8px;" },
+        label: '', label_html: { hidden: true } %>
+
+    <div class="input-group-append p-0">
+        <%= link_to_remove_association 'Remove', f, class: "pl-2 pt-1 text-danger" %>
+    </div>
+</fieldset>

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -48,3 +48,56 @@ class AdminPartnerIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', text: 'Partner phone'
   end
 end
+
+class PartnerShowingDeleteButtonIntegrationTest  < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'Edit has delete button for root users' do
+    root_user = create(:root)
+    default_site = create_default_site
+    partner = create(:partner)
+    get "http://admin.lvh.me"
+    sign_in root_user
+
+    get edit_admin_partner_path(partner)
+    assert_response :success
+
+    assert_select 'a#destroy-partner', 'Destroy Partner'
+  end
+
+  test 'Edit has delete button for neighbourhood admins' do
+    hood_user = create(:neighbourhood_region_admin)
+    default_site = create_default_site
+    partner = create(:partner)
+    partner.address.update! neighbourhood_id: hood_user.neighbourhoods.first.id
+
+    get "http://admin.lvh.me"
+    sign_in hood_user
+
+    get edit_admin_partner_path(partner)
+    assert_response :success
+
+    assert_select 'a#destroy-partner', 'Destroy Partner'
+  end
+end
+
+class PartnerHidingDeleteButtonIntegrationTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @admin = create(:neighbourhood_region_admin)
+    @default_site = create_default_site
+    @partner = create(:partner)
+    @admin.partners << @partner
+
+    get "http://admin.lvh.me"
+    sign_in @admin
+  end
+
+  test 'Edit does not have delete button for partner admins' do
+    get edit_admin_partner_path(@partner)
+    assert_response :success
+
+    assert_select 'a#destroy-partner', false, "This page must not have a Destroy Partner button"
+  end
+end


### PR DESCRIPTION
No more thousands of checkboxes when admins want to add or edit a
partners' service areas. Implements #898