### PR TITLE
GraphQL documentation

### DIFF
--- a/app/graphql/types/address_type.rb
+++ b/app/graphql/types/address_type.rb
@@ -4,12 +4,26 @@ module Types
     description 'An address representing a physical location'
 
     # field :id, ID, null: false
-    field :street_address, String, method: :full_street_address
-    field :address_locality, String
-    field :address_region, String
-    field :address_country, String, method: :country_code
-    field :postal_code, String, method: :postcode
-    field :neighbourhood, NeighbourhoodType
+    field :street_address, String, 
+      method: :full_street_address,
+      description: 'The first few lines of the address like: 123 Road, Eastleigh, Southampton'
+
+    field :address_locality, String,
+      description: 'The nieghbourhood name of this address (see neighbourhood type)'
+
+    field :address_region, String,
+      description: 'The neighbourhood region of this address (see neighbourhood type)'
+
+    field :address_country, String, 
+      method: :country_code,
+      description: 'The country of this event (at the moment is only UK)'
+
+    field :postal_code, String, 
+      method: :postcode,
+      description: '(UK) Postcode of address'
+
+    field :neighbourhood, NeighbourhoodType,
+      description: 'The neighbourhood of this address (see neighbourhood type)'
 
     # TODO: figure out parent and children accessors
     # field :containedInPlace

--- a/app/graphql/types/address_type.rb
+++ b/app/graphql/types/address_type.rb
@@ -9,18 +9,18 @@ module Types
       description: 'The first few lines of the address like: 123 Road, Eastleigh, Southampton'
 
     field :address_locality, String,
-      description: 'The nieghbourhood name of this address (see neighbourhood type)'
+      description: 'The ward this address is in'
 
     field :address_region, String,
-      description: 'The neighbourhood region of this address (see neighbourhood type)'
+      description: 'The district this address is in'
 
     field :address_country, String, 
       method: :country_code,
-      description: 'The country of this event (at the moment is only UK)'
+      description: 'The country of this event (England, Scotland, Wales, or Northern Ireland)'
 
     field :postal_code, String, 
       method: :postcode,
-      description: '(UK) Postcode of address'
+      description: 'A UK postcode'
 
     field :neighbourhood, NeighbourhoodType,
       description: 'The neighbourhood of this address (see neighbourhood type)'

--- a/app/graphql/types/contact_type.rb
+++ b/app/graphql/types/contact_type.rb
@@ -1,11 +1,22 @@
 module Types
   class ContactType < Types::BaseObject
 
-    description ''
+    description 'Contact information for a person'
 
-    field :name, String, null: false, method: :public_name
-    field :email, String, null: false, method: :public_email
-    field :telephone, String, null: false, method: :public_phone
+    field :name, String, 
+      null: false, 
+      method: :public_name,
+      description: 'Name of contact'
+
+    field :email, String, 
+      null: false,
+      method: :public_email,
+      description: 'Email address of contact'
+
+    field :telephone, String,
+      null: false, 
+      method: :public_phone,
+      description: 'Telephone number of contact'
 
   end
 end

--- a/app/graphql/types/contact_type.rb
+++ b/app/graphql/types/contact_type.rb
@@ -1,7 +1,7 @@
 module Types
   class ContactType < Types::BaseObject
 
-    description 'Contact information for a person'
+    description 'Contact information for a person or venue'
 
     field :name, String, 
       null: false, 

--- a/app/graphql/types/event_queries.rb
+++ b/app/graphql/types/event_queries.rb
@@ -2,17 +2,35 @@ module Types
   
   module EventQueries
     def self.included(klass)
-      klass.field :event, EventType, "Find Event by ID" do
+      klass.field :event, EventType do
+        description 'Retrieve one event based on specific ID'
         argument :id, ID
       end
 
-      klass.field :event_connection, Types::EventType.connection_type
+      klass.field :event_connection, Types::EventType.connection_type do
+        description "Get events in more manageble chunks sort of like pagination."
+      end
 
       klass.field :events_by_filter, [Types::EventType] do
-        argument :from_date, String, required: false
-        argument :to_date, String, required: false
-        argument :neighbourhood_id, Integer, required: false
-        argument :tag_id, Integer, required: false
+        
+        description \
+          'Find events with various filter parameters. By default `eventsByFilter` will show all events from the current time.'
+
+        argument :from_date, String, 
+          required: false,
+          description: 'Time to start filter from. Format like "YYYY-MM-DD HH:MM". Defaults to current time'
+
+        argument :to_date, String, 
+          required: false,
+          description: 'Optional, same format as `fromDate`. Represents a future cut off point to limit query to'
+
+        argument :neighbourhood_id, Integer,
+          required: false,
+          description: 'The neighbourhood ID to scope the events to. Works through both address and service areas.'
+
+        argument :tag_id, Integer,
+          required: false,
+          description: 'The tag ID to scope events to'
       end
     end
 

--- a/app/graphql/types/event_queries.rb
+++ b/app/graphql/types/event_queries.rb
@@ -8,7 +8,7 @@ module Types
       end
 
       klass.field :event_connection, Types::EventType.connection_type do
-        description "Get events in more manageble chunks sort of like pagination."
+        description "Get events in chunks"
       end
 
       klass.field :events_by_filter, [Types::EventType] do
@@ -26,11 +26,11 @@ module Types
 
         argument :neighbourhood_id, Integer,
           required: false,
-          description: 'The neighbourhood ID to scope the events to. Works through both address and service areas.'
+          description: 'Will filter events who are inside this neighbourhood, or who have a service area contained in this neighbourhood.'
 
         argument :tag_id, Integer,
           required: false,
-          description: 'The tag ID to scope events to'
+          description: 'Will only show events whose partners have this tag'
       end
     end
 

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -13,7 +13,7 @@ module Types
       description: 'An alias for `summary`'
 
     field :summary, String,
-      description: 'A description of this specific event'
+      description: 'The title of the event'
 
     field :description, String,
       description: 'A longer text about this event covering more detail'

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -1,17 +1,38 @@
 module Types
   class EventType < Types::BaseObject
+    description 'An event represents a date in time that a partner operates their service, meetup, workout or class etc'
 
-    field :id, ID, null: false
+    field :id, ID, 
+      null: false,
+      description: 'Our internal ID for further querying'
+
     # Summary and name are aliases, this is left as a convenience 
     #   for people used to iCal format
-    field :name, String, method: :summary
-    field :summary, String
-    field :description, String
-    field :startDate, String, method: :dtstart, null: false
-    field :endDate, String, method: :dtend
+    field :name, String, 
+      method: :summary,
+      description: 'An alias for `summary`'
 
-    field :address, AddressType
-    field :organizer, PartnerType, method: :partner
+    field :summary, String,
+      description: 'A description of this specific event'
+
+    field :description, String,
+      description: 'A longer text about this event covering more detail'
+
+    field :startDate, String, 
+      method: :dtstart, 
+      null: false,
+      description: 'The date (and time) when this event begins'
+
+    field :endDate, String, 
+      method: :dtend,
+      description: 'The (optional) end date of this event if the event goes on for more than one day (i.e. a conference weekend)'
+
+    field :address, AddressType,
+      description: 'The address where this event will take place'
+
+    field :organizer, PartnerType, 
+      method: :partner,
+      description: 'The organising partner of this event'
 
   end
 end

--- a/app/graphql/types/neighbourhood_type.rb
+++ b/app/graphql/types/neighbourhood_type.rb
@@ -1,7 +1,7 @@
 module Types
   class NeighbourhoodType < Types::BaseObject
 
-    description 'A region of physical space that may have sub-regions within'
+    description 'A political divison, for example as established by the UK Boundary Authority. Can be on a number of scales from local to national'
 
     # field :id, ID, null: false
     field :name, String, 
@@ -16,13 +16,13 @@ module Types
       description: 'Size of neighbourhood: country -> region -> county -> district -> ward'
 
     field :unit_name, String,
-      description: 'from postcode.io'
+      description: 'Official name of this neighbourhood'
 
     field :unit_code_key, String,
-      description: 'from postcode.io'
+      description: 'Official key for this neighbourhood'
 
     field :unit_code_value, String,
-      description: 'from postcode.io'
+      description: 'Official value (ID) of this neighbourhood'
 
   end
 end

--- a/app/graphql/types/neighbourhood_type.rb
+++ b/app/graphql/types/neighbourhood_type.rb
@@ -1,15 +1,29 @@
 module Types
   class NeighbourhoodType < Types::BaseObject
 
-    description 'A physical region of country'
+    description 'A region of physical space that may have sub-regions within'
 
     # field :id, ID, null: false
-    field :name, String, null: false
-    field :abbreviated_name, String, method: :name_abbr
-    field :unit, String
-    field :unit_name, String
-    field :unit_code_key, String
-    field :unit_code_value, String
+    field :name, String, 
+      null: false,
+      description: 'The common name for this region'
+
+    field :abbreviated_name, String,
+      method: :name_abbr,
+      description: 'Shorthand version of name in common use'
+
+    field :unit, String,
+      description: 'Size of neighbourhood: country -> region -> county -> district -> ward'
+
+    field :unit_name, String,
+      description: 'from postcode.io'
+
+    field :unit_code_key, String,
+      description: 'from postcode.io'
+
+    field :unit_code_value, String,
+      description: 'from postcode.io'
+
   end
 end
 

--- a/app/graphql/types/opening_hours_type.rb
+++ b/app/graphql/types/opening_hours_type.rb
@@ -1,6 +1,6 @@
 module Types
   class OpeningHoursType < Types::BaseObject
-    description 'The open hours within a specific weekday'
+    description 'A period of time that this partner is open for'
 
     field :day_of_week, String,
       description: 'Monday, Tuesday, Wednesday etc'

--- a/app/graphql/types/opening_hours_type.rb
+++ b/app/graphql/types/opening_hours_type.rb
@@ -1,8 +1,15 @@
 module Types
   class OpeningHoursType < Types::BaseObject
-    field :day_of_week, String
-    field :opens, String
-    field :closes, String
+    description 'The open hours within a specific weekday'
+
+    field :day_of_week, String,
+      description: 'Monday, Tuesday, Wednesday etc'
+
+    field :opens, String,
+      description: 'Hour at which business commences'
+
+    field :closes, String,
+      description: 'Hour at which business ceaces'
 
     def day_of_week
       object['dayOfWeek'].scan(/\/([^\/]*)$/)

--- a/app/graphql/types/partner_type.rb
+++ b/app/graphql/types/partner_type.rb
@@ -13,7 +13,7 @@ module Types
       description: 'A short string about this partner, an alias for `summary`'
 
     field :summary, String,
-      description: 'A short string describing partner'
+      description: 'A short summary describing what this partner does'
 
     field :description, String,
       description: 'Longer text about partner with more detail (in Markdown syntax)'
@@ -31,13 +31,13 @@ module Types
     field :url, String,
       description: 'The URL provided by the partner for users to find out more info'
 
-    field :facebook_page, String,
+    field :facebook_url, String,
       method: :facebook_link,
-      description: 'The possible facebook URL of this partner'
+      description: 'The URL of the partner\'s Facebook page'
 
     field :twitter_url, String, 
       method: :twitter_handle,
-      description: 'The URL to the partner\'s twitter profile'
+      description: 'The URL to the partner\'s Twitter profile'
 
     field :areas_served, [NeighbourhoodType],
       method: :service_area_neighbourhoods,

--- a/app/graphql/types/partner_type.rb
+++ b/app/graphql/types/partner_type.rb
@@ -2,32 +2,57 @@ module Types
   class PartnerType < Types::BaseObject
     
 
-    description 'A Partner who runs Events'
+    description 'Organisations that run events'
 
-    # placecalID
-    field :id, ID, null: false
-    field :name, String, null: false
-    field :summary, String
-    field :description, String
+    field :id, ID, 
+      null: false,
+      description: 'ID of partner'
 
-    field :accessibility_summary, String, method: :accessibility_info
+    field :name, String, 
+      null: false,
+      description: 'A short string about this partner, an alias for `summary`'
 
-    field :logo, String
-    field :address, AddressType
+    field :summary, String,
+      description: 'A short string describing partner'
 
-    field :url, String
-    field :facebook_page, String, method: :facebook_link
-    field :twitter_handle, String, method: :twitter_handle
+    field :description, String,
+      description: 'Longer text about partner with more detail'
 
-    field :areas_served, [NeighbourhoodType], method: :service_area_neighbourhoods
+    field :accessibility_summary, String,
+      method: :accessibility_info,
+      description: 'Accessibility information about this partner and the kind of events they run'
 
-    field :contact, ContactType
+    field :logo, String,
+      description: 'The URL of the logo that is served from placecal'
 
-    field :telephone, String, method: :public_phone
-    field :email, String, method: :public_email
-    field :contact_name, String, method: :public_name
+    field :address, AddressType,
+      description: 'The physical address of this partner'
 
-    field :opening_hours, [OpeningHoursType], null: true
+    field :url, String,
+      description: 'The URL provided by the partner for users to find out more info'
+
+    field :facebook_page, String,
+      method: :facebook_link,
+      description: 'The possible facebook URL of this partner'
+
+    field :twitter_handle, String, 
+      method: :twitter_handle,
+      description: 'The twitter handle of partner so users can see their tweet feed'
+
+    field :areas_served, [NeighbourhoodType],
+      method: :service_area_neighbourhoods,
+      description: 'Areas served by partner that are not at a physical address'
+
+    field :contact, ContactType,
+      description: 'Contact information of a person within the partner organisation'
+
+    # field :telephone, String, method: :public_phone
+    # field :email, String, method: :public_email
+    # field :contact_name, String, method: :public_name
+
+    field :opening_hours, [OpeningHoursType], 
+      null: true,
+      description: 'The hours that this partner opens for at their physical address'
 
     def contact
       object

--- a/app/graphql/types/partner_type.rb
+++ b/app/graphql/types/partner_type.rb
@@ -16,14 +16,14 @@ module Types
       description: 'A short string describing partner'
 
     field :description, String,
-      description: 'Longer text about partner with more detail'
+      description: 'Longer text about partner with more detail (in Markdown syntax)'
 
     field :accessibility_summary, String,
       method: :accessibility_info,
-      description: 'Accessibility information about this partner and the kind of events they run'
+      description: 'Information about this Partner\'s accessibility'
 
     field :logo, String,
-      description: 'The URL of the logo that is served from placecal'
+      description: 'The URL of the logo that is served from PlaceCal'
 
     field :address, AddressType,
       description: 'The physical address of this partner'
@@ -35,16 +35,16 @@ module Types
       method: :facebook_link,
       description: 'The possible facebook URL of this partner'
 
-    field :twitter_handle, String, 
+    field :twitter_url, String, 
       method: :twitter_handle,
-      description: 'The twitter handle of partner so users can see their tweet feed'
+      description: 'The URL to the partner\'s twitter profile'
 
     field :areas_served, [NeighbourhoodType],
       method: :service_area_neighbourhoods,
       description: 'Areas served by partner that are not at a physical address'
 
     field :contact, ContactType,
-      description: 'Contact information of a person within the partner organisation'
+      description: 'Venue contact information - could be a person or a general contact'
 
     # field :telephone, String, method: :public_phone
     # field :email, String, method: :public_email
@@ -66,6 +66,10 @@ module Types
       return '' if object.image.blank?
 
       ActionController::Base.helpers.image_url(object.image.url, skip_pipeline: true) 
+    end
+
+    def twitter_url
+      "https://twitter.com/#{object.twitter_handle}" if object.twitter_handle
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -3,11 +3,16 @@ module Types
 
   module PartnerQueries
     def self.included(klass)
-      klass.field :partner, PartnerType, "Find Partner by ID" do
+
+      klass.field :partner, PartnerType  do
+        description 'Retrieve one Partner based on specific ID'
         argument :id, ID
       end
 
-      klass.field :partner_connection, Types::PartnerType.connection_type
+      klass.field :partner_connection, Types::PartnerType.connection_type do
+        description \
+          'Get partners in more manageble chunks sort of like pagination.'
+      end
     end
 
     def partner(id:)
@@ -21,11 +26,15 @@ module Types
 
   module SiteQueries
     def self.included(klass)
-      klass.field :site, SiteType, "Find Site by ID" do
+      klass.field :site, SiteType do
+        description 'Retrieve one Site based on specific ID'
         argument :id, ID
       end
 
-      klass.field :site_connection, Types::SiteType.connection_type
+      klass.field :site_connection, Types::SiteType.connection_type do
+        description \
+          'Get sites in more manageble chunks sort of like pagination.'
+      end
     end
 
     def site(id:)
@@ -39,7 +48,9 @@ module Types
 
   module MiscQueries
     def self.included(klass)
-      klass.field :ping, String, null: false, description: "Ping server"
+      klass.field :ping, String,
+        null: false,
+        description: "Ping server, returns a happy message and a timestamp"
     end
 
     def ping
@@ -48,6 +59,8 @@ module Types
   end
 
   class QueryType < Types::BaseObject 
+
+    description "The base query schema for all of PlaceCals GraphQL queries"
 
     # Add `node(id: ID!) and `nodes(ids: [ID!]!)`
     # include GraphQL::Types::Relay::HasNodeField

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,7 +11,7 @@ module Types
 
       klass.field :partner_connection, Types::PartnerType.connection_type do
         description \
-          'Get partners in more manageble chunks sort of like pagination.'
+          'Get partners in chunks'
       end
     end
 
@@ -33,7 +33,7 @@ module Types
 
       klass.field :site_connection, Types::SiteType.connection_type do
         description \
-          'Get sites in more manageble chunks sort of like pagination.'
+          'Get sites in chunks'
       end
     end
 
@@ -60,7 +60,7 @@ module Types
 
   class QueryType < Types::BaseObject 
 
-    description "The base query schema for all of PlaceCals GraphQL queries"
+    description "The base query schema for all of PlaceCal's GraphQL queries"
 
     # Add `node(id: ID!) and `nodes(ids: [ID!]!)`
     # include GraphQL::Types::Relay::HasNodeField

--- a/app/graphql/types/site_type.rb
+++ b/app/graphql/types/site_type.rb
@@ -16,7 +16,7 @@ module Types
       description: 'Short unique URL friendly version of name'
 
     field :domain, String,
-      description: 'The public URL that this site can be found on placecal'
+      description: 'The public URL that this site can be found on PlaceCal'
 
     field :description, String,
       description: 'Longer description of site'

--- a/app/graphql/types/site_type.rb
+++ b/app/graphql/types/site_type.rb
@@ -3,29 +3,26 @@ module Types
 
     description 'Sites represent a collection of neighbourhoods or service areas'
 
-    field :id, ID, null: false
-    field :name, String, null: false
-    field :slug, String, null: false
+    field :id, ID, 
+      null: false,
+      description: 'Internal reference ID'
 
-    field :domain, String
-    field :description, String
+    field :name, String,
+      null: false,
+      description: 'Full name of site'
 
-    field :neighbourhoods, [NeighbourhoodType]
+    field :slug, String, 
+      null: false,
+      description: 'Short unique URL friendly version of name'
 
-    # field :partners, [PartnerType]
-    
-    # t.datetime "created_at", null: false
-    # t.datetime "updated_at", null: false
-    # t.bigint "site_admin_id"
-    # t.string "logo"
-    # t.string "hero_image"
-    # t.string "hero_image_credit"
-    # t.string "footer_logo"
-    # t.string "tagline", default: "The Community Calendar"
-    # t.string "place_name"
-    # t.string "theme"
-    # t.boolean "is_published", default: false
-    # t.string "badge_zoom_level"
+    field :domain, String,
+      description: 'The public URL that this site can be found on placecal'
+
+    field :description, String,
+      description: 'Longer description of site'
+
+    field :neighbourhoods, [NeighbourhoodType],
+      description: 'The neighbourhoods that this site encompasses'
 
   end
 end

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,9 @@
+# PlaceCal Developer Documentation
+
+## External Developers
+
+People who are using our API.
+
+## Internal Developers
+
+People who are working with/on the codebase itself


### PR DESCRIPTION
Implements #997 - puts description fields on all the graphql parts so when you're in the graphiql page (on localhost) you can slide open the 'docs' tab and peruse the structures easily