### PR TITLE
Bypass rails authentication for graphql endpoint

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,4 +1,7 @@
 class GraphqlController < ApplicationController
+  
+  skip_before_action :verify_authenticity_token
+
   # If accessing from outside this domain, nullify the session
   # This allows for outside API access while preventing CSRF attacks,
   # but you'll have to authenticate your user separately


### PR DESCRIPTION
So you no longer need to provide any authentication token.