### PR TITLE
User service area partner admin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,10 +80,14 @@ class User < ApplicationRecord
     owned_neighbourhoods.collect(&:id)
   end
 
-  def can_alter_neighbourhood?(neighbourhood)
-    owned_neighbourhoods.include? neighbourhood
+  def can_alter_neighbourhood_by_id?(neighbourhood_id)
+    owned_neighbourhood_ids.include? neighbourhood_id
   end
 
+  def can_alter_partner_by_id?(partner_id)
+    partners.pluck(:id).include? partner_id
+  end
+  
   def neighbourhood_admin?
     neighbourhoods.any?
   end

--- a/app/policies/partner_policy.rb
+++ b/app/policies/partner_policy.rb
@@ -20,8 +20,10 @@ class PartnerPolicy < ApplicationPolicy
   def update?
     return true if user.root?
 
-    user.owned_neighbourhood_ids.include?(record.neighbourhood_id) ||
-      user.partner_ids.include?(record.id)
+    return true if user.can_alter_neighbourhood_by_id?(record.neighbourhood_id)
+    return true if user.can_alter_partner_by_id?(record.id)
+    
+    false
   end
 
   def edit?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -35,12 +35,20 @@ class UserTest < ActiveSupport::TestCase
     ward     = owned_neighbourhoods.find_all { |u| u.unit == 'ward' }.first
 
     # We do not have permissions to edit the country!
-    assert (@neighbourhood_region_admin.can_alter_neighbourhood? region.parent) == false
+    assert (@neighbourhood_region_admin.can_alter_neighbourhood_by_id? region.parent.id) == false
 
     # We should have permissions to edit a county, district, or ward neighbourhood
-    assert @neighbourhood_region_admin.can_alter_neighbourhood?(county)
-    assert @neighbourhood_region_admin.can_alter_neighbourhood?(district)
-    assert @neighbourhood_region_admin.can_alter_neighbourhood?(ward)
+    assert @neighbourhood_region_admin.can_alter_neighbourhood_by_id?(county.id)
+    assert @neighbourhood_region_admin.can_alter_neighbourhood_by_id?(district.id)
+    assert @neighbourhood_region_admin.can_alter_neighbourhood_by_id?(ward.id)
+  end
+
+  test 'can edit partners' do
+    user = create(:user)
+    partner = create(:partner)
+    user.partners << partner
+
+    assert user.can_alter_partner_by_id?(partner.id)
   end
 
   test 'updates user role on save' do

--- a/test/policies/partner_policy_test.rb
+++ b/test/policies/partner_policy_test.rb
@@ -117,4 +117,31 @@ class PartnerPolicyTest < ActiveSupport::TestCase
     # assert_equal(permitted_records(@multi_admin, Partner).sort_by(&:id),
     #              [@partner, @partner_two, @ashton_partner])
   end
+
+  def test_create_with_partner_permissions
+    user = create(:user)
+
+    # user with no partners
+    assert denies_access(user, Partner, :create)
+
+    neighbourhood = create(:neighbourhood)
+    user.neighbourhoods << neighbourhood
+
+    # can create partners if user has neighbourhoods
+    assert allows_access(user, Partner, :create)
+  end
+
+  def test_update_with_partner_permissions
+    user = create(:user)
+    partner = create(:partner)
+
+    # denies user with no partners
+    assert denies_access(user, partner, :update)
+    
+    # can update partners user has access to
+    user.partners << partner
+    assert allows_access(user, partner, :update)
+  end
 end
+
+


### PR DESCRIPTION
Implements #993 - users can only modify partners that they have links to