### PR TITLE
Add events to GraphQL endpoint

### DIFF
--- a/app/graphql/types/address_type.rb
+++ b/app/graphql/types/address_type.rb
@@ -1,7 +1,7 @@
 module Types
   class AddressType < Types::BaseObject
 
-    description 'An address representing a physical building'
+    description 'An address representing a physical location'
 
     # field :id, ID, null: false
     field :street_address, String

--- a/app/graphql/types/address_type.rb
+++ b/app/graphql/types/address_type.rb
@@ -1,7 +1,7 @@
 module Types
   class AddressType < Types::BaseObject
 
-    description 'A partner'
+    description 'An address representing a physical building'
 
     # field :id, ID, null: false
     field :street_address, String

--- a/app/graphql/types/address_type.rb
+++ b/app/graphql/types/address_type.rb
@@ -1,0 +1,15 @@
+module Types
+  class AddressType < Types::BaseObject
+
+    description 'A partner'
+
+    # field :id, ID, null: false
+    field :street_address, String
+    field :street_address2, String
+    field :street_address3, String
+    field :city, String
+    field :postcode, String
+    field :country_code, String
+  end
+end
+

--- a/app/graphql/types/address_type.rb
+++ b/app/graphql/types/address_type.rb
@@ -10,6 +10,8 @@ module Types
     field :city, String
     field :postcode, String
     field :country_code, String
+    field :full_street_address, String
+    field :all_address_lines, [String]
   end
 end
 

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -1,0 +1,14 @@
+module Types
+  class EventType < Types::BaseObject
+
+    description 'An Event'
+
+    field :id, ID, null: false
+    field :description, String
+    field :summary, String
+
+    field :address, AddressType
+
+  end
+end
+

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -1,7 +1,7 @@
 module Types
   class EventType < Types::BaseObject
 
-    description 'An Event'
+    description 'An Event that is run by a Parter on a date at a given Address'
 
     field :id, ID, null: false
     field :description, String

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -1,7 +1,7 @@
 module Types
   class EventType < Types::BaseObject
 
-    description 'An Event that is run by a Parter on a date at a given Address'
+    description 'An Event that is run by a Parter'
 
     field :id, ID, null: false
     field :description, String

--- a/app/graphql/types/partner_type.rb
+++ b/app/graphql/types/partner_type.rb
@@ -1,7 +1,7 @@
 module Types
   class PartnerType < Types::BaseObject
 
-    description 'A partner'
+    description 'A Partner who runs Events'
 
     field :id, ID, null: false
     field :name, String, null: false

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -23,6 +23,24 @@ module Types
       Partner.all
     end
 
+    ####
+
+    field :event, EventType, "Find Event by ID" do
+      argument :id, ID
+    end
+
+    field :all_events, [EventType]
+
+    def event(id:)
+      Event.find(id)
+    end
+
+    def all_events
+      Event.all
+    end
+
+    ####
+
     field :ping, String, null: false, description: "Ping server"
 
     def ping

--- a/test/integration/graphql/event_integration_test.rb
+++ b/test/integration/graphql/event_integration_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GraphQLEventTest < ActionDispatch::IntegrationTest
+
+  setup do
+    @partner = FactoryBot.create(:partner)
+
+    @address = @partner.address
+    assert @address, 'Failed to create Address from partner'
+
+    @calendar = FactoryBot.create(
+      :calendar,
+      partner: @partner,
+      name: 'Partner Calendar',
+      source: 'http://example.com'
+    )
+    assert @calendar, 'Failed to create calendar from partner'
+  end
+
+  test 'can show partners' do
+
+    (0...5).collect do |n|
+      @partner.events.create!(
+        dtstart: Time.now,
+        summary: "An event summary #{n}",
+        description: 'Longer text covering the event in more detail',
+        address: @address
+      )
+    end
+
+    query_string = <<-GRAPHQL
+      query {
+        allEvents {
+          id
+          summary
+          description
+        }
+      }
+    GRAPHQL
+
+    result = PlaceCalSchema.execute(query_string)
+    data = result['data']
+    assert data.has_key?('allEvents'), 'result is missing key `allEvents`'
+
+    events = data['allEvents']
+    assert events.length == 5
+  end
+
+  test 'can show specific event' do
+    event = @partner.events.create!(
+      dtstart: Time.now,
+      summary: "An event summary",
+      description: 'Longer text covering the event in more detail',
+      address: @address
+    )
+
+    query_string = <<-GRAPHQL
+      query {
+        event(id: #{event.id}) {
+          id
+          summary
+          description
+          address {
+            streetAddress
+            city
+            postcode
+          }
+        }
+      }
+    GRAPHQL
+
+    result = PlaceCalSchema.execute(query_string)
+
+    data = result['data']
+    assert data.has_key?('event'), 'Data structure does not contain event key'
+
+    data_event = data['event']
+    assert data_event['summary'] == event.summary
+  end
+end


### PR DESCRIPTION
You can now query the API with things like this for event index:
```
query {
    allEvents {
        id
        summary
        description
    }
}
```

And this for show event:
```
query {
    event(id:123) {
        id
        summary
        description
        address {
            streetAddress
            city
            postcode
        }
    }
}
```