### PR TITLE
Add GeoCoordinates to Partner (GraphQL)

### DIFF
--- a/app/graphql/types/address_type.rb
+++ b/app/graphql/types/address_type.rb
@@ -1,29 +1,30 @@
+# frozen_string_literal: true
+
 module Types
   class AddressType < Types::BaseObject
-
     description 'An address representing a physical location'
 
     # field :id, ID, null: false
-    field :street_address, String, 
-      method: :full_street_address,
-      description: 'The first few lines of the address like: 123 Road, Eastleigh, Southampton'
+    field :street_address, String,
+          method: :full_street_address,
+          description: 'The first few lines of the address like: 123 Road, Eastleigh, Southampton'
 
     field :address_locality, String,
-      description: 'The ward this address is in'
+          description: 'The ward this address is in'
 
     field :address_region, String,
-      description: 'The district this address is in'
+          description: 'The district this address is in'
 
-    field :address_country, String, 
-      method: :country_code,
-      description: 'The country of this event (England, Scotland, Wales, or Northern Ireland)'
+    field :address_country, String,
+          method: :country_code,
+          description: 'The country of this event (England, Scotland, Wales, or Northern Ireland)'
 
-    field :postal_code, String, 
-      method: :postcode,
-      description: 'A UK postcode'
+    field :postal_code, String,
+          method: :postcode,
+          description: 'A UK postcode'
 
     field :neighbourhood, NeighbourhoodType,
-      description: 'The neighbourhood of this address (see neighbourhood type)'
+          description: 'The neighbourhood of this address (see neighbourhood type)'
 
     # TODO: figure out parent and children accessors
     # field :containedInPlace
@@ -38,4 +39,3 @@ module Types
     end
   end
 end
-

--- a/app/graphql/types/geo_coordinates_type.rb
+++ b/app/graphql/types/geo_coordinates_type.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  class GeoCoordinatesType < Types::BaseObject
+    description "The geo coordinates of the partner's address."
+
+    field :latitude, String,
+          description: "The latitude of the partner's address"
+
+    field :longitude, String,
+          description: "The longitude of the partner's address"
+
+    def latitude
+      object&.latitude
+    end
+
+    def longitude
+      object&.longitude
+    end
+  end
+end

--- a/app/graphql/types/opening_hours_type.rb
+++ b/app/graphql/types/opening_hours_type.rb
@@ -17,5 +17,3 @@ module Types
     end
   end
 end
-
-

--- a/app/graphql/types/partner_type.rb
+++ b/app/graphql/types/partner_type.rb
@@ -1,57 +1,61 @@
+# frozen_string_literal: true
+
 module Types
   class PartnerType < Types::BaseObject
-    
-
     description 'Organisations that run events'
 
-    field :id, ID, 
-      null: false,
-      description: 'ID of partner'
+    field :id, ID,
+          null: false,
+          description: 'ID of partner'
 
-    field :name, String, 
-      null: false,
-      description: 'A short string about this partner, an alias for `summary`'
+    field :name, String,
+          null: false,
+          description: 'A short string about this partner, an alias for `summary`'
 
     field :summary, String,
-      description: 'A short summary describing what this partner does'
+          description: 'A short summary describing what this partner does'
 
     field :description, String,
-      description: 'Longer text about partner with more detail (in Markdown syntax)'
+          description: 'Longer text about partner with more detail (in Markdown syntax)'
 
     field :accessibility_summary, String,
-      method: :accessibility_info,
-      description: 'An accessibility statement written by this partner'
+          method: :accessibility_info,
+          description: 'An accessibility statement written by this partner'
 
     field :logo, String,
-      description: 'The URL of the logo that is served from PlaceCal',
-      method: :logo_url
+          description: 'The URL of the logo that is served from PlaceCal',
+          method: :logo_url
 
     field :address, AddressType,
-      description: 'The physical address of this partner'
+          description: 'The physical address of this partner'
 
     field :url, String,
-      description: 'The URL provided by the partner for users to find out more info'
+          description: 'The URL provided by the partner for users to find out more info'
 
     field :facebook_url, String,
-      method: :facebook_link,
-      description: 'The URL of the partner\'s Facebook page'
+          method: :facebook_link,
+          description: 'The URL of the partner\'s Facebook page'
 
-    field :twitter_url, String, 
-      description: 'The URL to the partner\'s Twitter profile'
+    field :twitter_url, String,
+          description: 'The URL to the partner\'s Twitter profile'
 
     field :areas_served, [NeighbourhoodType],
-      method: :service_area_neighbourhoods,
-      description: 'Areas served by partner that are not at a physical address'
+          method: :service_area_neighbourhoods,
+          description: 'Areas served by partner that are not at a physical address'
 
     field :contact, ContactType,
-      description: 'Venue contact information - could be a person or a general contact'
+          description: 'Venue contact information - could be a person or a general contact'
 
-    field :opening_hours, [OpeningHoursType], 
-      null: true,
-      description: 'The hours that this partner opens for at their physical address'
+    field :opening_hours, [OpeningHoursType],
+          null: true,
+          description: 'The hours that this partner opens for at their physical address'
 
     field :articles, [ArticleType],
-      description: 'News and information from this partner'
+          description: 'News and information from this partner'
+
+    field :geo, GeoCoordinatesType,
+          null: true,
+          description: 'The geo coordinates of the place.'
 
     def contact
       object
@@ -64,6 +68,9 @@ module Types
     def articles
       object.articles.published.by_publish_date
     end
+
+    def geo
+      object&.address
+    end
   end
 end
-

--- a/test/integration/graphql/partners_integration_test.rb
+++ b/test/integration/graphql/partners_integration_test.rb
@@ -4,9 +4,7 @@ require 'test_helper'
 
 class GraphQLPartnerTest < ActionDispatch::IntegrationTest
   test 'can show partners' do
-    5.times do |n|
-      FactoryBot.create(:partner, name: "Partner #{n}")
-    end
+    partner_list = create_list(:partner, 5)
 
     query_string = <<-GRAPHQL
       query {
@@ -14,6 +12,7 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
           edges {
             node {
               id
+              name
               summary
               description
             }
@@ -23,19 +22,27 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     GRAPHQL
 
     result = PlaceCalSchema.execute(query_string)
-    data = result['data']
+    refute_field result, 'errors'
 
-    assert data.key?('partnerConnection'), 'result is missing key `partnerConnection`'
-    connection = data['partnerConnection']
+    data = assert_field result, 'data'
+    connection = assert_field data, 'partnerConnection'
+    edges = assert_field connection, 'edges'
 
-    assert connection.key?('edges')
-    edges = connection['edges']
+    assert_equal edges.length, 5
 
-    assert edges.length == 5
+    # Validate that we are in-fact returning the partner's data, too
+    edges.lazy.zip(partner_list).each do |edge, partner|
+      node = assert_field(edge, 'node')
+
+      assert_field_equals node, 'id', value: partner.id.to_s
+      assert_field_equals node, 'name', value: partner.name
+      assert_field_equals node, 'summary', value: partner.summary
+      assert_field_equals node, 'description', value: partner.description
+    end
   end
 
   test 'can show specific partner' do
-    partner = FactoryBot.create(:partner)
+    partner = create(:partner)
 
     query_string = <<-GRAPHQL
       query {
@@ -47,12 +54,13 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     GRAPHQL
 
     result = PlaceCalSchema.execute(query_string)
+    refute_field result, 'errors'
 
-    data = result['data']
-    assert data.key?('partner')
+    data = assert_field result, 'data'
+    data_partner = assert_field data, 'partner'
 
-    data_partner = data['partner']
-    assert data_partner['name'] == partner.name
+    assert_field_equals data_partner, 'id', value: partner.id.to_s
+    assert_field_equals data_partner, 'name', value: partner.name
   end
 
   def check_address(data, address)
@@ -63,8 +71,7 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     assert_field_equals data, 'addressLocality', value: neighbourhood.name
     assert_field_equals data, 'addressRegion', value: neighbourhood.region.to_s
 
-    assert_field data, 'neighbourhood'
-    hood = data['neighbourhood']
+    hood = assert_field data, 'neighbourhood'
 
     assert_field_equals hood, 'name', value: neighbourhood.name
     assert_field_equals hood, 'abbreviatedName', value: neighbourhood.abbreviated_name
@@ -76,9 +83,7 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
 
   def check_contact(data, contact)
     assert_field_equals data, 'name', value: contact.public_name
-
     assert_field_equals data, 'telephone', value: contact.public_phone
-
     assert_field_equals data, 'email', value: contact.public_email
   end
 
@@ -128,7 +133,7 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can view contact info when selected' do
-    partner = FactoryBot.create(:partner, twitter_handle: 'Alpha', image: 'https://example.com/logo.png')
+    partner = create(:partner, twitter_handle: 'Alpha', image: 'https://example.com/logo.png')
     partner.service_area_neighbourhoods << neighbourhoods(:one)
 
     # FIXME: logo URL field is tricky as it expects an upload from rails
@@ -187,7 +192,7 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     GRAPHQL
 
     result = PlaceCalSchema.execute(query_string)
-    refute result.key?('errors'), 'errors are present'
+    refute_field result, 'errors'
 
     data = result['data']
 
@@ -211,7 +216,7 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
 
   test 'can see published articles by partnetr' do
     user = create(:user)
-    partner = FactoryBot.create(:partner, twitter_handle: 'Alpha')
+    partner = create(:partner, twitter_handle: 'Alpha')
 
     article_1 = partner.articles.create!(
       title: 'A published article',
@@ -242,7 +247,7 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     GRAPHQL
 
     result = PlaceCalSchema.execute(query_string)
-    refute result.key?('errors'), 'errors are present'
+    refute_field result, 'errors'
 
     data = result['data']
     partner_data = data['partner']
@@ -252,8 +257,8 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
   end
 
   test 'finding partners by tag' do
-    partner = FactoryBot.create(:partner)
-    tag = FactoryBot.create(:tag)
+    partner = create(:partner)
+    tag = create(:tag)
     partner.tags << tag
 
     query_string = <<-GRAPHQL
@@ -266,7 +271,7 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     GRAPHQL
 
     result = PlaceCalSchema.execute(query_string)
-    refute result.key?('errors'), 'errors are present'
+    refute_field result, 'errors'
 
     data = result['data']
     partner_data = data['partnersByTag']
@@ -274,7 +279,7 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
   end
 
   test 'returns null properly if openning times are missing' do
-    partner = FactoryBot.create(:partner, opening_times: nil)
+    partner = create(:partner, opening_times: nil)
 
     query_string = <<-GRAPHQL
       query {
@@ -289,15 +294,49 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     GRAPHQL
 
     result = PlaceCalSchema.execute(query_string)
-    assert result.key?('errors') == false, 'errors are present'
+    refute_field result, 'errors'
 
-    data = result['data']
-    assert data.key?('partner')
+    data = assert_field result, 'data'
+    partner = assert_field data, 'partner'
 
-    data_partner = data['partner']
-    assert data_partner.key?('openingHours')
+    assert_field_equals partner, 'openingHours', value: nil
+  end
 
-    opening_hours = data_partner['openingHours']
-    assert_nil opening_hours
+  test 'test that we have geo location' do
+    partner = create(:partner,
+                     address: create(:address,
+                                     latitude: 69.420666,
+                                     longitude: -2.666666))
+
+    query_string = <<-GRAPHQL
+      query {
+        partnerConnection {
+          edges {
+            node {
+              id
+              geo {
+                longitude
+                latitude
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    result = PlaceCalSchema.execute(query_string)
+    refute_field result, 'errors'
+
+    data = assert_field result, 'data'
+    connection = assert_field data, 'partnerConnection'
+    edges = assert_field connection, 'edges'
+
+    assert_equal edges.length, 1
+    data_partner = assert_field edges.first, 'node'
+
+    assert_field_equals data_partner, 'id', value: partner.id.to_s
+    geo = assert_field data_partner, 'geo'
+    assert_field_equals geo, 'longitude', value: partner.address.longitude.to_s
+    assert_field_equals geo, 'latitude', value: partner.address.latitude.to_s
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -243,9 +243,9 @@ Geocoder::Lookup::Test.add_stub(
 # GraphQL helpers
 
 def assert_field_equals(obj, key, value: nil)
-  assert obj.key?(key), "field #{key} is missing"
+  assert obj.key?(key), "field '#{key}' is missing"
 
-  error_msg = "Field #{key} has incorrect value: wanted '#{value}', but got '#{obj[key]}'"
+  error_msg = "Field '#{key}' has incorrect value: wanted '#{value}', but got '#{obj[key]}'"
 
   # This is super awkward and horrible. Basically if both parameters ending up at assert_equal are nil,
   # it throws a deprecation warning:
@@ -267,8 +267,15 @@ rescue Minitest::Assertion => e
 end
 
 def assert_field(obj, key, message = nil)
-  message ||= "#{key} doesn't exist / is nil in #{obj}"
+  message ||= "Field '#{key}' doesn't exist / is nil in: #{obj}"
   assert obj.key?(key), message # obj.key? returns false if an item is nil, ergo...
+
+  obj[key]
+end
+
+def refute_field(obj, key, message = nil)
+  message ||= "Field '#{key}' exists in: #{obj}"
+  refute obj.key?(key), message # obj.key? returns false if an item is nil, ergo...
 
   obj[key]
 end


### PR DESCRIPTION
Fixes #1165

- Add geo field to partners_type
- Add GeoCoordinatesType
- Add tests (fixup some of the existing tests as well)
- Some formatting stuff