### PR TITLE
Show service area information on location lozenges

### DIFF
--- a/app/assets/stylesheets/base/turf.sass
+++ b/app/assets/stylesheets/base/turf.sass
@@ -1,4 +1,4 @@
-.neighbourhood
+.neighbourhood, .service-area
   // padding-top: 0.5rem
   span
     margin-top: 0.8rem

--- a/app/components/place_partner_preview/_place_partner_preview.html.erb
+++ b/app/components/place_partner_preview/_place_partner_preview.html.erb
@@ -1,12 +1,20 @@
 <li class="preview">
   <div class="preview__header">
     <h3><%= link_to name, link %></h3>
+
+    <% if show_service_area? %>
+      <div class="service-area service-area--secondary preview__service-area">
+        <span><%= service_area_name %></span>
+      </div>
+    <% end %>
+
     <% if show_neighbourhoods %>
       <div class="neighbourhood <%= primary_neighbourhood? ? 'neighbourhood--primary' : 'neighbourhood--secondary' %> preview__neighbourhood">
         <span><%= neighbourhood_name(badge_zoom_level) %></span>
       </div>
     <% end %>
   </div>
+  
   <% if description %>
     <div class="preview__details">
       <%= content_tag :p, description %>

--- a/app/components/place_partner_preview/_place_partner_preview.html.erb
+++ b/app/components/place_partner_preview/_place_partner_preview.html.erb
@@ -8,7 +8,7 @@
       </div>
     <% end %>
 
-    <% if show_neighbourhoods %>
+    <% if show_neighbourhood? %>
       <div class="neighbourhood <%= primary_neighbourhood? ? 'neighbourhood--primary' : 'neighbourhood--secondary' %> preview__neighbourhood">
         <span><%= neighbourhood_name(badge_zoom_level) %></span>
       </div>

--- a/app/components/place_partner_preview/place_partner_preview_component.rb
+++ b/app/components/place_partner_preview/place_partner_preview_component.rb
@@ -2,7 +2,8 @@
 
 # app/components/place/place_partner_preview_component.rb
 class PlacePartnerPreviewComponent < MountainView::Presenter
-  properties :primary_neighbourhood, :previewee, :show_neighbourhoods, :badge_zoom_level
+  properties :primary_neighbourhood,
+    :previewee, :show_neighbourhoods, :badge_zoom_level, :service_areas
 
   def name
     previewee.name
@@ -28,6 +29,18 @@ class PlacePartnerPreviewComponent < MountainView::Presenter
     primary_neighbourhood && (previewee.address&.neighbourhood == primary_neighbourhood)
   end
 
+  def show_service_area?
+    service_areas.count > 0
+  end
+
+  def service_area_name
+    if previewee.service_areas.count > 1
+      "various areas"
+    else
+      previewee.service_areas.first&.neighbourhood&.shortname
+    end
+  end
+  
   private
 
   def previewee

--- a/app/components/place_partner_preview/place_partner_preview_component.rb
+++ b/app/components/place_partner_preview/place_partner_preview_component.rb
@@ -13,6 +13,11 @@ class PlacePartnerPreviewComponent < MountainView::Presenter
     previewee
   end
 
+  def show_neighbourhood?
+    return false if show_service_area?
+    show_neighbourhoods
+  end
+
   def neighbourhood_name(badge_zoom_level)
     return previewee.address&.neighbourhood&.district&.shortname if badge_zoom_level == 'district'
 
@@ -35,7 +40,7 @@ class PlacePartnerPreviewComponent < MountainView::Presenter
 
   def service_area_name
     if previewee.service_areas.count > 1
-      "various areas"
+      "various"
     else
       previewee.service_areas.first&.neighbourhood&.shortname
     end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -7,4 +7,19 @@ module PartnersHelper
     @all_neighbourhoods.filter { |e| e.name != '' }
                        .collect { |e| { name: e.contextual_name, id: e.id } }
   end
+
+  def partner_service_area_text(partner)
+    neighbourhoods = partner.service_area_neighbourhoods.order(:name).all
+
+    if neighbourhoods.length == 1
+      neighbourhoods.first.name
+
+    else
+      head = neighbourhoods[0..-2]
+      tail = neighbourhoods[-1]
+
+      "#{head.map(&:name).join(', ')} and #{tail.name}"
+    end
+  end
+  
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -147,6 +147,10 @@ class Partner < ApplicationRecord
     slug.blank?
   end
 
+  def has_service_areas?
+    service_areas.count > 0
+  end
+
   def permalink
     "https://placecal.org/partners/#{id}"
   end

--- a/app/views/admin/users/profile.html.erb
+++ b/app/views/admin/users/profile.html.erb
@@ -65,7 +65,7 @@
           <ul>
             <% current_user.neighbourhoods.each do |neighbourhood| %>
               <li>
-                <%= link_to neighbourhood.name, edit_admin_neighbourhood_path(neighbourhood) %>
+                <%= link_to neighbourhood.contextual_name, edit_admin_neighbourhood_path(neighbourhood) %>
               </li>
             <% end %>
           </ul>

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -9,6 +9,7 @@
       <%= render_component("place_partner_preview",
         previewee: partner,
         primary_neighbourhood: @primary_neighbourhood,
+        service_areas: partner.service_areas,
         show_neighbourhoods: @current_site.show_neighbourhoods?,
         badge_zoom_level: @current_site.badge_zoom_level) %>
     <% end %>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -38,6 +38,9 @@
         %>
 
         <h3 class="udl udl--fw allcaps h4">Address</h3>
+        <% if @partner.has_service_areas? %>
+          <p>We operate in <%= partner_service_area_text(@partner) %>.</p>
+        <% end %>
         <%= render_component "address",
           address: @partner.address
         %>

--- a/test/helpers/partners_helper_test.rb
+++ b/test/helpers/partners_helper_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PartnersHelperTest < ActionView::TestCase
+  setup do
+    @partner = FactoryBot.create(:partner)
+    @hoods = [
+      FactoryBot.create(:neighbourhood, name: 'alpha'),
+      FactoryBot.create(:neighbourhood, name: 'beta'),
+      FactoryBot.create(:neighbourhood, name: 'cappa')
+    ]
+  end
+
+  # testing partner_service_area_text
+
+  test "shows only one text correctly" do
+    @partner.service_areas.create neighbourhood: @hoods[0]
+
+    output = partner_service_area_text(@partner)
+
+    assert output == 'alpha'
+  end
+
+  test "shows two texts correctly" do
+    @partner.service_areas.create neighbourhood: @hoods[0]
+    @partner.service_areas.create neighbourhood: @hoods[1]
+
+    output = partner_service_area_text(@partner)
+
+    assert output == 'alpha and beta'
+  end
+
+  test "shows N texts correctly" do
+    @partner.service_areas.create neighbourhood: @hoods[0]
+    @partner.service_areas.create neighbourhood: @hoods[1]
+    @partner.service_areas.create neighbourhood: @hoods[2]
+
+    output = partner_service_area_text(@partner)
+
+    assert output == 'alpha, beta and cappa'
+  end
+end

--- a/test/integration/admin/user_integration_test.rb
+++ b/test/integration/admin/user_integration_test.rb
@@ -55,7 +55,7 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'h3', text: 'Your neighbourhoods'
     assert_select 'a[href=?]',
                   edit_admin_neighbourhood_path(@neighbourhood),
-                  text: @neighbourhood.name
+                  text: @neighbourhood.contextual_name
   end
 
   test "Profile form has correct fields for neighbourhood admin" do

--- a/test/integration/partners_integration_test.rb
+++ b/test/integration/partners_integration_test.rb
@@ -88,7 +88,7 @@ class PartnersIntegrationTest < ActionDispatch::IntegrationTest
     get partners_url 
     assert_response :success
 
-    assert_select '.service-area span', text: 'various areas'
+    assert_select '.service-area span', text: 'various'
   end
 
 end

--- a/test/integration/partners_integration_test.rb
+++ b/test/integration/partners_integration_test.rb
@@ -69,4 +69,26 @@ class PartnersIntegrationTest < ActionDispatch::IntegrationTest
     assert_select '.preview__header', text: @region_site_partners.first.name
     assert_select '.preview__details', text: @region_site_partners.first.summary
   end
+
+  test 'partner shows service area if available' do
+    partner = @default_site_partners.first
+    partner.service_areas.create! neighbourhood: @neighbourhood3
+
+    get partners_url 
+    assert_response :success
+
+    assert_select '.service-area span', text: @neighbourhood3.shortname
+  end
+
+  test 'partner shows "various areas" if more than one service area present' do
+    partner = @default_site_partners.first
+    partner.service_areas.create! neighbourhood: @neighbourhood3
+    partner.service_areas.create! neighbourhood: @neighbourhood2
+
+    get partners_url 
+    assert_response :success
+
+    assert_select '.service-area span', text: 'various areas'
+  end
+
 end


### PR DESCRIPTION
On guest users partner index page when seeing partners if the partner has a service area this now appears as a lozenge like the neighbourhood does (if present).

Things not covered in this PR:
* styling
* business logic covering how partners must have at least one of service_area or address