### PR TITLE
Add Datatables for Calendars, Tags, and Sites

### DIFF
--- a/app/components/admin_index/_admin_index.html.erb
+++ b/app/components/admin_index/_admin_index.html.erb
@@ -1,6 +1,7 @@
 <h1 class="page-header"><%= properties[:title] %></h1>
 
-<span class="mb-3">
+<%# A weird bug in the datatables template means that we have to apply the margin for each link, rather than for the container span. So this span has no class. TODO: Fix this. %>
+<span>
   <%- if policy(model_name.constantize).create? && properties[:new_link] %>
     <%= link_to "Add New #{model_name}", properties[:new_link], data: { turbolinks: false }, class: "btn btn-primary" %>
   <% end %>

--- a/app/controllers/admin/calendars_controller.rb
+++ b/app/controllers/admin/calendars_controller.rb
@@ -8,6 +8,17 @@ module Admin
     def index
       @calendars = policy_scope(Calendar)
       authorize Calendar
+
+      respond_to do |format|
+        format.html
+        format.json {
+          render json: CalendarDatatable.new(
+            params,
+            view_context: view_context,
+            calendars: @calendars
+          )
+        }
+      end
     end
 
     def new

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -8,6 +8,17 @@ module Admin
     def index
       @sites = policy_scope(Site).order(:name)
       authorize @sites
+
+      respond_to do |format|
+        format.html
+        format.json {
+          render json: SiteDatatable.new(
+            params,
+            view_context: view_context,
+            sites: @sites
+          )
+        }
+      end
     end
 
     def show; end

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -7,6 +7,17 @@ module Admin
     def index
       @tags = policy_scope(Tag).order(:name)
       authorize @tags
+
+      respond_to do |format|
+        format.html
+        format.json {
+          render json: TagDatatable.new(
+            params,
+            view_context: view_context,
+            tags: @tags
+          )
+        }
+      end
     end
 
     def new

--- a/app/datatables/calendar_datatable.rb
+++ b/app/datatables/calendar_datatable.rb
@@ -1,0 +1,33 @@
+class CalendarDatatable < Datatable
+  def view_columns
+    # Declare strings in this format: ModelName.column_name
+    # or in aliased_join_table.column_name format
+    @view_columns ||= {
+      id: { source: 'Calendar.id', cond: :eq },
+      name: { source: 'Calendar.name' },
+      partner: { source: 'Calendar.partner', searchable: false, orderable: false },
+      place: { source: 'Calendar.place', searchable: false, orderable: false },
+      is_working: { source: 'Calendar.is_working' },
+      last_import_at: { source: 'Calendar.last_import_at' }
+    }
+  end
+
+  def data
+    records.map do |record|
+      {
+        id: link_to(record.id, edit_admin_calendar_path(record)),
+        name: link_to(record.name, edit_admin_calendar_path(record)),
+        partner: record.partner,
+        place: record.place,
+        is_working: record.is_working,
+        last_import_at: record.last_import_at
+      }
+    end
+  end
+
+  def get_raw_records
+    # insert query here
+    # Calendar.all
+    options[:calendars]
+  end
+end

--- a/app/datatables/datatable.rb
+++ b/app/datatables/datatable.rb
@@ -5,6 +5,7 @@ class Datatable < AjaxDatatablesRails::ActiveRecord
   def_delegator :@view, :edit_admin_neighbourhood_path
   def_delegator :@view, :edit_admin_user_path
   def_delegator :@view, :edit_admin_partner_path
+  def_delegator :@view, :edit_admin_site_path
 
   def initialize(params, opts = {})
     @view = opts[:view_context]

--- a/app/datatables/datatable.rb
+++ b/app/datatables/datatable.rb
@@ -7,6 +7,7 @@ class Datatable < AjaxDatatablesRails::ActiveRecord
   def_delegator :@view, :edit_admin_partner_path
   def_delegator :@view, :edit_admin_site_path
   def_delegator :@view, :edit_admin_tag_path
+  def_delegator :@view, :edit_admin_calendar_path
 
   def initialize(params, opts = {})
     @view = opts[:view_context]

--- a/app/datatables/datatable.rb
+++ b/app/datatables/datatable.rb
@@ -6,6 +6,7 @@ class Datatable < AjaxDatatablesRails::ActiveRecord
   def_delegator :@view, :edit_admin_user_path
   def_delegator :@view, :edit_admin_partner_path
   def_delegator :@view, :edit_admin_site_path
+  def_delegator :@view, :edit_admin_tag_path
 
   def initialize(params, opts = {})
     @view = opts[:view_context]

--- a/app/datatables/site_datatable.rb
+++ b/app/datatables/site_datatable.rb
@@ -1,0 +1,27 @@
+class SiteDatatable < Datatable
+  def view_columns
+    # Declare strings in this format: ModelName.column_name
+    # or in aliased_join_table.column_name format
+    @view_columns ||= {
+      id: { source: 'Site.id', cond: :eq },
+      name: { source: 'Site.name' },
+      slug: { source: 'Site.slug' },
+    }
+  end
+
+  def data
+    records.map do |record|
+      {
+        id: link_to(record.id, edit_admin_site_path(record)),
+        name: link_to(record.name, edit_admin_site_path(record)),
+        slug: record.slug,
+      }
+    end
+  end
+
+  def get_raw_records
+    # insert query here
+    # User.all
+    options[:sites]
+  end
+end

--- a/app/datatables/tag_datatable.rb
+++ b/app/datatables/tag_datatable.rb
@@ -1,0 +1,29 @@
+class TagDatatable < Datatable
+  def view_columns
+    # Declare strings in this format: ModelName.column_name
+    # or in aliased_join_table.column_name format
+    @view_columns ||= {
+      id: { source: 'Tag.id', cond: :eq },
+      name: { source: 'Tag.name' },
+      slug: { source: 'Tag.slug' },
+      description: { source: 'Tag.description' }
+    }
+  end
+
+  def data
+    records.map do |record|
+      {
+        id: link_to(record.id, edit_admin_tag_path(record)),
+        name: link_to(record.name, edit_admin_tag_path(record)),
+        slug: record.slug,
+        description: record.description
+      }
+    end
+  end
+
+  def get_raw_records
+    # insert query here
+    # Tag.all
+    options[:tags]
+  end
+end

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -6,8 +6,8 @@ class UserDatatable < Datatable
       id:          { source: 'User.id', cond: :eq },
       first_name:  { source: 'User.first_name' },
       last_name:   { source: 'User.last_name' },
-      admin_roles: { source: 'User.admin_roles', searchable: false },
-      email:       { source: 'User.email' },
+      admin_roles: { source: 'User.admin_roles', searchable: false, orderable: false },
+      email:       { source: 'User.email' }
     }
   end
 

--- a/app/views/admin/calendars/index.html.erb
+++ b/app/views/admin/calendars/index.html.erb
@@ -1,14 +1,28 @@
-<%= render_component "admin_index",
-  title: "Calendars",
-  model: :calendars,
-  columns: %i[id name partner place is_working last_import_at],
-  data: @calendars,
-  new_link: new_admin_calendar_path,
-  additional_links: [
-    if current_user.has_facebook_keys?
-      link_to("Add New Calendar From Facebook", user_facebook_omniauth_authorize_url, class: "btn btn-primary")
-    else
-      link_to("Add New Calendar From Facebook", admin_profile_path(missing_keys: true), class: 'btn btn-primary')
-    end
+<script>
+var columns = [
+    {"data": "id"},
+    {"data": "name"},
+    {"data": "partner"},
+    {"data": "place"},
+    {"data": "is_working"},
+    {"data": "last_import_at"},
   ]
+</script>
+
+<%# A weird bug in the datatables template means that we have to apply the margin for each link, rather than for the container span. %>
+<%= render partial: 'layouts/admin/datatable', locals: {
+    title: 'Calendars',
+    model: :calendars,
+    columns: %i[id name partner place is_working last_import_at],
+    data: @calendars,
+    source: admin_calendars_path(format: :json),
+    new_link: new_admin_calendar_path,
+    additional_links: [
+      if current_user.has_facebook_keys?
+        link_to('Add New Calendar From Facebook', user_facebook_omniauth_authorize_url, class: 'btn btn-primary mb-3')
+      else
+        link_to('Add New Calendar From Facebook', admin_profile_path(missing_keys: true), class: 'btn btn-primary mb-3')
+      end
+    ]
+  }
 %>

--- a/app/views/admin/sites/index.html.erb
+++ b/app/views/admin/sites/index.html.erb
@@ -1,7 +1,17 @@
-<%= render_component "admin_index",
-  title: "Sites",
-  model: :sites,
-  columns: %i[id name slug],
-  data: @sites,
-  new_link: new_admin_site_path
+<script>
+var columns = [
+    {"data": "id"},
+    {"data": "name"},
+    {"data": "slug"}
+  ]
+</script>
+
+<%= render partial: "layouts/admin/datatable", locals: {
+    title: "Sites",
+    model: :sites,
+    columns: %i[id name slug],
+    data: @sites,
+    source: admin_sites_path(format: :json),
+    new_link: new_admin_site_path
+  }
 %>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,9 +1,20 @@
 <%# TODO: Only show Edit link for root users %>
 
-<%= render_component "admin_index",
-  title: "Tags",
-  model: :tags,
-  columns: %i[id name slug description],
-  data: @tags,
-  new_link: new_admin_tag_path
+<script>
+var columns = [
+    {"data": "id"},
+    {"data": "name"},
+    {"data": "slug"},
+    {"data": "description"}
+  ]
+</script>
+
+<%= render partial: "layouts/admin/datatable", locals: {
+    title: "Tags",
+    model: :tags,
+    columns: %i[id name slug description],
+    data: @tags,
+    source: admin_tags_path(format: :json),
+    new_link: new_admin_tag_path
+  }
 %>

--- a/app/views/layouts/admin/_datatable.html.erb
+++ b/app/views/layouts/admin/_datatable.html.erb
@@ -2,9 +2,17 @@
 
 <%- model_name = model.to_s.chop.humanize %>
 
-<%- if policy(model_name.constantize).create? && defined?(new_link) %>
-  <%= link_to "Add New #{model_name}", new_link, data: { turbolinks: false }, class: "btn btn-primary mb-3" %>
-<% end %>
+<span>
+  <%- if policy(model_name.constantize).create? && defined?(new_link) %>
+    <%= link_to "Add New #{model_name}", new_link, data: { turbolinks: false }, class: "btn btn-primary mb-3" %>
+  <% end %>
+
+  <% if defined?(additional_links) %>
+    <% additional_links.each do |link| %>
+      <%= sanitize link %>
+    <% end %>
+  <% end %>
+</span>
 
 <table class="table table-striped" id="datatable" data-source="<%= source %>">
   <thead>


### PR DESCRIPTION
- Adds Datatables for Calendars, Tags, Sites
- Fixes small bug where clicking on admin_role in Users would cause an AJAX error
- Alter Datatables partial to add the extra links for Calendars (Facebook importer -- perhaps no longer needed? Separate ticket territory :slightly_smiling_face: )

Fixes #921 