### PR TITLE
Reading articles through the GQL API

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -46,7 +46,7 @@ module Types
     end
 
     def article_connection(**args)
-      Article.published.order(published_at: :desc).all
+      Article.global_newsfeed
     end
   end
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -33,6 +33,18 @@ module Types
     end
   end
 
+  module ArticleQueries
+    def self.included(klass)
+      klass.field :all_articles, [ArticleType] do
+        description 'Return news articles from all sites for all partners'
+      end
+    end
+
+    def all_articles(**args)
+      Article.all
+    end
+  end
+
   module SiteQueries
     def self.included(klass)
       klass.field :site, SiteType do
@@ -81,6 +93,7 @@ module Types
     include PartnerQueries
     include EventQueries
     include SiteQueries
+    include ArticleQueries
     include MiscQueries
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -35,13 +35,18 @@ module Types
 
   module ArticleQueries
     def self.included(klass)
-      klass.field :all_articles, [ArticleType] do
-        description 'Return news articles from all sites for all partners'
+      #klass.field :all_articles, [ArticleType] do
+      #  description 'Return news articles from all sites for all partners'
+      #end
+
+      klass.field :article_connection, Types::ArticleType.connection_type do
+        description \
+          'Get articles in chunks'
       end
     end
 
-    def all_articles(**args)
-      Article.all
+    def article_connection(**args)
+      Article.published.order(published_at: :desc).all
     end
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -11,6 +11,8 @@ class Article < ApplicationRecord
   scope :published, -> { where is_draft: false }
   scope :by_publish_date, -> { order(:published_at) }
 
+  scope :global_newsfeed, -> { published.order(published_at: :desc) }
+
   def update_published_at
     self.published_at = self.is_draft ? nil : DateTime.now
   end

--- a/test/integration/graphql/article_query_type_test.rb
+++ b/test/integration/graphql/article_query_type_test.rb
@@ -12,15 +12,21 @@ class ArticleIndexTest< ActionDispatch::IntegrationTest
     5.times do |n|
       Article.create!(
         title: "News article #{n}",
-        body: 'article body text'
+        body: 'article body text',
+        is_draft: false,
+        published_at: DateTime.now
       )
     end
 
     query_string = <<-GRAPHQL
       query {
-        allArticles {
-          name
-          text
+        articleConnection {
+          edges {
+            node {
+              name
+              text
+            }
+          }
         }
       }
     GRAPHQL
@@ -29,9 +35,10 @@ class ArticleIndexTest< ActionDispatch::IntegrationTest
     # puts JSON.pretty_generate(result.as_json)
     data = result['data']
 
-    assert data.has_key?('allArticles'), 'result is missing key `allArticles`'
-    articles = data['allArticles']
+    assert data.has_key?('articleConnection'), 'result is missing key `allArticles`'
+    article_connection = data['articleConnection']
+    edges = article_connection['edges']
 
-    assert articles.length == 5
+    assert edges.length == 5
   end
 end

--- a/test/integration/graphql/article_query_type_test.rb
+++ b/test/integration/graphql/article_query_type_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ArticleIndexTest< ActionDispatch::IntegrationTest
+
+  setup do
+  end
+
+  test 'returns articles when invoked' do
+
+    5.times do |n|
+      Article.create!(
+        title: "News article #{n}",
+        body: 'article body text'
+      )
+    end
+
+    query_string = <<-GRAPHQL
+      query {
+        allArticles {
+          name
+          text
+        }
+      }
+    GRAPHQL
+
+    result = PlaceCalSchema.execute(query_string)
+    # puts JSON.pretty_generate(result.as_json)
+    data = result['data']
+
+    assert data.has_key?('allArticles'), 'result is missing key `allArticles`'
+    articles = data['allArticles']
+
+    assert articles.length == 5
+  end
+end


### PR DESCRIPTION
Implements #1094.

New `allArticles` endpoint of type `[ArticleType]`. Just returns whatever is in the articles table.