### PR TITLE
Site lookup Partners now includes service areas

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -88,9 +88,11 @@ class Partner < ApplicationRecord
   scope :recently_updated, -> { order(updated_at: desc) }
 
   scope :for_site, lambda { |site|
-    joins(:address).where(addresses: {
-                            neighbourhood: site.neighbourhoods.map(&:subtree).flatten
-                          })
+    site_neighbourhood_ids = site.neighbourhoods.map(&:subtree).flatten.map(&:id)
+
+    joins('left join addresses on addresses.id = partners.address_id')
+      .joins('left join service_areas on partners.id = service_areas.partner_id')
+      .where('(service_areas.neighbourhood_id in (?)) or (addresses.neighbourhood_id in (?))', site_neighbourhood_ids, site_neighbourhood_ids)
   }
 
   scope :of_tag, ->(tag) { joins(:partners_tags).where(partners_tags: { tag: tag }) }

--- a/test/fixtures/neighbourhoods.yml
+++ b/test/fixtures/neighbourhoods.yml
@@ -15,3 +15,12 @@ two:
   unit_code_key: 'WD19CD'
   unit_code_value: 'E05000800'
   unit_name: 'Ashton Hurst'
+
+# this must match up with the geocode stub API data in test_helper.rb
+moss_side:
+  name: 'Moss Side'
+  name_abbr: ''
+  unit: 'ward'
+  unit_code_key: 'WD19CD'
+  unit_code_value: 'E05011372'
+  unit_name: 'Moss Side'

--- a/test/models/partner_test.rb
+++ b/test/models/partner_test.rb
@@ -275,4 +275,82 @@ class PartnerAddressOrServiceAreaPermissionsTest < ActiveSupport::TestCase
   end
 end
 
+class PartnerSiteScopeTest < ActiveSupport::TestCase
+
+  # this verifies that partner#for_site is behaving
+
+  setup do
+    neighbourhood = neighbourhoods(:one) 
+
+    @site = create(:site)
+    @site.neighbourhoods << neighbourhood
+
+    assert @site.neighbourhoods.length == 1
+
+    address_partner_1 = build(:partner, address: create(:address, neighbourhood: neighbourhood))
+    address_partner_1.save!
+
+    address_partner_2 = build(:partner, address: create(:address, neighbourhood: neighbourhood))
+    address_partner_2.save!
+
+    service_area_partner_1 = build(:partner, address: nil)
+    service_area_partner_1.service_areas.build(neighbourhood: neighbourhood)
+    service_area_partner_1.save!
+
+    service_area_partner_2 = build(:partner, address: nil)
+    service_area_partner_2.service_areas.build(neighbourhood: neighbourhood)
+    service_area_partner_2.save!
+
+    service_area_partner_3 = build(:partner, address: nil)
+    service_area_partner_3.service_areas.build(neighbourhood: neighbourhood)
+    service_area_partner_3.save!
+
+    # has both, should appear only once though
+    address_and_service_area_partner = build(:partner, address: nil)
+    address_and_service_area_partner.address = create(:address, neighbourhood: neighbourhood)
+    address_and_service_area_partner.service_areas.build(neighbourhood: neighbourhood)
+    address_and_service_area_partner.save!
+  end
+
+  test "can find partners in site with address" do
+    output = Partner.for_site(@site)
+    count = output.count
+    assert count == 6 # number of partners with addresses in site
+  end
+
+  test "works with sites that have multiple neighbourhoods" do
+    other_neighbourhood = neighbourhoods(:two)
+    @site.neighbourhoods << other_neighbourhood
+
+    address_partner_3 = build(:partner, address: create(:address, neighbourhood: other_neighbourhood))
+    address_partner_3.save!
+
+    service_area_partner_4 = build(:partner, address: nil)
+    service_area_partner_4.service_areas.build(neighbourhood: other_neighbourhood)
+    service_area_partner_4.save!
+
+    output = Partner.for_site(@site)
+    count = output.count
+    assert count == 8 # number of partners with addresses in site
+  end
+
+  # being very thorough and paranoid about my SQL fu -IK
+  test "it definitely works even when there's a second site" do
+
+    other_site = create(:site)
+    other_neighbourhood = neighbourhoods(:moss_side)
+    other_site.neighbourhoods << other_neighbourhood
+
+    address_partner_4 = build(:partner, address: create(:moss_side_address, neighbourhood: other_neighbourhood))
+    address_partner_4.save!
+
+    service_area_partner_5 = build(:partner, address: nil)
+    service_area_partner_5.service_areas.build(neighbourhood: other_neighbourhood)
+    service_area_partner_5.save!
+
+    output = Partner.for_site(other_site)
+    count = output.count
+    assert count == 2 # only two partners in other site
+  end
+end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -186,3 +186,49 @@ Geocoder::Lookup::Test.add_stub(
       } }
   ]
 )
+
+# this compliments the neighbourhood fixture in test/fixtures/neighbourhood.yml
+Geocoder::Lookup::Test.add_stub(
+  'M16 7BA', [
+    {
+      'postcode' => 'M16 7BA',
+      'quality' => 1,
+      'eastings' => 383321,
+      'northings' => 395843,
+      'country' => 'England',
+      'nhs_ha' => 'North West',
+      'longitude' => -2.252664,
+      'latitude' => 53.459069,
+      'european_electoral_region' => 'North West',
+      'primary_care_trust' => 'Manchester Teaching',
+      'region' => 'North West',
+      'lsoa' => 'Manchester 024B',
+      'msoa' => 'Manchester 024',
+      'incode' => '7BA',
+      'outcode' => 'M16',
+      'parliamentary_constituency' => 'Manchester Central',
+      'admin_district' => 'Manchester',
+      'parish' => 'Manchester, unparished area',
+      'admin_county' => nil,
+      'admin_ward' => 'Moss Side',
+      'ced' => nil,
+      'ccg' => 'NHS Manchester',
+      'nuts' => 'Manchester',
+      'codes' => {
+        'admin_district' => 'E08000003',
+        'admin_county' => 'E99999999',
+        'admin_ward' => 'E05011372',
+        'parish' => 'E43000157',
+        'parliamentary_constituency' => 'E14000807',
+        'ccg' => 'E38000217',
+        'ccg_id' => '14L',
+        'ced' => 'E99999999',
+        'nuts' => 'TLD33',
+        'lsoa' => 'E01005243',
+        'msoa' => 'E02001068',
+        'lau2' => 'E08000003'
+      }
+    }
+  ]
+)
+


### PR DESCRIPTION
Implements part 1 of #999 - Partners can be found via service area and address