### PR TITLE
Articles now have Image Headers

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -5,7 +5,7 @@ module Admin
     before_action :set_article, only: %i[edit update destroy]
 
     def index
-      @articles = policy_scope(Article).order({ :updated_at => :desc }, :title)
+      @articles = policy_scope(Article).order({ updated_at: :desc }, :title)
       authorize @articles
 
       respond_to do |format|
@@ -21,7 +21,7 @@ module Admin
     end
 
     def new
-      @article = params[:article] ? Article.new(permitted_attributes(Article)) : Article.new
+      @article = Article.new(permitted_attributes(Article))
       @article.partners = current_user.partners if current_user.partners.count == 1
       @article.author = current_user unless current_user.root?
       authorize @article

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -21,7 +21,7 @@ module Admin
     end
 
     def new
-      @article = Article.new(permitted_attributes(Article))
+      @article = params[:article] ? Article.new(permitted_attributes(Article)) : Article.new
       @article.partners = current_user.partners if current_user.partners.count == 1
       @article.author = current_user unless current_user.root?
       authorize @article

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -9,8 +9,7 @@ module Admin
     before_action :set_service_area_map_ids, only: %i[new edit]
 
     def index
-      @partners = policy_scope(Partner).order({ :updated_at => :desc }, :name).includes(:address)
-
+      @partners = policy_scope(Partner).order({ updated_at: :desc }, :name).includes(:address)
 
       respond_to do |format|
         format.html
@@ -115,11 +114,10 @@ module Admin
     def set_service_area_map_ids
       # maps neighbourhood ID to service_area ID
       if @partner
-        @service_area_id_map = @partner.
-          service_areas.select(:id, :neighbourhood_id).
-          map { |sa| { sa.neighbourhood_id => sa.id } }.
-          reduce({}, :merge)
-
+        @service_area_id_map = @partner
+                               .service_areas.select(:id, :neighbourhood_id)
+                               .map { |sa| { sa.neighbourhood_id => sa.id } }
+                               .reduce({}, :merge)
       else
         @service_area_id_map = {}
       end

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class ArticleType < Types::BaseObject
     description 'A news article posted on PlaceCal'
@@ -7,40 +9,44 @@ module Types
     #   description: 'ID of article'
 
     field :name, String,
-      description: 'The name of the article (alias for headline)',
-      method: :title
-
-    field :author, [String],
-      description: 'The user who authored this article',
-      method: :author_name
+          description: 'The name of the article (alias for headline)',
+          method: :title
 
     field :headline, String,
-      description: 'The title of the article',
-      method: :title
+          description: 'The title of the article',
+          method: :title
+
+    field :author, String,
+          description: 'The user who authored this article',
+          method: :author_name
 
     field :text, String,
-      description: 'The contents of the article (alias for articleBody)',
-      method: :body
+          description: 'The contents of the article (alias for articleBody)',
+          method: :body
 
     field :article_body, String,
-      description: 'The contents of the article (in markdown format)',
-      method: :body
+          description: 'The contents of the article (in markdown format)',
+          method: :body
+
+    field :image, String,
+          description: 'The image of the article (a URL)',
+          method: :highres_image
 
     field :date_published, GraphQL::Types::ISO8601DateTime,
-      description: 'Date that the article was published on PlaceCal',
-      method: :published_at
+          description: 'Date that the article was published on PlaceCal',
+          method: :published_at
 
     field :date_created, GraphQL::Types::ISO8601DateTime,
-      description: 'The time that the article was created on PlaceCal',
-      method: :created_at
+          description: 'The time that the article was created on PlaceCal',
+          method: :created_at
 
     field :date_updated, GraphQL::Types::ISO8601DateTime,
-      description: 'The time that the article was modified on PlaceCal',
-      method: :updated_at
+          description: 'The time that the article was modified on PlaceCal',
+          method: :updated_at
 
     field :providers, [PartnerType],
-      description: 'The partner this article is about',
-      method: :partners
+          description: 'The partner this article is about',
+          method: :partners
 
     # creativeWorkStatus: string, from is_draft
     # author: person, from user

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -10,7 +10,7 @@ class Article < ApplicationRecord
 
   belongs_to :author, class_name: 'User'
 
-  mount_uploader :article_header, ArticleHeaderUploader
+  mount_uploader :article_image, ArticleHeaderUploader
 
   scope :published, -> { where is_draft: false }
   scope :by_publish_date, -> { order(:published_at) }
@@ -21,7 +21,15 @@ class Article < ApplicationRecord
     self.published_at = self.is_draft ? nil : DateTime.now
   end
 
+  # This retrieves the author's name for use in the GQL output
+  # We return emptystring because that indicates to the user that this field is required
   def author_name
-    author.full_name
+    author&.full_name ? author.full_name : ''
+  end
+
+  # This retrieves the url of the highres header image for use in GQL output
+  # We let it return nil because articles are not guaranteed to have images
+  def highres_image
+    article_image&.highres&.url
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -10,6 +10,8 @@ class Article < ApplicationRecord
 
   belongs_to :author, class_name: 'User'
 
+  mount_uploader :article_header, ArticleHeaderUploader
+
   scope :published, -> { where is_draft: false }
   scope :by_publish_date, -> { order(:published_at) }
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -10,7 +10,7 @@ class Article < ApplicationRecord
 
   belongs_to :author, class_name: 'User'
 
-  mount_uploader :article_image, ArticleHeaderUploader
+  mount_uploader :article_image, ArticleImageUploader
 
   scope :published, -> { where is_draft: false }
   scope :by_publish_date, -> { order(:published_at) }

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -34,7 +34,7 @@ class ArticlePolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:title, :author_id, :body, :published_at, :is_draft, partner_ids: []]
+    [:title, :author_id, :body, :published_at, :is_draft, :article_header, partner_ids: []]
   end
 
   def disabled_fields
@@ -44,7 +44,7 @@ class ArticlePolicy < ApplicationPolicy
     elsif user.editor? || user.partner_admin? || user.neighbourhood_admin?
       %i[author_id]
     else # Should never be hit, but it's useful as a guard
-      %i[title body published_at is_draft partner_ids]
+      %i[title author_id body published_at is_draft article_header partner_ids]
     end
   end
 

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -34,7 +34,7 @@ class ArticlePolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:title, :author_id, :body, :published_at, :is_draft, :article_header, partner_ids: []]
+    [:title, :author_id, :body, :published_at, :is_draft, :article_image, partner_ids: []]
   end
 
   def disabled_fields
@@ -44,7 +44,7 @@ class ArticlePolicy < ApplicationPolicy
     elsif user.editor? || user.partner_admin? || user.neighbourhood_admin?
       %i[author_id]
     else # Should never be hit, but it's useful as a guard
-      %i[title author_id body published_at is_draft article_header partner_ids]
+      %i[title author_id body published_at is_draft article_image partner_ids]
     end
   end
 

--- a/app/uploaders/article_header_uploader.rb
+++ b/app/uploaders/article_header_uploader.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ArticleHeaderUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MiniMagick
+
+  storage :file
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  process resize_to_fit: [1920, 1280]
+
+  version :highres do
+    process resize_to_fit: [1272, 714]
+  end
+
+  def extension_allowlist
+    %w[svg jpg jpeg png]
+  end
+end

--- a/app/uploaders/article_header_uploader.rb
+++ b/app/uploaders/article_header_uploader.rb
@@ -9,10 +9,10 @@ class ArticleHeaderUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  process resize_to_fit: [1920, 1280]
+  process resize_to_fill: [1920, 1280, :center]
 
   version :highres do
-    process resize_to_fit: [1272, 714]
+    process resize_to_fill: [1272, 714, :center]
   end
 
   def extension_allowlist

--- a/app/uploaders/article_image_uploader.rb
+++ b/app/uploaders/article_image_uploader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ArticleHeaderUploader < CarrierWave::Uploader::Base
+class ArticleImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   storage :file

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -26,12 +26,12 @@
 
   <h2>Header</h2>
   <p>Headers should be one of: svg, png, jpg<p>
-  <% if disabled_fields.include?(:article_header) %>
-    <%= f.input :article_header, disabled: true %>
+  <% if disabled_fields.include?(:article_image) %>
+    <%= f.input :article_image, disabled: true %>
   <% else %>
-    <%= f.input :article_header %>
+    <%= f.input :article_image %>
   <% end %>
-  <%= image_tag f.object.article_header.url, class: 'card-img-top' if f.object.article_header.url %>
+  <%= image_tag f.object.article_image.highres.url, class: 'card-img-top' if f.object.article_image.highres.url %>
 
   <span>
     <br>

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -22,6 +22,17 @@
                       input_html: { class: 'form-control select2 multi-select' } %>
   <% end %>
 
+  <hr>
+
+  <h2>Header</h2>
+  <p>Headers should be one of: svg, png, jpg<p>
+  <% if disabled_fields.include?(:article_header) %>
+    <%= f.input :article_header, disabled: true %>
+  <% else %>
+    <%= f.input :article_header %>
+  <% end %>
+  <%= image_tag f.object.article_header.url, class: 'card-img-top' if f.object.article_header.url %>
+
   <span>
     <br>
     <%= f.submit 'Save', class: "btn btn-primary" %>

--- a/db/migrate/20220405102801_add_article_header_to_articles.rb
+++ b/db/migrate/20220405102801_add_article_header_to_articles.rb
@@ -1,5 +1,5 @@
 class AddArticleHeaderToArticles < ActiveRecord::Migration[6.1]
   def change
-    add_column :articles, :article_header, :string
+    add_column :articles, :article_image, :string
   end
 end

--- a/db/migrate/20220405102801_add_article_header_to_articles.rb
+++ b/db/migrate/20220405102801_add_article_header_to_articles.rb
@@ -1,0 +1,5 @@
+class AddArticleHeaderToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :article_header, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2022_04_05_102801) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "author_id"
-    t.string "article_header"
+    t.string "article_image"
     t.index ["author_id"], name: "index_articles_on_author_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_30_160817) do
+ActiveRecord::Schema.define(version: 2022_04_05_102801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2022_03_30_160817) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "author_id"
+    t.string "article_header"
     t.index ["author_id"], name: "index_articles_on_author_id"
   end
 

--- a/test/integration/admin/sites_integration_test.rb
+++ b/test/integration/admin/sites_integration_test.rb
@@ -17,22 +17,21 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
     host! 'admin.lvh.me'
   end
 
-  test "Site admin index has appropriate title" do
+  test 'Site admin index has appropriate title' do
     sign_in(@root)
     get admin_sites_path
     assert_response :success
 
-    assert_select 'title', text: "Sites | PlaceCal Admin"
-    assert_select 'h1', text: "Sites"
+    assert_select 'title', text: 'Sites | PlaceCal Admin'
+    assert_select 'h1', text: 'Sites'
   end
 
-
-  test "root : can get new site" do
+  test 'root : can get new site' do
     sign_in @root
 
     get new_admin_site_path
 
-    assert_select 'title', text: "New Site | PlaceCal Admin"
+    assert_select 'title', text: 'New Site | PlaceCal Admin'
   end
 
   test 'create a site through the admin page' do

--- a/test/integration/graphql/article_query_type_test.rb
+++ b/test/integration/graphql/article_query_type_test.rb
@@ -8,6 +8,7 @@ class ArticleIndexTest < ActionDispatch::IntegrationTest
 
   test 'returns articles when invoked' do
     @user = create(:user)
+    @partners = create_list(:partner, 2)
 
     5.times do |n|
       Article.create!(
@@ -15,7 +16,8 @@ class ArticleIndexTest < ActionDispatch::IntegrationTest
         body: 'article body text',
         author: @user,
         is_draft: false,
-        published_at: DateTime.now
+        published_at: DateTime.now,
+        partners: @partners,
       )
     end
 
@@ -25,7 +27,22 @@ class ArticleIndexTest < ActionDispatch::IntegrationTest
           edges {
             node {
               name
+              headline
+
+              author
+
               text
+              articleBody
+
+              image
+
+              datePublished
+              dateCreated
+              dateUpdated
+
+              providers {
+                id
+              }
             }
           }
         }
@@ -37,9 +54,35 @@ class ArticleIndexTest < ActionDispatch::IntegrationTest
 
     assert data.key?('articleConnection'), 'result is missing key `allArticles`'
 
-    article_connection = data['articleConnection']
-    edges = article_connection['edges']
+    edges = data['articleConnection']['edges']
+    assert_equal edges.length, 5
 
-    assert edges.length == 5
+    # Strip the 'node' object container off so we don't have to deal with that
+    nodes = edges.map { |edge| edge['node'] }
+
+    nodes.each do |gql_article|
+      assert_field gql_article, 'name', 'Article title is nil?'
+
+      refute_nil article = Article.find_by(title: gql_article['name']), 'Returned article that doesn\'t exist?'
+
+      assert_field_equals gql_article, 'headline', value: article.title
+      assert_field_equals gql_article, 'author', value: article.author_name
+
+      assert_field_equals gql_article, 'text', value: article.body
+      assert_field_equals gql_article, 'articleBody', value: article.body
+
+      assert_field_equals gql_article, 'image', value: article.highres_image
+
+      # We only check existence of datePublished simply because there's some iffy goo around how
+      # graphql renders T00:00 and how rails renders it. Would probably blow up the code by a fair bit,
+      # and honestly if the other values are set, and this one exists, it's Probably Enough To
+      assert_field gql_article, 'datePublished'
+
+      assert_field_equals gql_article, 'dateCreated', value: article.created_at.iso8601
+      assert_field_equals gql_article, 'dateUpdated', value: article.updated_at.iso8601
+
+      providers = assert_field gql_article, 'providers', 'Returned article has no providers'
+      assert_equal providers.length, article.partners.length
+    end
   end
 end

--- a/test/integration/graphql/article_query_type_test.rb
+++ b/test/integration/graphql/article_query_type_test.rb
@@ -81,6 +81,8 @@ class ArticleIndexTest < ActionDispatch::IntegrationTest
       assert_field_equals gql_article, 'dateCreated', value: article.created_at.iso8601
       assert_field_equals gql_article, 'dateUpdated', value: article.updated_at.iso8601
 
+      # Partners are Providers, here we are only checking the length of the providers dict because otherwise
+      # it just gets super annoying and messy doing nested maps and the like
       providers = assert_field gql_article, 'providers', 'Returned article has no providers'
       assert_equal providers.length, article.partners.length
     end

--- a/test/integration/graphql/partners_integration_test.rb
+++ b/test/integration/graphql/partners_integration_test.rb
@@ -53,47 +53,33 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
 
     data_partner = data['partner']
     assert data_partner['name'] == partner.name
-
-  end
-
-  def verify_field_presence(obj, name, value: nil)
-    assert obj.key?(name), "field #{name} is missing"
-    if value
-      assert_equal value, obj[name], "field #{name} has incorrect value: wanted='#{value}', but got='#{obj[name]}'"
-    end
-
-  rescue Minitest::Assertion => e
-    # ugh- we need to see the line that actually caused the problem here and not
-    # just the above assertion line
-    puts e.backtrace[2]
-    raise e
   end
 
   def check_address(data, address)
     neighbourhood = address.neighbourhood
 
-    verify_field_presence data, 'streetAddress', value: address.full_street_address
-    verify_field_presence data, 'postalCode', value: address.postcode
-    verify_field_presence data, 'addressLocality', value: neighbourhood.name
-    verify_field_presence data, 'addressRegion', value: neighbourhood.region.to_s
+    assert_field_equals data, 'streetAddress', value: address.full_street_address
+    assert_field_equals data, 'postalCode', value: address.postcode
+    assert_field_equals data, 'addressLocality', value: neighbourhood.name
+    assert_field_equals data, 'addressRegion', value: neighbourhood.region.to_s
 
-    verify_field_presence data, 'neighbourhood'
+    assert_field data, 'neighbourhood'
     hood = data['neighbourhood']
 
-    verify_field_presence hood, 'name', value: neighbourhood.name
-    verify_field_presence hood, 'abbreviatedName', value: neighbourhood.abbreviated_name
-    verify_field_presence hood, 'unit', value: neighbourhood.unit
-    verify_field_presence hood, 'unitName', value: neighbourhood.unit_name
-    verify_field_presence hood, 'unitCodeKey', value: neighbourhood.unit_code_key
-    verify_field_presence hood, 'unitCodeValue', value: neighbourhood.unit_code_value
+    assert_field_equals hood, 'name', value: neighbourhood.name
+    assert_field_equals hood, 'abbreviatedName', value: neighbourhood.abbreviated_name
+    assert_field_equals hood, 'unit', value: neighbourhood.unit
+    assert_field_equals hood, 'unitName', value: neighbourhood.unit_name
+    assert_field_equals hood, 'unitCodeKey', value: neighbourhood.unit_code_key
+    assert_field_equals hood, 'unitCodeValue', value: neighbourhood.unit_code_value
   end
 
   def check_contact(data, contact)
-    verify_field_presence data, 'name', value: contact.public_name
+    assert_field_equals data, 'name', value: contact.public_name
 
-    verify_field_presence data, 'telephone', value: contact.public_phone
+    assert_field_equals data, 'telephone', value: contact.public_phone
 
-    verify_field_presence data, 'email', value: contact.public_email
+    assert_field_equals data, 'email', value: contact.public_email
   end
 
   def check_opening_hours(data, opening_hours)
@@ -104,11 +90,11 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     assert data.length == 6 # from factory
     first_day = data.first
 
-    expected_day_of_week = expected_day['dayOfWeek'] =~ /\/([^\/]*)$/ && $1
-    verify_field_presence first_day, 'dayOfWeek', value: expected_day_of_week
+    expected_day_of_week = expected_day['dayOfWeek'] =~ %r{/([^/]*)$} && Regexp.last_match(1)
+    assert_field_equals first_day, 'dayOfWeek', value: expected_day_of_week
 
-    verify_field_presence first_day, 'opens', value: expected_day['opens']
-    verify_field_presence first_day, 'closes', value: expected_day['closes']
+    assert_field_equals first_day, 'opens', value: expected_day['opens']
+    assert_field_equals first_day, 'closes', value: expected_day['closes']
   end
 
   def check_areas_served(data, service_areas)
@@ -118,26 +104,27 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     wanted_area = service_areas.first
     service_area = data.first
 
-    verify_field_presence service_area, 'name', value: wanted_area.name
-    verify_field_presence service_area, 'abbreviatedName', value: wanted_area.abbreviated_name
-    verify_field_presence service_area, 'unit', value: wanted_area.unit
-    verify_field_presence service_area, 'unitName', value: wanted_area.unit_name
-    verify_field_presence service_area, 'unitCodeKey', value: wanted_area.unit_code_key
-    verify_field_presence service_area, 'unitCodeValue', value: wanted_area.unit_code_value
+    assert_field_equals service_area, 'name', value: wanted_area.name
+    assert_field_equals service_area, 'abbreviatedName', value: wanted_area.abbreviated_name
+    assert_field_equals service_area, 'unit', value: wanted_area.unit
+    assert_field_equals service_area, 'unitName', value: wanted_area.unit_name
+    assert_field_equals service_area, 'unitCodeKey', value: wanted_area.unit_code_key
+    assert_field_equals service_area, 'unitCodeValue', value: wanted_area.unit_code_value
   end
 
   def check_basic_fields(data, partner)
-    verify_field_presence data, 'id', value: partner.id.to_s
-    verify_field_presence data, 'name', value: partner.name
-    verify_field_presence data, 'summary', value: partner.summary
-    verify_field_presence data, 'description', value: partner.description
-    verify_field_presence data, 'accessibilitySummary', value: partner.accessibility_info
-    verify_field_presence data, 'url', value: partner.url
-    verify_field_presence data, 'twitterUrl', value: "https://twitter.com/#{partner.twitter_handle}"
-    verify_field_presence data, 'facebookUrl', value: partner.facebook_link
+    assert_field_equals data, 'id', value: partner.id.to_s
+
+    assert_field_equals data, 'name', value: partner.name
+    assert_field_equals data, 'summary', value: partner.summary
+    assert_field_equals data, 'description', value: partner.description
+    assert_field_equals data, 'accessibilitySummary', value: partner.accessibility_info
+    assert_field_equals data, 'url', value: partner.url
+    assert_field_equals data, 'twitterUrl', value: "https://twitter.com/#{partner.twitter_handle}"
+    assert_field_equals data, 'facebookUrl', value: partner.facebook_link
 
     # see note below
-    # verify_field_presence data, 'logo', value: partner.image.url
+    # assert_field_equals data, 'logo', value: partner.image.url
   end
 
   test 'can view contact info when selected' do
@@ -204,21 +191,21 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
 
     data = result['data']
 
-    verify_field_presence data, 'partner'
+    assert_field data, 'partner'
     partner_data = data['partner']
 
     check_basic_fields partner_data, partner
 
-    verify_field_presence partner_data, 'address'
+    assert_field partner_data, 'address'
     check_address partner_data['address'], partner.address
 
-    verify_field_presence partner_data, 'contact'
+    assert_field partner_data, 'contact'
     check_contact partner_data['contact'], partner
 
-    verify_field_presence partner_data, 'openingHours'
+    assert_field partner_data, 'openingHours'
     check_opening_hours partner_data['openingHours'], partner.opening_times
 
-    verify_field_presence partner_data, 'areasServed'
+    assert_field partner_data, 'areasServed'
     check_areas_served partner_data['areasServed'], partner.service_area_neighbourhoods
   end
 
@@ -313,5 +300,4 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     opening_hours = data_partner['openingHours']
     assert_nil opening_hours
   end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -236,3 +236,35 @@ Geocoder::Lookup::Test.add_stub(
   ]
 )
 
+# GraphQL helpers
+
+def assert_field_equals(obj, key, value: nil)
+  assert obj.key?(key), "field #{key} is missing"
+
+  error_msg = "Field #{key} has incorrect value: wanted '#{value}', but got '#{obj[key]}'"
+
+  # This is super awkward and horrible. Basically if both parameters ending up at assert_equal are nil,
+  # it throws a deprecation warning:
+  # DEPRECATED: Use assert_nil if expecting nil from (here). This will fail in Minitest 6.
+  # So instead of being able to do
+  #   assert_equal value, obj[key], error_msg
+  # we have to do this super-awkward if statement mix :(
+
+  if value
+    assert_equal value, obj[key], error_msg
+  else
+    assert_nil obj[key], error_msg
+  end
+rescue Minitest::Assertion => e
+  # ugh- we need to see the line that actually caused the problem here and not
+  # just the above assertion line
+  puts e.backtrace[2]
+  raise e
+end
+
+def assert_field(obj, key, message = nil)
+  message ||= "#{key} doesn't exist / is nil in #{obj}"
+  assert obj.key?(key), message # obj.key? returns false if an item is nil, ergo...
+
+  obj[key]
+end


### PR DESCRIPTION
Fixes #1108 

- Add `ArticleHeaderUploader`, make sure it properly crops and centers
- Add `article_image` field to Article, policy code, controller, etc.
- Add `highres_image` to Article for GraphQL
- Guard `author_name` to return empty string for GraphQL in Articles
- Add `article_image` upload button and preview to view code 
- Add `image` field and correct `author` field type in GraphQL
  - Also align the arguments of a method call when they span more than one line
- Change `author_name` to return an empty string as the field is required
- Add deep testing of Article models returned from GraphQL
- Rename `verify_field_presence` -> `assert_field_equals` (checked with Ivan :slightly_smiling_face:)
- Pull out `assert_field_equals` into `test_helper.rb` to be used in other tests
- Add `assert_field` to differentiate between field existence and property tests
- Some minor changes in GraphQL partner test to use `%r{}` so the regex looks
  easier on the eyes, and to use `Regexp.last_match(1)` rather than the
  non-descriptive `$1`. Also remove now-needless escaping of regex \\:D/