### PR TITLE
Fixed bug in ICS event download action

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -126,6 +126,16 @@ class Event < ApplicationRecord
     address&.neighbourhood
   end
 
+  def location
+    use_address = address || partner&.address
+    #  (address if address.present?) ||
+    #  (partner.address if partner.present?)
+
+    return '' if use_address.nil?
+
+    use_address.to_s
+  end
+
   # TODO: plan this out on paper, currently half finished
   # Who to contact if the event is wrong
   def blame

--- a/test/models/events_test.rb
+++ b/test/models/events_test.rb
@@ -58,4 +58,35 @@ class EventTest < ActiveSupport::TestCase
     b = Event.new(calendar: create(:calendar), **event_hash)
     assert b.valid?
   end
+
+  test 'has blank location with no addresses at all' do
+    event = Event.new
+
+    assert_equal '', event.location, 'expected event location to be blank'
+  end
+
+  test 'has location pulled from its own address' do
+    address = create(:address)
+    event = Event.new(address: address)
+
+    wanted = '123 Moss Ln E, Manchester, Manchester, M15 5DD'
+    assert_equal wanted, event.location
+  end
+
+  test 'uses partners address if it has partner' do
+    partner = create(:partner, address: create(:moss_side_address))
+    event = Event.new(partner: partner)
+
+    wanted = '42 Alexandra Rd, Moss Side, Manchester, M16 7BA'
+    assert_equal wanted, event.location
+  end
+
+  test 'prioritises events address over partners address' do
+    partner = create(:partner, address: create(:moss_side_address))
+    address = create(:address)
+    event = Event.new(address: address, partner: partner)
+
+    wanted = '123 Moss Ln E, Manchester, Manchester, M15 5DD'
+    assert_equal wanted, event.location
+  end
 end


### PR DESCRIPTION
Fixes #1114

An action was attempting to read `location` from an event object, which did not exist but has now been implemented (+ tests).