### PR TITLE
Articles can have tags (part one!)

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,6 +8,9 @@ class Article < ApplicationRecord
   has_many :article_partners, dependent: :destroy
   has_many :partners, through: :article_partners
 
+  has_many :article_tags, dependent: :destroy
+  has_many :tags, through: :article_tags
+
   belongs_to :author, class_name: 'User'
 
   mount_uploader :article_image, ArticleImageUploader

--- a/app/models/article_tag.rb
+++ b/app/models/article_tag.rb
@@ -1,0 +1,10 @@
+class ArticleTag < ApplicationRecord
+  belongs_to :article
+  belongs_to :tag
+
+  validates :tag_id,
+            uniqueness: {
+              scope: :article_id,
+              message: 'Article cannot be assigned more than once to a Tag'
+            }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,6 +17,9 @@ class Tag < ApplicationRecord
   has_many :sites_tag, dependent: :destroy
   has_many :sites, through: :sites_tag
 
+  has_many :article_tags, dependent: :destroy
+  has_many :articles, through: :articles_tags
+
   validates :name, :slug, presence: true
   validates :name, :slug, uniqueness: true
   validates :description,

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class ArticlePolicy < ApplicationPolicy
+  # The permissions for /index, which are basically universal across all actions someone can take
+  # This is just a litmus test and we flesh out the list of Articles someone can see in Scope#resolve,
+  # and the list of fields they can edit for each Article in #permitted_attributes/#disabled_fields
+  #
+  # @return [Boolean]
   def index?
     return true if user.root? || user.editor?
     return true if user.partner_admin? && user.partners.count.positive?
@@ -33,10 +38,23 @@ class ArticlePolicy < ApplicationPolicy
     update?
   end
 
+  # A list of attributes that someone is allowed to pass via POST/PATCH
+  #
+  # We do a broad-spectrum "allow" here. Because:
+  # - We do not expect someone manually POST/PATCH these parameters
+  # - Removing them from this list would mean the form doesn't show them.
+  #
+  # So instead, we rely on disabled_fields so the user can look, but not touch
+  #
+  # @returns [Array<String>] A list of URL Parameters
   def permitted_attributes
-    [:title, :author_id, :body, :published_at, :is_draft, :article_image, partner_ids: []]
+    [:title, :author_id, :body, :published_at, :is_draft, :article_image,
+     { partner_ids: [] }, { tag_ids: [] }]
   end
 
+  # Form fields that the user can not interact with
+  #
+  # @return [Array<String>] A list of URL Parameters the user cannot edit
   def disabled_fields
     # Partner admins can edit the assigned partners for the article
     if user.root?
@@ -49,6 +67,12 @@ class ArticlePolicy < ApplicationPolicy
   end
 
   class Scope < Scope
+    # Resolves the list of Articles the user can see
+    # In this case, we want to ensure that:
+    # - Root / Editor roles can see everything
+    # - Partner Admin and Neighbourhood Admin roles can see Articles from
+    #   their neighbourhoods/service areas
+    # @return [ActiveRecord::Relation<Article>] A list of Articles to show in /index
     def resolve
       return scope.all if user.root? || user.editor?
 
@@ -64,6 +88,8 @@ class ArticlePolicy < ApplicationPolicy
 
   private
 
+  # Does the current User have Partners in their Neighbourhoods?
+  # @return [ActiveRecord::Relation<Article>] A list of Partners
   def owned_neighbourhoods_have_partners?
     # We can make this less shallow, but it's not important since scoping rules have the deeper stuff anyway
     Partner.from_neighbourhoods_and_service_areas(user.owned_neighbourhood_ids).count.positive?

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -12,7 +12,7 @@
   <hr>
 
   <div class='row'>
-    <div class="col-md-4">
+    <div class="col-md-6">
       <h2>Partners</h2>
       <p>Display this in relation to the given partners</p>
       <% if disabled_fields.include?(:partner_ids) %>
@@ -24,7 +24,7 @@
                           input_html: { class: 'form-control select2 multi-select' } %>
       <% end %>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-6">
       <h2>Tags</h2>
       <p>What tags should this article be associated with?</p>
       <% if disabled_fields.include?(:tag_ids) %>

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -11,16 +11,32 @@
 
   <hr>
 
-  <h2>Partners</h2>
-  <p>Display this in relation to the given partners</p>
-  <% if disabled_fields.include?(:partner_ids) %>
-    <%# # Create a dummy field, because f.assoc disappears %>
-    <%= f.input :partners, collection: options_for_partners,
-        input_html: { class: 'form-control select2 multi-select' }, disabled: true %>
-  <% else %>
-    <%= f.association :partners, collection: options_for_partners,
-                      input_html: { class: 'form-control select2 multi-select' } %>
-  <% end %>
+  <div class='row'>
+    <div class="col-md-4">
+      <h2>Partners</h2>
+      <p>Display this in relation to the given partners</p>
+      <% if disabled_fields.include?(:partner_ids) %>
+        <%# # Create a dummy field, because f.assoc disappears %>
+        <%= f.input :partners, collection: options_for_partners,
+            input_html: { class: 'form-control select2 multi-select' }, disabled: true %>
+      <% else %>
+        <%= f.association :partners, collection: options_for_partners,
+                          input_html: { class: 'form-control select2 multi-select' } %>
+      <% end %>
+    </div>
+    <div class="col-md-4">
+      <h2>Tags</h2>
+      <p>What tags should this article be associated with?</p>
+      <% if disabled_fields.include?(:tag_ids) %>
+        <%# # Create a dummy field, because f.assoc disappears %>
+        <%= f.input :tags, collection: options_for_tags,
+            input_html: { class: 'form-control select2 multi-select' }, disabled: true %>
+      <% else %>
+        <%= f.association :tags, collection: options_for_tags,
+                          input_html: { class: 'form-control select2 multi-select' } %>
+      <% end %>
+    </div>
+  </div>
 
   <hr>
 

--- a/db/migrate/20220406135448_create_article_tags.rb
+++ b/db/migrate/20220406135448_create_article_tags.rb
@@ -1,0 +1,10 @@
+class CreateArticleTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :article_tags do |t|
+      t.belongs_to :article
+      t.belongs_to :tag
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_05_102801) do
+ActiveRecord::Schema.define(version: 2022_04_06_135448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,15 @@ ActiveRecord::Schema.define(version: 2022_04_05_102801) do
     t.index ["article_id", "partner_id"], name: "index_article_partners_on_article_id_and_partner_id", unique: true
     t.index ["article_id"], name: "index_article_partners_on_article_id"
     t.index ["partner_id"], name: "index_article_partners_on_partner_id"
+  end
+
+  create_table "article_tags", force: :cascade do |t|
+    t.bigint "article_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_article_tags_on_article_id"
+    t.index ["tag_id"], name: "index_article_tags_on_tag_id"
   end
 
   create_table "articles", force: :cascade do |t|

--- a/test/integration/graphql/event_integration_test.rb
+++ b/test/integration/graphql/event_integration_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class GraphQLEventTest < ActionDispatch::IntegrationTest
-
   setup do
     partner_address = FactoryBot.create(:bare_address_1, neighbourhood: neighbourhoods(:one))
     @partner = FactoryBot.create(:partner, address: partner_address)
@@ -21,7 +20,6 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
   end
 
   test 'can show partners (with pagination)' do
-
     (0...5).collect do |n|
       @partner.events.create!(
         dtstart: Time.now,
@@ -93,31 +91,30 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
     assert result.has_key?('errors') == false, 'errors are present'
 
     data = result['data']
-    assert data.has_key?('event'), 'Data structure does not contain event key'
+    assert_field data, 'event', 'Data structure does not contain event key'
 
     data_event = data['event']
 
-    assert data_event['summary'] == event.summary
-    assert data_event['name'] == event.summary
+    assert_field_equals data_event, 'summary', value: event.summary
+    assert_field_equals data_event, 'name', value: event.summary
 
-    assert data_event.has_key?('startDate'), 'missing startDate'
+    assert_field data_event, 'startDate', 'missing startDate'
     assert data_event['startDate'] =~ /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/, 'startDate is not in ISO format'
 
-    assert data_event.has_key?('endDate'), 'missing endDate'
-    assert data_event.has_key?('address'), 'missing address'
-    assert data_event.has_key?('organizer'), 'missing organizer'
+    assert_field data_event, 'endDate', 'missing endDate'
+    assert_field data_event, 'address', 'missing address'
+    assert_field data_event, 'organizer', 'missing organizer'
   end
 
   # the filter tests
 
   def build_time_events(now_time)
-
     # events in the past
     time = now_time - 100.days
     5.times do
       @partner.events.create!(
         dtstart: time,
-        summary: "past: An event summary",
+        summary: 'past: An event summary',
         description: 'Longer text covering the event in more detail',
         address: @address
       )
@@ -129,7 +126,7 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
     5.times do
       @partner.events.create!(
         dtstart: time,
-        summary: "present: An event summary",
+        summary: 'present: An event summary',
         description: 'Longer text covering the event in more detail',
         address: @address
       )


### PR DESCRIPTION
- Add ArticleTags relation via a migration
- Add policy code and document existing policy funcs :)
- Add view code (split into a side by side with Partners -- text will
  need workshopping maybe)
- Add some improved coverage in the Controller tests for checking we can
  edit partner_ids and tag_ids for root + editor (WILLFIX,TODO on
  expanding that)
- Some formatting stuff