### PR TITLE
Fix some rough edges

### DIFF
--- a/app/components/admin_index/_admin_index.html.erb
+++ b/app/components/admin_index/_admin_index.html.erb
@@ -1,12 +1,14 @@
 <h1 class="page-header"><%= properties[:title] %></h1>
 
-<%- if policy(model_name.constantize).create? && properties[:new_link] %>
-  <%= link_to "Add New #{model_name}", properties[:new_link], data: { turbolinks: false }, class: "btn btn-primary mb-3" %>
-<% end %>
+<span class="mb-3">
+  <%- if policy(model_name.constantize).create? && properties[:new_link] %>
+    <%= link_to "Add New #{model_name}", properties[:new_link], data: { turbolinks: false }, class: "btn btn-primary" %>
+  <% end %>
 
-<% additional_links.each do |link| %>
-  <%= sanitize link %>
-<% end %>
+  <% additional_links.each do |link| %>
+    <%= sanitize link %>
+  <% end %>
+</span>
 
 <table class="table table-striped">
   <thead>

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -6,7 +6,7 @@ class UserDatatable < Datatable
       id:          { source: 'User.id', cond: :eq },
       first_name:  { source: 'User.first_name' },
       last_name:   { source: 'User.last_name' },
-      admin_roles: { source: 'User.admin_roles' },
+      admin_roles: { source: 'User.admin_roles', searchable: false },
       email:       { source: 'User.email' },
     }
   end

--- a/app/views/admin/calendars/_form.html.erb
+++ b/app/views/admin/calendars/_form.html.erb
@@ -22,7 +22,7 @@
           <%= f.input :source, input_html: { value: params[:page_link] } %>
         <% else %>
           <%= f.input :name, hint: 'A simple description to help rememember what this calendar is' %>
-          <%= f.input :source, label: 'URL', placeholder: 'https://your-domain.com/events.ics', hint: "The source URL for your calendar feed. See the #{link_to 'PlaceCal Handbook', 'https://handbook.placecal.org/admins/supported-sources'} if you need help.".html_safe %>
+          <%= f.input :source, label: 'URL', placeholder: 'https://your-domain.com/events.ics', hint: "The source URL for your calendar feed. See the #{link_to 'PlaceCal Handbook', 'https://handbook.placecal.org/admins/supported-sources.html'} if you need help.".html_safe %>
         <% end %>
 
         <% unless @calendar.new_record? %>

--- a/app/views/admin/calendars/_form.html.erb
+++ b/app/views/admin/calendars/_form.html.erb
@@ -22,7 +22,7 @@
           <%= f.input :source, input_html: { value: params[:page_link] } %>
         <% else %>
           <%= f.input :name, hint: 'A simple description to help rememember what this calendar is' %>
-          <%= f.input :source, label: 'URL', placeholder: 'https://your-domain.com/events.ics', hint: "The source URL for your calendar feed. See the #{link_to 'PlaceCal Handbook', 'https://handbook.placecal.org/how-to-use-placecal/admins'} if you need help.".html_safe %>
+          <%= f.input :source, label: 'URL', placeholder: 'https://your-domain.com/events.ics', hint: "The source URL for your calendar feed. See the #{link_to 'PlaceCal Handbook', 'https://handbook.placecal.org/admins/supported-sources'} if you need help.".html_safe %>
         <% end %>
 
         <% unless @calendar.new_record? %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -83,4 +83,5 @@
   <% unless @site.new_record? %>
     <%= link_to "Destroy Site", admin_site_path(@site), method: :delete, class: "btn btn-danger btn-lg" %>
   <% end %>
+  <br />
 <% end %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -64,7 +64,7 @@
           label: '', label_html: { hidden: true } %>
     <% end %>
   <% end %>
-  <br />
+  <br>
 
   <h2>Other neighbourhoods to include</h2>
   <p class="font-weight-light">Information from these neighbourhoods will also be displayed on this site</p>
@@ -83,5 +83,5 @@
   <% unless @site.new_record? %>
     <%= link_to "Destroy Site", admin_site_path(@site), method: :delete, class: "btn btn-danger btn-lg" %>
   <% end %>
-  <br />
+  <br>
 <% end %>

--- a/app/views/admin/users/profile.html.erb
+++ b/app/views/admin/users/profile.html.erb
@@ -21,7 +21,7 @@
       <p>Leave this blank if you don't want to change your password.</p>
       <%= f.input :password, autocomplete: "off" %>
       <% if @minimum_password_length %>
-        <br />
+        <br>
         <em><%= @minimum_password_length %> characters minimum</em>
       <% end %>
       <%= f.input :password_confirmation, autocomplete: "off" %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -5,7 +5,7 @@
     <%= devise_error_messages! %>
   
     <div class="field">
-      <%= f.label :email %><br />
+      <%= f.label :email %><br>
       <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
     </div>
   
@@ -15,4 +15,4 @@
   <% end %>
   
   <%= render "devise/shared/links" %>
-</div>  
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -6,15 +6,15 @@
     <%= f.hidden_field :reset_password_token %>
   
     <div class="field">
-      <%= f.label :password, "New password" %><br />
+      <%= f.label :password, "New password" %><br>
       <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+        <em>(<%= @minimum_password_length %> characters minimum)</em><br>
       <% end %>
       <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
     </div>
   
     <div class="field">
-      <%= f.label :password_confirmation, "Confirm new password" %><br />
+      <%= f.label :password_confirmation, "Confirm new password" %><br>
       <%= f.password_field :password_confirmation, autocomplete: "off" %>
     </div>
   
@@ -24,4 +24,4 @@
   <% end %>
   
   <%= render "devise/shared/links" %>
-</div>  
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -4,7 +4,7 @@
   <%= devise_error_messages! %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email %><br>
     <%= f.email_field :email, autofocus: true %>
   </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
     <%= devise_error_messages! %>
   
     <div class="field">
-      <%= f.label :email %><br />
+      <%= f.label :email %><br>
       <%= f.email_field :email, autofocus: true %>
     </div>
   
@@ -14,21 +14,21 @@
     <% end %>
   
     <div class="field">
-      <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+      <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br>
       <%= f.password_field :password, autocomplete: "off" %>
       <% if @minimum_password_length %>
-        <br />
+        <br>
         <em><%= @minimum_password_length %> characters minimum</em>
       <% end %>
     </div>
   
     <div class="field">
-      <%= f.label :password_confirmation %><br />
+      <%= f.label :password_confirmation %><br>
       <%= f.password_field :password_confirmation, autocomplete: "off" %>
     </div>
   
     <div class="field">
-      <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+      <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br>
       <%= f.password_field :current_password, autocomplete: "off" %>
     </div>
   
@@ -43,4 +43,4 @@
   
   <%= link_to "Back", :back %>
 
-</div>  
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,17 +5,17 @@
     <%= devise_error_messages! %>
 
     <div class="field">
-      <%= f.label :First_Name %><br />
+      <%= f.label :First_Name %><br>
       <%= f.text_field :first_name, autofocus: true %>
     </div>
 
      <div class="field">
-      <%= f.label :Last_Name %><br />
+      <%= f.label :Last_Name %><br>
       <%= f.text_field :last_name, autofocus: true %>
     </div>
   
     <div class="field">
-      <%= f.label :email %><br />
+      <%= f.label :email %><br>
       <%= f.email_field :email, autofocus: true %>
     </div>
   
@@ -23,12 +23,12 @@
       <%= f.label :password %>
       <% if @minimum_password_length %>
       <em>(<%= @minimum_password_length %> characters minimum)</em>
-      <% end %><br />
+      <% end %><br>
       <%= f.password_field :password, autocomplete: "off" %>
     </div>
   
     <div class="field">
-      <%= f.label :password_confirmation %><br />
+      <%= f.label :password_confirmation %><br>
       <%= f.password_field :password_confirmation, autocomplete: "off" %>
     </div>
   
@@ -39,4 +39,4 @@
   
   <%= render "devise/shared/links" %>
 
-</div>  
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,12 +3,12 @@
   
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <div class="field">
-      <%= f.label :email %><br />
+      <%= f.label :email %><br>
       <%= f.email_field :email, autofocus: true %>
     </div>
   
     <div class="field">
-      <%= f.label :password %><br />
+      <%= f.label :password %><br>
       <%= f.password_field :password, autocomplete: "off" %>
     </div>
   
@@ -26,4 +26,4 @@
   
   <%= render "devise/shared/links" %>
 
-</div>  
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,26 +1,26 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Log in", new_session_path(resource_name) %><br>
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br>
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br>
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br>
 <% end -%>
 
 <%# Don't need this on the sign in page %>
 <%#- if devise_mapping.omniauthable? %>
   <%#- resource_class.omniauth_providers.each do |provider| %>
-    <%#= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+    <%#= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br>
   <%# end -%>
 <%# end -%>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -5,7 +5,7 @@
     <%= devise_error_messages! %>
   
     <div class="field">
-      <%= f.label :email %><br />
+      <%= f.label :email %><br>
       <%= f.email_field :email, autofocus: true %>
     </div>
   
@@ -15,4 +15,4 @@
   <% end %>
   
   <%= render "devise/shared/links" %>
-</div>  
+</div>

--- a/app/views/layouts/admin/_admin_topbar.html.erb
+++ b/app/views/layouts/admin/_admin_topbar.html.erb
@@ -3,7 +3,7 @@
   <input class="form-control form-control-dark w-100" type="text" placeholder="Search" aria-label="Search">
   <ul class="navbar-nav flex-row px-3">
     <li class="nav-item text-nowrap mr-4">
-      <%= link_to "<i class='fa fa-user'></i> #{@current_user.email} #{"👑" if @current_user.role == :root}".html_safe, admin_profile_path, class: 'nav-link'  %>
+      <%= link_to "<i class='fa fa-user'></i> #{@current_user&.email} #{"👑" if @current_user&.role == :root}".html_safe, admin_profile_path, class: 'nav-link'  %>
     </li>
     <li class="nav-item text-nowrap">
       <%= link_to "<i class='fa fa-sign-out'></i> Sign out".html_safe, destroy_user_session_path, method: :delete, class: 'nav-link'  %>

--- a/app/views/layouts/admin/_admin_topbar.html.erb
+++ b/app/views/layouts/admin/_admin_topbar.html.erb
@@ -3,7 +3,7 @@
   <input class="form-control form-control-dark w-100" type="text" placeholder="Search" aria-label="Search">
   <ul class="navbar-nav flex-row px-3">
     <li class="nav-item text-nowrap mr-4">
-      <%= link_to "<i class='fa fa-user'></i> Your profile".html_safe, admin_profile_path, class: 'nav-link'  %>
+      <%= link_to "<i class='fa fa-user'></i> #{@current_user.email} #{"👑" if @current_user.role == :root}".html_safe, admin_profile_path, class: 'nav-link'  %>
     </li>
     <li class="nav-item text-nowrap">
       <%= link_to "<i class='fa fa-sign-out'></i> Sign out".html_safe, destroy_user_session_path, method: :delete, class: 'nav-link'  %>


### PR DESCRIPTION
Topbar:
- Switch to using email address in topbar and clearly indicate if user is root (Fixes #903)

Users page:
- Moves the margin on the top buttons into a surrounding element puts them both on the same line in the user interface, otherwise the Facebook link looks wonky and weirdly offset
- Fixes broken search on users page due to Datatables AJAX error (Fixes #901)

Calendars edit page:
- Adds some leeway at the bottom between the lower end of page boundary and the update/delete buttons
 
Sites edit page:
- Link to (prospective) correct page in handbook of event sources (See: [Add Event Sources List](https://github.com/geeksforsocialchange/PlaceCal-Handbook/pull/5) )

Also amend `<br />` => `<br>`

