### PR TITLE
Root users can assign service areas at will

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -205,7 +205,7 @@ class Partner < ApplicationRecord
   end
 
   def check_service_area_access
-    return if accessed_by_user.nil?
+    return if accessed_by_user.nil? || accessed_by_user.root?
 
     my_neighbourhoods = service_areas.map(&:neighbourhood_id)
     return if my_neighbourhoods.empty?

--- a/test/models/partner_test.rb
+++ b/test/models/partner_test.rb
@@ -172,6 +172,20 @@ class PartnerServiceAreaTest < ActiveSupport::TestCase
 
     assert @partner.valid? == false, 'Partner should not be valid'
   end
+
+  test 'can be set by root users' do
+    root_user = create(:root)
+    other_neighbourhood = create(:moss_side_neighbourhood)
+
+    @partner.accessed_by_user = root_user
+    @partner.service_area_neighbourhoods << other_neighbourhood
+    @partner.save!
+
+    assert @partner.valid?, 'Partner (with service_area) should be valid'
+
+    neighbourhood_count = @partner.service_area_neighbourhoods.count
+    assert_equal 1, neighbourhood_count, 'count neighbourhoods'
+  end
 end
 
 class PartnerAddressOrServiceAreaPresenceTest < ActiveSupport::TestCase


### PR DESCRIPTION
No restriction on needing to be in user's neighbourhoods

Implements fix for #1011