### PR TITLE
Add TagUser model + tags to user's form. Clean up stuff

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,7 +3,6 @@
 module Admin
   class UsersController < Admin::ApplicationController
     before_action :set_user, only: %i[edit update destroy]
-    before_action :set_roles_and_tags, only: %i[new create edit assign_tag update destroy]
 
     def profile
       authorize current_user, :profile?
@@ -96,11 +95,6 @@ module Admin
     end
 
     private
-
-    def set_roles_and_tags
-      @tags = Tag.all
-      @roles = User.role.values
-    end
 
     def profile_params
       params.require(:user).permit(:first_name,

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -97,9 +97,9 @@ module Admin
     private
 
     def collect_partners
-      return policy_scope(Partner).where(id: params[:partner_id]).map(&:id) if params[:partner_id]
+      return policy_scope(Partner).where(id: params[:partner_id])&.map(&:id) if params[:partner_id]
 
-      @user.partners.map(&:id)
+      @user&.partners&.map(&:id)
     end
 
     def profile_params

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,6 +10,7 @@ module Admin
 
     def update_profile
       authorize current_user, :update_profile?
+
       if update_user_profile
         bypass_sign_in(current_user)
         flash[:success] = 'User profile has been updated'
@@ -37,16 +38,15 @@ module Admin
     end
 
     def new
-      if params[:partner_id]
-        # TODO: scoping for current_user
-        @partner = Partner.where(id: params[:partner_id]).first
-      end
+      @partners = collect_partners
 
       @user = User.new
       authorize @user
     end
 
     def edit
+      @partners = collect_partners
+
       authorize @user
     end
 
@@ -95,6 +95,12 @@ module Admin
     end
 
     private
+
+    def collect_partners
+      return policy_scope(Partner).where(id: params[:partner_id]).map(&:id) if params[:partner_id]
+
+      @user.partners.map(&:id)
+    end
 
     def profile_params
       params.require(:user).permit(:first_name,

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -28,4 +28,26 @@ module CalendarsHelper
       "#{(Date.current - date).to_i} Days Ago"
     end
   end
+
+  def strategy_label(val)
+    case val.second
+    when 'event'
+      '<strong>Event</strong>: ' \
+      'Get the location of this event from the address field on the source event. ' \
+      'This is for area calendars, or organisations with no solid base.'.html_safe
+    when 'place'
+      '<strong>Default location</strong>: ' \
+      'Every event is in one location (set below). The address field on the source calendar is ignored.'.html_safe
+    when 'room_number'
+      '<strong>Room Number</strong>: ' \
+      'Every event is on one location (set below), and the address field is used ' \
+      'to store a room number.'.html_safe
+    when 'event_override'
+      '<strong>Event Override</strong>: ' \
+      'Every event is in one location (set below), unless the address field ' \
+      'is set to another location'.html_safe
+    else
+      val
+    end
+  end
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module TagsHelper
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -29,4 +29,18 @@ module UsersHelper
   def options_for_tags
     policy_scope(Tag).order(:name).map { |tag| [tag.name, tag.id] }
   end
+
+  def role_label(value)
+    case value.second
+    when 'root'
+      '<strong>Root</strong>: Can do everything'.html_safe
+    when 'editor'
+      '<strong>Editor</strong>: Can edit news articles'.html_safe
+    when 'citizen'
+      '<strong>Citizen</strong>: ' \
+      'Can only edit entities listed on this page'.html_safe
+    else
+      value
+    end
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -10,10 +10,8 @@ module UsersHelper
               class: 'gravatar')
   end
 
-  def tooltip_label(attribute, title)
-    str = attribute 
-    str += button_tag('?', class: "btn btn-secondary", data: { toggle: "tooltip", placement: "top"  }, title: title)
-    sanitize(str, tags: %w(button), attributes: %w(class type data-toggle data-placement title))
+  def options_for_roles
+    User.role.values
   end
 
   def options_for_partners
@@ -21,10 +19,14 @@ module UsersHelper
   end
 
   def options_for_neighbourhoods
-    policy_scope(Neighbourhood).
-      where('name is not null and name != \'\'').
-      order(:name).
-      all.
-      map { |nh| [nh.contextual_name, nh.id] }
+    policy_scope(Neighbourhood)
+      .where('name is not null and name != \'\'')
+      .order(:name)
+      .all
+      .map { |nh| [nh.contextual_name, nh.id] }
+  end
+
+  def options_for_tags
+    policy_scope(Tag).order(:name).map { |tag| [tag.name, tag.id] }
   end
 end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -41,30 +41,6 @@ class Calendar < ApplicationRecord
     %i[place room_number event_override].include? strategy.to_sym
   end
 
-  class << self
-    def strategy_label(val)
-      case val.second
-      when 'event'
-        '<strong>Event</strong>: ' \
-        'Get the location of this event from the address field on the source event. ' \
-        'This is for area calendars, or organisations with no solid base.'.html_safe
-      when 'place'
-        '<strong>Default location</strong>: ' \
-        'Every event is in one location (set below). The address field on the source calendar is ignored.'.html_safe
-      when 'room_number'
-        '<strong>Room Number</strong>: ' \
-        'Every event is on one location (set below), and the address field is used ' \
-        'to store a room number.'.html_safe
-      when 'event_override'
-        '<strong>Event Override</strong>: ' \
-        'Every event is in one location (set below), unless the address field ' \
-        'is set to another location'.html_safe
-      else
-        val
-      end
-    end
-  end
-
   # Output constant for event import date limit
   def self.import_up_to
     1.year.from_now

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -42,23 +42,23 @@ class Calendar < ApplicationRecord
   end
 
   class << self
-    def strategy_label val
+    def strategy_label(val)
       case val.second
       when 'event'
         '<strong>Event</strong>: ' \
-        "Get the location of this event from the address field on the source event. " \
-        "This is for area calendars, or organisations with no solid base.".html_safe
+        'Get the location of this event from the address field on the source event. ' \
+        'This is for area calendars, or organisations with no solid base.'.html_safe
       when 'place'
-        "<strong>Default location</strong>: " \
-        "Every event is in one location (set below). The address field on the source calendar is ignored.".html_safe
+        '<strong>Default location</strong>: ' \
+        'Every event is in one location (set below). The address field on the source calendar is ignored.'.html_safe
       when 'room_number'
-        "<strong>Room Number</strong>: " \
-        "Every event is on one location (set below), and the address field is used " \
-        "to store a room number.".html_safe
+        '<strong>Room Number</strong>: ' \
+        'Every event is on one location (set below), and the address field is used ' \
+        'to store a room number.'.html_safe
       when 'event_override'
-        "<strong>Event Override</strong>: " \
-        "Every event is in one location (set below), unless the address field " \
-        "is set to another location".html_safe
+        '<strong>Event Override</strong>: ' \
+        'Every event is in one location (set below), unless the address field ' \
+        'is set to another location'.html_safe
       else
         val
       end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -8,8 +8,10 @@ class Tag < ApplicationRecord
 
   self.table_name = 'tags' # Maybe we can remove this? Tag should automagically railsify to tags right?
 
-  has_and_belongs_to_many :users
   has_and_belongs_to_many :partners
+
+  has_many :tags_users, dependent: :destroy
+  has_many :users, through: :tags_users
 
   validates :name, :slug, presence: true
   validates :name, :slug, uniqueness: true
@@ -23,4 +25,15 @@ class Tag < ApplicationRecord
   enumerize :edit_permission,
             in: %i[root all],
             default: :root
+
+  def self.edit_permission_label(value)
+    case value.second
+    when 'root'
+      '<strong>Root</strong>: Only root-level users may assign this tag'.html_safe
+    when 'all'
+      '<strong>All</strong>: Any user may assign this tag'.html_safe
+    else
+      value
+    end
+  end
 end

--- a/app/models/tags_user.rb
+++ b/app/models/tags_user.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class TagsUser < ApplicationRecord
+  self.table_name = 'tags_users'
+  belongs_to :tag
+  belongs_to :user
+  validates :tag_id,
+            uniqueness: {
+              scope: :user_id,
+              message: 'User cannot be assigned more than once to a tag'
+            }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,20 +116,6 @@ class User < ApplicationRecord
     facebook_app_id.present? && facebook_app_secret.present?
   end
 
-  def self.role_label(value)
-    case value.second
-    when 'root'
-      '<strong>Root</strong>: Can do everything'.html_safe
-    when 'editor'
-      '<strong>Editor</strong>: Can edit news articles'.html_safe
-    when 'citizen'
-      '<strong>Citizen</strong>: ' \
-      'Can only edit entities listed on this page'.html_safe
-    else
-      value
-    end
-  end
-
   def assigned_to_postcode?(postcode)
     return true unless neighbourhood_admin?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,16 +27,15 @@ class User < ApplicationRecord
   # TODO: set up join models properly
   # has_many :partners_users, dependent: :destroy
   # has_many :partners, through: :partners_users
-  # # TODO: Rename to 'tags' on DB level
-  # has_many :tags_users, dependent: :destroy
-  # has_many :tags, through: :tags_users
 
   has_and_belongs_to_many :partners
-  has_and_belongs_to_many :tags
   has_many :sites, foreign_key: :site_admin
 
   has_many :neighbourhoods_users, dependent: :destroy
   has_many :neighbourhoods, through: :neighbourhoods_users
+
+  has_many :tags_users, dependent: :destroy
+  has_many :tags, through: :tags_users
 
   validates :email,
             presence: true,
@@ -117,6 +116,20 @@ class User < ApplicationRecord
     facebook_app_id.present? && facebook_app_secret.present?
   end
 
+  def self.role_label(value)
+    case value.second
+    when 'root'
+      '<strong>Root</strong>: Can do everything'.html_safe
+    when 'editor'
+      '<strong>Editor</strong>: Can edit news articles'.html_safe
+    when 'citizen'
+      '<strong>Citizen</strong>: ' \
+      'Can only edit entities listed on this page'.html_safe
+    else
+      value
+    end
+  end
+
   def assigned_to_postcode?(postcode)
     return true unless neighbourhood_admin?
 
@@ -134,6 +147,7 @@ class User < ApplicationRecord
 
   def password_required?
     return false if skip_password_validation
+
     super
   end
 end

--- a/app/views/admin/calendars/_form.html.erb
+++ b/app/views/admin/calendars/_form.html.erb
@@ -39,7 +39,7 @@
         <h3>Location</h3>
         <%= f.input :strategy,
                     as: :radio_buttons,
-                    label_method: ->(val){Calendar.strategy_label(val)},
+                    label_method: ->(val){strategy_label(val)},
                     hint: 'How should PlaceCal decide where events on this calendar are held?',
                     input_html: { 'v-model': 'strategy', 'v-on:change': "updateLocation" } %>
         <div v-if="locationVisible">

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -7,7 +7,10 @@
 
   <%= f.input :description, class: "form-control" %>
 
-  <%= f.input :edit_permission, class: "form-control" %>
+  <%= f.input :edit_permission,
+              as: :radio_buttons,
+              label_method: ->(val){ Tag.edit_permission_label(val) },
+              hint: 'Users with this role will be granted access to assign this tag' %>
 
   <%# = f.association :partner, collection: @partners %>
   <% unless @tag.new_record? %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -3,19 +3,46 @@
 <div class="form-group">
   <%= render "contact", f: f %>
 
-  <%# f.association :tags, label: false, collection: @tags, as: :check_boxes %>
-  <%= f.association :partners,
-                    label: tooltip_label('Partners', 'Partners this user can edit, as well as their associated calendars'),
-                    collection: options_for_partners,
-                    selected: (@partner.id if @partner),
-                    input_html: {class: 'form-control select2' } %>
+  <br>
+  <hr>
 
-  <%= f.association :neighbourhoods,
-                    label: tooltip_label('Neighbourhoods', 'Grants access to every partner and calendar in these neighbourhoods. Use with care!'),
-                    collection: options_for_neighbourhoods,
-                    input_html: {class: 'form-control select2' } %>
+  <div class="row">
+    <div class="col-md-6">
+      <h3>Partners</h3>
+      <p>Partners this user can edit, as well as their associatied calendars</p>
+      <%= f.association :partners,
+                        label: false,
+                        collection: options_for_partners,
+                        input_html: {class: 'form-control select2' } %>
+    </div>
+    <div class="col-md-6">
+      <h3>Neighbourhoods</h3>
+      <p>Grants access to every partner and calendar in these neighbourhoods. Use with care!</p>
+      <%= f.association :neighbourhoods,
+                        label: false,
+                        collection: options_for_neighbourhoods,
+                        input_html: {class: 'form-control select2' } %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <h3>Allowed Tags</h3>
+      <p>Grants access to apply the given tags</p>
+      <%= f.association :tags,
+                        label: false,
+                        collection: options_for_tags,
+                        input_html: {class: 'form-control select2' } %>
+    </div>
+    <div class="col-md-6">
+      <h3>Role</h3>
+      <%= f.input :role,
+                  as: :radio_buttons,
+                  label_method: ->(val){ User.role_label(val) } %>
+    </div>
+  </div>
 
-  <%= f.input :role, collection: @roles, class: 'form-control', include_blank: false %>
+  <br>
+  <hr>
 
   <% if current_user.root? %>
     <%= f.input :facebook_app_id, as: :string %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -13,7 +13,9 @@
       <%= f.association :partners,
                         label: false,
                         collection: options_for_partners,
-                        input_html: {class: 'form-control select2' } %>
+                        selected: @partners,
+                        input_html: {class: 'form-control select2' }
+          %>
     </div>
     <div class="col-md-6">
       <h3>Neighbourhoods</h3>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -39,7 +39,7 @@
       <h3>Role</h3>
       <%= f.input :role,
                   as: :radio_buttons,
-                  label_method: ->(val){ User.role_label(val) } %>
+                  label_method: ->(val){ role_label(val) } %>
     </div>
   </div>
 

--- a/db/migrate/20220221063323_add_id_to_tags_users.rb
+++ b/db/migrate/20220221063323_add_id_to_tags_users.rb
@@ -1,0 +1,5 @@
+class AddIdToTagsUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tags_users, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_17_120103) do
+ActiveRecord::Schema.define(version: 2022_02_21_063323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -305,7 +305,7 @@ ActiveRecord::Schema.define(version: 2022_02_17_120103) do
     t.string "edit_permission"
   end
 
-  create_table "tags_users", id: false, force: :cascade do |t|
+  create_table "tags_users", force: :cascade do |t|
     t.bigint "tag_id", null: false
     t.bigint "user_id", null: false
     t.index ["tag_id", "user_id"], name: "index_tags_users_on_tag_id_and_user_id"

--- a/test/integration/admin/user_integration_test.rb
+++ b/test/integration/admin/user_integration_test.rb
@@ -87,9 +87,10 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Email *'
     assert_select 'label', 'Phone'
     assert_select 'label', 'Avatar'
-    assert_select 'label', /\APartners/
-    assert_select 'label', /\ANeighbourhoods/
-    assert_select 'label', 'Role *'
+    assert_select 'h3', 'Partners'
+    assert_select 'h3', 'Neighbourhoods'
+    assert_select 'h3', 'Allowed Tags'
+    assert_select 'h3', 'Role'
     assert_select 'label', 'Facebook app'
     assert_select 'label', 'Facebook app secret'
   end
@@ -105,9 +106,10 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Email *'
     assert_select 'label', 'Phone'
     assert_select 'label', 'Avatar'
-    assert_select 'label', /\APartners/
-    assert_select 'label', html: /\A'Neighbourhoods/, count: 0
-    assert_select 'label', text: 'Role *', count: 0
+    assert_select 'h3', 'Partners'
+    assert_select 'h3', 'Allowed Tags'
+    assert_select 'h3', 'Neighbourhoods', count: 0
+    assert_select 'h3', 'Role', count: 0
     assert_select 'label', text: 'Facebook app', count: 0
     assert_select 'label', text: 'Facebook app secret', count: 0
   end
@@ -124,9 +126,10 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Email *'
     assert_select 'label', 'Phone'
     assert_select 'label', 'Avatar'
-    assert_select 'label', /\APartners/
-    assert_select 'label', /\ANeighbourhoods/
-    assert_select 'label', 'Role *'
+    assert_select 'h3', 'Partners'
+    assert_select 'h3', 'Neighbourhoods'
+    assert_select 'h3', 'Allowed Tags'
+    assert_select 'h3', 'Role'
     assert_select 'label', 'Facebook app'
     assert_select 'label', 'Facebook app secret'
   end
@@ -142,9 +145,10 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Email *'
     assert_select 'label', 'Phone'
     assert_select 'label', 'Avatar'
-    assert_select 'label', /\APartners/
-    assert_select 'label', html: /\A'Neighbourhoods/, count: 0
-    assert_select 'label', text: 'Role *', count: 0
+    assert_select 'h3', 'Partners'
+    assert_select 'h3', 'Neighbourhoods', count: 0
+    assert_select 'h3', 'Allowed Tags'
+    assert_select 'h3', 'Role', count: 0
     assert_select 'label', text: 'Facebook app', count: 0
     assert_select 'label', text: 'Facebook app secret', count: 0
   end


### PR DESCRIPTION
Fixes #971 

- Add TagsUser model
  - Pluralisation fixed courtesey of Kim
  - Edit User, Tag models to fix relation
- Add Tags to User's form
  - Clean up User form
    - Move roles and tags out of user's controller into helper
    - Properly policy scope tags
    - Add role_label Singleton
    - Switch to using two column layout
    - Fix options_for_neighbourhoods formatting
    - Fix strategy_label formatting
- Add TagsUsers to Tag model and form
  - Add edit_permission_label singleton to Tag
  - Add edit_permission radio buttons to Tags form