### PR TITLE
Make login and password reset processes nicer

### DIFF
--- a/app/assets/stylesheets/home/_form.sass
+++ b/app/assets/stylesheets/home/_form.sass
@@ -20,6 +20,21 @@
   input
     background: transparent
 
+  input[type='checkbox'].round
+    width: 1.3rem
+    height: 1.3rem
+    padding: 0rem
+    border-radius: 50%
+    vertical-align: middle
+    border: 2px solid $base-primary
+    appearance: none
+    -webkit-appearance: none
+    outline: none
+    cursor: pointer
+    &:checked
+      background-color: $base-primary
+
+
   input.form__submit
     border-color: $base-text
     background-color: $base-text
@@ -97,3 +112,28 @@
     +for-tablet-portrait-up
       width: 60%
       margin: 0 auto
+
+  &--login
+    input
+      border-color: $base-primary
+    input[type='submit']
+      background-color: $base-primary
+      width: auto
+      margin: 0 auto
+      padding-left: 3rem
+      padding-right: 3rem
+      display: block
+      cursor: pointer
+    label
+      text-align: center
+    +for-tablet-portrait-up
+      width: 50%
+      margin: 0 auto
+    .devise
+      font-size: 90%
+      text-align: center
+    .form__field--remember
+      text-align: center
+      label, input
+        display: inline-block
+        width: auto

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -215,7 +215,14 @@ class ApplicationController < ActionController::Base
                   end
   end
 
+  # action filter:
+  #
+  # In devise controllers: push all users on any subdomain of placecal to 
+  #   authenticate on the base placecal.org site so the site is set up
+  #   properly and the styling will work
+  #
   def devise_check_on_root_site
+    return if current_user.present?
     return if not request.subdomain.present?
     
     redirect_to url_for(subdomain: nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -215,6 +215,12 @@ class ApplicationController < ActionController::Base
                   end
   end
 
+  def devise_check_on_root_site
+    return if not request.subdomain.present?
+    
+    redirect_to url_for(subdomain: nil)
+  end
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -215,18 +215,6 @@ class ApplicationController < ActionController::Base
                   end
   end
 
-  # action filter:
-  #
-  # In devise controllers: push all users on any subdomain of placecal to 
-  #   authenticate on the base placecal.org site so the site is set up
-  #   properly and the styling will work
-  #
-  def devise_check_on_root_site
-    return if current_user.present?
-    return if not request.subdomain.present?
-    
-    redirect_to url_for(subdomain: nil)
-  end
 
   protected
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class Users::SessionsController < Devise::SessionsController
-  protected
-
-    def after_sign_in_path_for(resource_or_scope)
-      stored_location_for(resource_or_scope) || admin_root_path
-    end
-end

--- a/app/controllers/users/auth_common.rb
+++ b/app/controllers/users/auth_common.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Users
+  module AuthCommon
+
+    def self.included(klass)
+      klass.before_action :devise_check_on_root_site
+      klass.after_action :patch_flash
+    end
+
+    private
+
+    # action filter:
+    #
+    # In devise controllers: push all users on any subdomain of placecal to 
+    #   authenticate on the base placecal.org site so the site is set up
+    #   properly and the styling will work
+    #
+    def devise_check_on_root_site
+      return if current_user.present?
+      return if not request.subdomain.present?
+
+      redirect_to url_for(subdomain: nil)
+    end
+
+    def patch_flash
+      # notice -> success
+      # alert -> danger
+      if flash.key?(:notice)
+        flash[:success] = flash[:notice]
+        flash.delete :notice
+      end
+
+      if flash.key?(:alert)
+        flash[:danger] = flash[:alert]
+        flash.delete :alert
+      end
+
+      if flash.now.flash.key?(:notice)
+        flash.now[:success] = flash.now[:notice]
+        flash.now.flash.delete :notice
+      end
+
+      if flash.now.flash.key?(:alert)
+        flash.now[:danger] = flash.now[:alert]
+        flash.now.flash.delete :alert
+      end
+    end
+  end
+
+end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::ConfirmationsController < Devise::ConfirmationsController
+  before_filter :devise_check_on_root_site
+
   # GET /resource/confirmation/new
   # def new
   #   super

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,32 +1,5 @@
 # frozen_string_literal: true
 
 class Users::ConfirmationsController < Devise::ConfirmationsController
-  before_filter :devise_check_on_root_site
-
-  # GET /resource/confirmation/new
-  # def new
-  #   super
-  # end
-
-  # POST /resource/confirmation
-  # def create
-  #   super
-  # end
-
-  # GET /resource/confirmation?confirmation_token=abcdef
-  # def show
-  #   super
-  # end
-
-  # protected
-
-  # The path used after resending confirmation instructions.
-  # def after_resending_confirmation_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
-
-  # The path used after confirmation.
-  # def after_confirmation_path_for(resource_name, resource)
-  #   super(resource_name, resource)
-  # end
+  include AuthCommon
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,5 +1,5 @@
 class Users::InvitationsController < Devise::InvitationsController
-  before_action :devise_check_on_root_site
+  include AuthCommon
 
   protected
 

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,4 +1,5 @@
 class Users::InvitationsController < Devise::InvitationsController
+  before_action :devise_check_on_root_site
 
   protected
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
-  before_action :devise_check_on_root_site
+  include AuthCommon
   before_action :set_site
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
+  before_action :devise_check_on_root_site
   before_action :set_site
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  before_action :set_site
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,7 +6,18 @@ class Users::SessionsController < Devise::SessionsController
 
   protected
 
+  # when we have authenticated the user take them to the admin site
+  # 
+  # == Parameters
+  #   resource_or_scope: ignored
+  # 
+  # == Returns
+  #   URL of admin site with correct path and subdomain
+  #   
   def after_sign_in_path_for(resource_or_scope)
-    stored_location_for(resource_or_scope) || admin_root_path
+    route_for(
+      :root,
+      subdomain: Site::ADMIN_SUBDOMAIN
+    )
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  before_action :set_site
+
+  protected
+
+  def after_sign_in_path_for(resource_or_scope)
+    stored_location_for(resource_or_scope) || admin_root_path
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
-  before_action :devise_check_on_root_site
+  include AuthCommon
   before_action :set_site
 
   protected

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  before_action :devise_check_on_root_site
   before_action :set_site
 
   protected

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,27 +1,32 @@
-<div class="c">
-  <h2>Change your password</h2>
+<article class="home margin">
+  <div class="card card--plainer">
+    <h1 class="center fc-primary">Change your password</h1>
+
+    <div class="centre form--login">
+        <%= form_for(resource, as: resource_name, 
+                         url: password_path(resource_name), 
+                         html: { method: :put, class: 'form' }) do |f| %>
+      <%= devise_error_messages! %>
+      <%= f.hidden_field :reset_password_token %>
   
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-    <%= devise_error_messages! %>
-    <%= f.hidden_field :reset_password_token %>
+      <div class="form__field">
+        <%= f.label :password, "New password" %>
+        <% if @minimum_password_length %>
+          <em>(<%= @minimum_password_length %> characters minimum)</em><br>
+        <% end %>
+        <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+      </div>
   
-    <div class="field">
-      <%= f.label :password, "New password" %><br>
-      <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em><br>
-      <% end %>
-      <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+      <div class="form__field">
+        <%= f.label :password_confirmation, "Confirm new password" %>
+        <%= f.password_field :password_confirmation, autocomplete: "off" %>
+      </div>
+      <br>
+
+      <div class="actions">
+        <%= f.submit "Change my password", class: "btn btn--big btn--home-3" %>
+      </div>
+      <br>
     </div>
-  
-    <div class="field">
-      <%= f.label :password_confirmation, "Confirm new password" %><br>
-      <%= f.password_field :password_confirmation, autocomplete: "off" %>
-    </div>
-  
-    <div class="actions">
-      <%= f.submit "Change my password" %>
-    </div>
-  <% end %>
-  
-  <%= render "devise/shared/links" %>
-</div>
+  </div>
+</article>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,23 @@
-<h2>Forgot your password?</h2>
+<article class="home margin">
+  <div class="card card--plainer">
+    <h1 class="center fc-primary">Forgot your password?</h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+    <div class="centre form--login">
+      <%= form_for(resource, as: resource_name, 
+                            url: password_path(resource_name), 
+                            html: { method: :post, class: 'form' }) do |f| %>
+      <%= devise_error_messages! %>
 
-  <div class="field">
-    <%= f.label :email %><br>
-    <%= f.email_field :email, autofocus: true %>
+      <div class="form__field">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true %>
+      </div>
+      <br>
+      <div class="actions">
+        <%= f.submit "Send me reset password instructions", class: "btn btn--big btn--home-3" %>
+      </div>
+      <% end %>
+      <br>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</article>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,29 +1,41 @@
-<div class="c">
-  <h2>Log in</h2>
-  
-  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <div class="field">
-      <%= f.label :email %><br>
-      <%= f.email_field :email, autofocus: true %>
-    </div>
-  
-    <div class="field">
-      <%= f.label :password %><br>
-      <%= f.password_field :password, autocomplete: "off" %>
-    </div>
-  
-    <% if devise_mapping.rememberable? -%>
-      <div class="field">
-        <%= f.check_box :remember_me %>
-        <%= f.label :remember_me %>
-      </div>
-    <% end -%>
-  
-    <div class="actions">
-      <%= f.submit "Log in" %>
-    </div>
-  <% end %>
-  
-  <%= render "devise/shared/links" %>
+<article class="home margin">
+  <div class="card card--plainer">
+    <h1 class="center fc-primary">Log in</h1>
+    
+    <div class="centre form--login">
+      <%= form_for(resource, as: resource_name, 
+                            url: session_path(resource_name),  
+                            html: { class: 'form' } ) do |f| %>
+        <div class="form__field">
+          <%= f.label :email %>
+          <%= f.email_field :email, autofocus: true %>
+        </div>
+      
+        <div class="form__field">
+          <%= f.label :password %>
+          <%= f.password_field :password, autocomplete: "off" %>
+        </div>
+      
+        <% if devise_mapping.rememberable? -%>
+          <div class="form__field--remember">
+            <%= f.label :remember_me %>
+            <%= f.check_box :remember_me, class: "round" %>
+          </div>
+        <% end -%>
+      
+        <div class="devise">
+          <%= render "devise/shared/links" %>
+        </div>
 
-</div>
+        <br>
+
+        <div class="actions">
+          <%= f.submit "Log in", class: "btn btn--big btn--home-3" %>
+        </div>
+      <% end %>
+      
+      
+    </div>
+    <br><br>
+  </div>
+</article>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,7 @@
         <%= render_component "navigation", navigation: @navigation %>
       </header>
       <main>
+        <%= render_component "admin_flash" %>
         <%= yield %>
       </main>
       <footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   devise_for :users,
              controllers: {
                omniauth_callbacks: 'admin/omniauth_callbacks',
-               invitations: 'users/invitations'
+               invitations: 'users/invitations',
+               sessions: 'users/sessions',
+               passwords: 'users/passwords'
              }
 
   devise_scope :user do

--- a/test/integration/users_log_in_go_to_admin_site_test.rb
+++ b/test/integration/users_log_in_go_to_admin_site_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UsersLogInGoToAdminSiteTest < ActionDispatch::IntegrationTest
+
+  include Capybara::DSL
+  include Capybara::Minitest::Assertions
+
+  setup do
+    @root = create(:root)
+    create_default_site
+  end
+
+  test 'logging in takes user to admin site' do
+    visit 'http://lvh.me/users/sign_in'
+
+    fill_in 'Email', with: @root.email
+    fill_in 'Password', with: 'password'
+    click_button 'Log in'
+
+    # has redirected to admin site
+    assert_equal 'http://admin.lvh.me/', current_url
+  end
+end

--- a/test/integration/users_login_on_site_test.rb
+++ b/test/integration/users_login_on_site_test.rb
@@ -1,0 +1,17 @@
+
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UsersLoginOnSiteTest < ActionDispatch::IntegrationTest
+
+  setup do
+    create_default_site
+  end
+
+  test 'redirects to base site' do
+    get 'http://default-site.lvh.me/users/sign_in'
+
+    assert_redirected_to 'http://lvh.me/users/sign_in'
+  end
+end


### PR DESCRIPTION
Left to do

- [x] make *.placecal.org devise screens redirect to just placecal.org (this is because of how the default site works, if you go to https://admin.placecal.org/users/sign_in it will load the wrong background, there might be other ways to do this)
- [x] check password reset css looks right (i can't on my local)
- [x] make it redirect to admin subdomain after login
- [x] make flash message work in admin after signin