### PR TITLE
Fix calendar organiser preselect bug

### DIFF
--- a/app/controllers/admin/calendars_controller.rb
+++ b/app/controllers/admin/calendars_controller.rb
@@ -33,6 +33,7 @@ module Admin
 
     def edit
       @versions = @calendar.recent_activity
+      @partner = @calendar.partner
     end
 
     def show

--- a/test/integration/admin/calendars_integration_test.rb
+++ b/test/integration/admin/calendars_integration_test.rb
@@ -89,7 +89,7 @@ class Admin::CalendarsTest < ActionDispatch::IntegrationTest
       assert_select 'option', count: 3
     end
 
-    assert_select 'option', @partner.name, count: 1
+    assert_select 'option[selected="selected"]', @partner.name
     assert_select 'option', @partner_two.name, count: 1
   end
 


### PR DESCRIPTION
On the admin calendar edit page the form pre-fills the partner select
box correctly.