### PR TITLE
Partner admin interface site duplicates

### DIFF
--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -27,9 +27,16 @@ module PartnersHelper
 
   def service_area_links(partner)
     partner.service_area_neighbourhoods
-      .order(:name)
-      .map { |hood| link_to hood.name, edit_admin_neighbourhood_path(hood) }
-      .join(', ')
-      .html_safe
+           .order(:name)
+           .map { |hood| link_to hood.name, edit_admin_neighbourhood_path(hood) }
+           .join(', ')
+           .html_safe
+  end
+
+  def site_links
+    @sites.order(:name)
+          .map { |site| link_to site.name, site.domain }
+          .join(', ')
+          .html_safe
   end
 end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -25,6 +25,12 @@ module PartnersHelper
     end
   end
 
+  # Get a String containing a list of <a> tags for each service area related to
+  # Partner, where the name is the Neighbourhood's name, and the URL is the
+  # admin edit page for the Neighbourhood
+  #
+  # @param [Partner]
+  # @return [String] HTML string
   def service_area_links(partner)
     partner.service_area_neighbourhoods
            .order(:name)
@@ -33,6 +39,10 @@ module PartnersHelper
            .html_safe
   end
 
+  # Get a String containing a list of <a> tags for each site,
+  # where the name is the Site's name, and the URL is the site's domain
+  #
+  # @return [String] HTML string
   def site_links
     @sites.order(:name)
           .map { |site| link_to site.name, site.domain }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -116,7 +116,7 @@ class Site < ApplicationRecord
       # Typically this will be for non-production sites.
       site_slug =
         if request.subdomain == 'www'
-          request.subdomains.second if request.subdomains.second
+          request.subdomains.second if request&.subdomains&.second
         elsif request.subdomain.present?
           request.subdomain
         end

--- a/app/views/admin/partners/_service_area_fields.html.erb
+++ b/app/views/admin/partners/_service_area_fields.html.erb
@@ -1,11 +1,13 @@
 <fieldset class="input-group nested-fields p-0">
     <%# The style width setting here is applied to dynamically created elements, we do not know why. %>
     <%# TODO: Fix the dynamic styling so that width does not get applied, so we can remove this smell %>
-    <%= f.input :neighbourhood_id, collection: options_for_service_area_neighbourhoods, include_blank: false,
-        value_method: ->(obj) { obj[:id] },
-        label_method: ->(obj) { obj[:name] },
-        input_html: { class: 'form-control select2', style: "width: 599.8px;" },
-        label: '', label_html: { hidden: true } %>
+    <%= f.input :neighbourhood_id,
+                collection: options_for_service_area_neighbourhoods,
+                include_blank: false,
+                value_method: ->(obj) { obj[:id] },
+                label_method: ->(obj) { obj[:name] },
+                input_html: { class: 'form-control select2', style: "width: 599.8px;" },
+                label: '', label_html: { hidden: true } %>
 
     <div class="input-group-append p-0">
         <%= link_to_remove_association 'Remove', f, class: "pl-2 pt-1 text-danger" %>

--- a/app/views/admin/partners/edit.html.erb
+++ b/app/views/admin/partners/edit.html.erb
@@ -15,7 +15,12 @@
 
   <%# Show a list of sites that the partner is related to %>
   <span id="partner-sites">
-    <p>This partner (and their events) appear on the following sites: <%= site_links %>.</p>
+    <% partners_sites_links = site_links %>
+    <% if partners_sites_links.present? %>
+      <p>This partner (and their events) appear on the following sites: <%= site_links %>.</p>
+    <% else %>
+      <p class="text-danger">This partner (and their events) do not appear on any sites</p>
+    <% end %>
   </span>
   <br>
 <% end -%>

--- a/app/views/admin/partners/edit.html.erb
+++ b/app/views/admin/partners/edit.html.erb
@@ -17,9 +17,9 @@
   <span id="partner-sites">
     <% partners_sites_links = site_links %>
     <% if partners_sites_links.present? %>
-      <p>This partner (and their events) appear on the following sites: <%= site_links %>.</p>
+      <p>This partner appears on the following sites: <%= site_links %>.</p>
     <% else %>
-      <p class="text-danger">This partner does not appear on any sites</p>
+      <p class="text-danger">This partner does not appear on any sites.</p>
     <% end %>
   </span>
   <br>

--- a/app/views/admin/partners/edit.html.erb
+++ b/app/views/admin/partners/edit.html.erb
@@ -3,19 +3,20 @@
 <h1 class="page-header">Edit Partner: <em><%= @partner.name %></em></h1>
 
 <% if current_user.root? -%>
+  <%# Show the Neighbourhood the partner is related to via Address %>
   <% if @partner.address -%>
     <p>In neighbourhood <%= link_to @partner.address.neighbourhood.name, admin_neighbourhood_path(@partner.address.neighbourhood) %>.</p>
   <% end -%>
+
+  <%# Show a list of Service Areas that the partner is related to %>
   <% if @partner.service_areas.any? -%>
     <p>In service areas <%= service_area_links(@partner) %>.</p>
   <% end -%>
-  <h2>Partner Site Visibility</h2>
-  <p>This partner (and their events) appear on the following sites</p>
-  <ul class='list-group' id='partner-sites'>
-  <% @sites.order(:name).each do |site| -%>
-    <li class='list-group-item'><%= link_to site.name, edit_admin_site_path(site) %></li>
-  <% end -%>
-  </ul>
+
+  <%# Show a list of sites that the partner is related to %>
+  <span id="partner-sites">
+    <p>This partner (and their events) appear on the following sites: <%= site_links %>.</p>
+  </span>
   <br>
 <% end -%>
 

--- a/app/views/admin/partners/edit.html.erb
+++ b/app/views/admin/partners/edit.html.erb
@@ -19,7 +19,7 @@
     <% if partners_sites_links.present? %>
       <p>This partner (and their events) appear on the following sites: <%= site_links %>.</p>
     <% else %>
-      <p class="text-danger">This partner (and their events) do not appear on any sites</p>
+      <p class="text-danger">This partner does not appear on any sites</p>
     <% end %>
   </span>
   <br>

--- a/test/controllers/admin/partner_edit_site_test.rb
+++ b/test/controllers/admin/partner_edit_site_test.rb
@@ -5,21 +5,24 @@ require 'test_helper'
 class PartnerEditSiteTest < ActionDispatch::IntegrationTest
   setup do
     @root_user = create(:root)
-    sign_in @root_user
-    
-    @site = build(:site)
-    @site.save!
+    @partner = create(:partner, service_area_neighbourhoods: [create(:neighbourhood)])
 
-    @partner = build(:partner)
-    @partner.save!
+    sign_in @root_user
   end
 
-  test 'user can see sites this partner is involved with' do
-    @site.neighbourhoods << @partner.address.neighbourhood
+  test 'user can see sites this partner is involved with via addresses' do
+    @site = create(:site, neighbourhoods: [@partner.address.neighbourhood])
     get edit_admin_partner_url(@partner)
 
-    assert_select 'ul#partner-sites li', count: 1
-    assert_select 'ul#partner-sites li:first a', text: @site.name
+    assert_select 'span#partner-sites a', count: 1
+    assert_select 'span#partner-sites a:first', text: @site.name
+  end
+
+  test 'user can see sites this partner is involved with via service areas' do
+    @site = create(:site, neighbourhoods: @partner.service_area_neighbourhoods)
+    get edit_admin_partner_url(@partner)
+
+    assert_select 'span#partner-sites a', count: 1
+    assert_select 'span#partner-sites a:first', text: @site.name
   end
 end
-

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -17,24 +17,24 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     host! 'admin.lvh.me'
   end
 
-  test "Partner admin index has appropriate fields" do
+  test 'Partner admin index has appropriate fields' do
     sign_in(@admin)
     get admin_partners_path
     assert_response :success
 
-    assert_select 'title', text: "Partners | PlaceCal Admin"
-    assert_select 'h1', text: "Partners"
+    assert_select 'title', text: 'Partners | PlaceCal Admin'
+    assert_select 'h1', text: 'Partners'
   end
 
-  test "root : can get new partner" do
+  test 'root : can get new partner' do
     sign_in @admin
 
     get new_admin_partner_path
 
-    assert_select 'title', text: "New Partner | PlaceCal Admin"
+    assert_select 'title', text: 'New Partner | PlaceCal Admin'
   end
 
-  test "Edit form has correct fields" do
+  test 'Edit form has correct fields' do
     sign_in @admin
 
     get edit_admin_partner_path(@partner)
@@ -100,7 +100,7 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     get edit_admin_partner_path(@partner)
     assert_response :success
 
-    assert_select 'a#destroy-partner', false, "This page must not have a Destroy Partner button"
+    assert_select 'a#destroy-partner', false, 'This page must not have a Destroy Partner button'
   end
 
   test 'Partner has owned tag preselected' do
@@ -116,9 +116,7 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     tag = tag_options.first
     assert tag.attributes.key?('selected')
   end
-
 end
-
 
 # Capybara feature test that doesn't work and i have no time to fix
 =begin


### PR DESCRIPTION
- Add owned_neighbourhood_ids to Partner model
- Correct sites_that_contain_partner to use GROUP BY to avoid duplicates
- Correct sites_that_contain_partner to use owned_neighbourhood_ids
- Add site_links to Partners helper, Partners admin edit screen
- Add test for admin interface Sites listing via service_areas
  - Slightly refactor test for Partner admin interface sites listing
- Document stuff
  - Scopes for partner model
  - Document sites_that_contain_partner
  - Document find_by_request