### PR TITLE
Fix badges + simplify some code

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,7 +32,7 @@ class Event < ApplicationRecord
 
   # Filter by Site
   scope :for_site, lambda { |site|
-    site_neighbourhood_ids = site.neighbourhoods.map(&:subtree).flatten.map(&:id)
+    site_neighbourhood_ids = site.owned_neighbourhoods.map(&:id)
 
     joins(:address)
       .joins('left join partners on events.partner_id = partners.id')

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -90,7 +90,7 @@ class Partner < ApplicationRecord
   scope :recently_updated, -> { order(updated_at: desc) }
 
   scope :for_site, lambda { |site|
-    site_neighbourhood_ids = site.neighbourhoods.map(&:subtree).flatten.map(&:id)
+    site_neighbourhood_ids = site.owned_neighbourhoods.map(&:id)
     site_tag_ids = site.tags.map(&:id)
 
     partners = joins('left join addresses on addresses.id = partners.address_id')

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -44,6 +44,10 @@ class Site < ApplicationRecord
     "#{id}: #{name}"
   end
 
+  def owned_neighbourhoods
+    neighbourhoods.map(&:subtree).flatten
+  end
+
   # ASSUMPTION: There is no row in the sites table for the admin site, hence
   # defining the admin subdomain string here.
   ADMIN_SUBDOMAIN = 'admin'
@@ -59,7 +63,7 @@ class Site < ApplicationRecord
 
   # Should we show the neighbourhood lozenge out on this site?
   def show_neighbourhoods?
-    neighbourhoods.count > 1
+    owned_neighbourhoods.count > 1
   end
 
   def self.badge_zoom_level_label(value)
@@ -67,7 +71,7 @@ class Site < ApplicationRecord
   end
 
   def join_word
-    if neighbourhoods.count > 1
+    if owned_neighbourhoods.count > 1
       'near'
     else
       'in'

--- a/test/integration/partners_integration_test.rb
+++ b/test/integration/partners_integration_test.rb
@@ -78,9 +78,9 @@ class PartnersIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'div.hero h4', text: "Neighbourhood's Community Calendar"
     assert_select 'div.hero h1', text: 'Partners in your area'
     assert_select 'ul.partners li', 5
-    # Ensure title/summary description is displayed
-    assert_select '.preview__header', text: @region_site_partners.first.name
-    assert_select '.preview__details', text: @region_site_partners.first.summary
+    # Ensure title/summary description is displayed (select the h3 tag to avoid badge selection)
+    assert_select 'div.preview__header h3', text: @region_site_partners.first.name
+    assert_select 'div.preview__details', text: @region_site_partners.first.summary
   end
 
   test 'tagged site page shows only tagged partners' do


### PR DESCRIPTION
Fixes #1042 

- Fix badges not displaying properly for region sites
  - Adds function `owned_neighbourhoods` to `Site` model
- Simplify some code to use `site.owned_neighbourhoods` instead