### PR TITLE
Add edit_permission field to tags, adjust interface inc. datatables

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -80,7 +80,7 @@ module Admin
     private
 
     def set_tag
-      @tag = Tag.find(params[:id])
+      @tag = Tag.friendly.find(params[:id])
     end
 
     def tag_params

--- a/app/datatables/tag_datatable.rb
+++ b/app/datatables/tag_datatable.rb
@@ -6,7 +6,8 @@ class TagDatatable < Datatable
       id: { source: 'Tag.id', cond: :eq },
       name: { source: 'Tag.name' },
       slug: { source: 'Tag.slug' },
-      description: { source: 'Tag.description' }
+      description: { source: 'Tag.description' },
+      edit_permission: { source: 'Tag.edit_permission' }
     }
   end
 
@@ -16,7 +17,8 @@ class TagDatatable < Datatable
         id: link_to(record.id, edit_admin_tag_path(record)),
         name: link_to(record.name, edit_admin_tag_path(record)),
         slug: record.slug,
-        description: record.description
+        description: record.description,
+        edit_permission: record.edit_permission
       }
     end
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,11 +1,26 @@
 # frozen_string_literal: true
 
 class Tag < ApplicationRecord
-  self.table_name = 'tags'
+  extend FriendlyId
+  extend Enumerize
+
+  friendly_id :name, use: :slugged
+
+  self.table_name = 'tags' # Maybe we can remove this? Tag should automagically railsify to tags right?
 
   has_and_belongs_to_many :users
   has_and_belongs_to_many :partners
 
   validates :name, :slug, presence: true
   validates :name, :slug, uniqueness: true
+  validates :description,
+            length: {
+              maximum: 200,
+              too_long: 'maximum length is 200 characters'
+            }
+  validates :edit_permission, presence: true
+
+  enumerize :edit_permission,
+            in: %i[root all],
+            default: :root
 end

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -7,6 +7,9 @@
 
   <%= f.input :description, class: "form-control" %>
 
+  <%= f.input :edit_permission, class: "form-control" %>
+
+  <%# = f.association :partner, collection: @partners %>
   <% unless @tag.new_record? %>
     <h2>Partners</h2>
     <% unless @partners.empty? %>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -5,6 +5,7 @@ var columns = [
     {"data": "id"},
     {"data": "name"},
     {"data": "slug"},
+    {"data": "edit_permission"},
     {"data": "description"}
   ]
 </script>
@@ -12,7 +13,7 @@ var columns = [
 <%= render partial: "layouts/admin/datatable", locals: {
     title: "Tags",
     model: :tags,
-    columns: %i[id name slug description],
+    columns: %i[id name slug edit_permission description],
     data: @tags,
     source: admin_tags_path(format: :json),
     new_link: new_admin_tag_path

--- a/db/migrate/20220217050106_add_edit_permission_to_tags.rb
+++ b/db/migrate/20220217050106_add_edit_permission_to_tags.rb
@@ -1,0 +1,5 @@
+class AddEditPermissionToTags < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tags, :edit_permission, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_10_165818) do
+ActiveRecord::Schema.define(version: 2022_02_17_050106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -293,6 +293,7 @@ ActiveRecord::Schema.define(version: 2022_02_10_165818) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "edit_permission"
   end
 
   create_table "tags_users", id: false, force: :cascade do |t|

--- a/test/factories/tag.rb
+++ b/test/factories/tag.rb
@@ -6,5 +6,12 @@ FactoryBot.define do
       "Hulme #{n}"
     end
     slug { name.parameterize }
+    description { 'I am a tag' }
+    edit_permission { 'root' }
+
+    factory :tag_perms_all, class: :tag do
+      description { 'I am a public tag' }
+      edit_permission { 'public' }
+    end
   end
 end


### PR DESCRIPTION
Fixes #965

- Add edit_permission to schema
- Add description validation, tags enum, friendly id to tags model
- Correct friendly id in tags controller
- Add tags edit permission to datatables, edit form