### PR TITLE
Tag Preselection and Datatables search fix

### DIFF
--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -23,6 +23,8 @@ module Admin
 
     def new
       @partner = params[:partner] ? Partner.new(permitted_attributes(Partner)) : Partner.new
+      @partner.tags = current_user.tags
+
       authorize @partner
     end
 

--- a/app/datatables/partner_datatable.rb
+++ b/app/datatables/partner_datatable.rb
@@ -7,7 +7,7 @@ class PartnerDatatable < Datatable
       name:       { source: 'Partner.name', cond: :like },
       slug:       { source: 'Partner.slug' },
       address:    { source: 'Partner.address', searchable: false },
-      updated_at: { source: 'Partner.address' },
+      updated_at: { source: 'Partner.updated_at' },
     }
   end
 

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -28,7 +28,7 @@ module PartnersHelper
   def service_area_links(partner)
     partner.service_area_neighbourhoods
       .order(:name)
-      .map { |hood| link_to hood.name, admin_neighbourhood_path(hood) }
+      .map { |hood| link_to hood.name, edit_admin_neighbourhood_path(hood) }
       .join(', ')
       .html_safe
   end

--- a/app/views/admin/users/profile.html.erb
+++ b/app/views/admin/users/profile.html.erb
@@ -50,25 +50,40 @@
     <div class="col-md-6">
       <% if current_user.partners.any? %>
         <h3>Your partners</h3>
-          <ul>
-            <% current_user.partners.each do |partner| %>
-              <li>
-                <%= link_to partner.name, edit_admin_partner_path(partner) %>
-              </li>
-            <% end %>
-          </ul>
+        <ul>
+          <% current_user.partners.each do |partner| %>
+            <li>
+              <%= link_to partner.name, edit_admin_partner_path(partner) %>
+            </li>
+          <% end %>
+        </ul>
       <% end %>
     </div>
     <div class="col-md-6">
       <% if current_user.neighbourhoods.any? %>
         <h3>Your neighbourhoods</h3>
-          <ul>
-            <% current_user.neighbourhoods.each do |neighbourhood| %>
-              <li>
-                <%= link_to neighbourhood.contextual_name, edit_admin_neighbourhood_path(neighbourhood) %>
-              </li>
-            <% end %>
-          </ul>
+        <ul>
+          <% current_user.neighbourhoods.each do |neighbourhood| %>
+            <li>
+              <%= link_to neighbourhood.contextual_name, edit_admin_neighbourhood_path(neighbourhood) %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <% if current_user.tag_admin? %>
+        <h3>Your assigned tags</h3>
+        <p>Please note these tags will be pre-selected when creating a new partner<p>
+        <ul>
+          <% current_user.tags.each do |tag| %>
+            <li>
+              <%= link_to tag.name, edit_admin_tag_path(tag) %>
+            </li>
+          <% end %>
+        </ul>
       <% end %>
     </div>
   </div>

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -12,8 +12,10 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
 
     @neighbourhood_region_admin = create(:neighbourhood_region_admin)
 
+    @tag = create(:tag)
+
     @default_site = create_default_site
-    get "http://admin.lvh.me"
+    get 'http://admin.lvh.me'
   end
 
   test "Edit form has correct fields" do
@@ -82,5 +84,21 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_select 'a#destroy-partner', false, "This page must not have a Destroy Partner button"
+  end
+
+  test 'Partner has owned tag preselected' do
+    @neighbourhood_region_admin.tags << @tag
+
+    sign_in @neighbourhood_region_admin
+
+    get new_admin_partner_path(@partner)
+    assert_response :success
+
+    assert_select 'div.tags > fieldset.check_boxes' do |checkbox|
+      tag = assert_select checkbox, 'div.form-check', 1 # We have one tag
+
+      assert_select tag, 'label', text: @tag.name
+      assert_select tag, 'input:match("checked", ?)', 'checked'
+    end
   end
 end

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -1,21 +1,24 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/StringLiterals
-
 require 'test_helper'
 
-class AdminPartnerIntegrationTest < ActionDispatch::IntegrationTest
+class PartnerIntegrationTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
     @admin = create(:root)
-    @default_site = create_default_site
+
     @partner = create(:partner)
+
+    @neighbourhood_region_admin = create(:neighbourhood_region_admin)
+
+    @default_site = create_default_site
     get "http://admin.lvh.me"
-    sign_in @admin
   end
 
   test "Edit form has correct fields" do
+    sign_in @admin
+
     get edit_admin_partner_path(@partner)
     assert_response :success
 
@@ -47,54 +50,34 @@ class AdminPartnerIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', text: 'Partner email'
     assert_select 'label', text: 'Partner phone'
   end
-end
-
-class PartnerShowingDeleteButtonIntegrationTest  < ActionDispatch::IntegrationTest
-  include Devise::Test::IntegrationHelpers
 
   test 'Edit has delete button for root users' do
-    root_user = create(:root)
-    default_site = create_default_site
-    partner = create(:partner)
-    get "http://admin.lvh.me"
-    sign_in root_user
+    sign_in @admin
 
-    get edit_admin_partner_path(partner)
+    get edit_admin_partner_path(@partner)
     assert_response :success
 
     assert_select 'a#destroy-partner', 'Delete Partner'
   end
 
   test 'Edit has delete button for neighbourhood admins' do
-    hood_user = create(:neighbourhood_region_admin)
-    default_site = create_default_site
-    partner = create(:partner)
-    partner.address.update! neighbourhood_id: hood_user.neighbourhoods.first.id
+    @partner.address.update!(
+      neighbourhood_id: @neighbourhood_region_admin.neighbourhoods.first.id
+    )
 
-    get "http://admin.lvh.me"
-    sign_in hood_user
+    sign_in @neighbourhood_region_admin
 
-    get edit_admin_partner_path(partner)
+    get edit_admin_partner_path(@partner)
     assert_response :success
 
     assert_select 'a#destroy-partner', 'Delete Partner'
   end
-end
-
-class PartnerHidingDeleteButtonIntegrationTest < ActionDispatch::IntegrationTest
-  include Devise::Test::IntegrationHelpers
-
-  setup do
-    @admin = create(:neighbourhood_region_admin)
-    @default_site = create_default_site
-    @partner = create(:partner)
-    @admin.partners << @partner
-
-    get "http://admin.lvh.me"
-    sign_in @admin
-  end
 
   test 'Edit does not have delete button for partner admins' do
+    @neighbourhood_region_admin.partners << @partner
+
+    sign_in @neighbourhood_region_admin
+
     get edit_admin_partner_path(@partner)
     assert_response :success
 

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -14,8 +14,7 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
 
     @tag = create(:tag)
 
-    @default_site = create_default_site
-    get 'http://admin.lvh.me'
+    host! 'admin.lvh.me'
   end
 
   test "Edit form has correct fields" do


### PR DESCRIPTION
Fixes #1033

- Adds tag preselection for tag_admin tags to Partners create form
- Adds tags listing to users profile
- Refactors partner integration tests to be cleaner and more in-line with the rest of the codebase
- Fix link to neighbourhood entry on the partners page
- Fixes Datatable search on Calendar entries