### PR TITLE
Move GeoCoordinates type into AddressType

### DIFF
--- a/app/graphql/types/address_type.rb
+++ b/app/graphql/types/address_type.rb
@@ -26,9 +26,17 @@ module Types
     field :neighbourhood, NeighbourhoodType,
           description: 'The neighbourhood of this address (see neighbourhood type)'
 
+    field :geo, GeoCoordinatesType,
+          null: true,
+          description: 'The geo coordinates of the place.'
+
     # TODO: figure out parent and children accessors
     # field :containedInPlace
     # field :containedPlace
+
+    def geo
+      object
+    end
 
     def address_locality
       object.neighbourhood.name

--- a/app/graphql/types/partner_type.rb
+++ b/app/graphql/types/partner_type.rb
@@ -53,10 +53,6 @@ module Types
     field :articles, [ArticleType],
           description: 'News and information from this partner'
 
-    field :geo, GeoCoordinatesType,
-          null: true,
-          description: 'The geo coordinates of the place.'
-
     def contact
       object
     end
@@ -67,10 +63,6 @@ module Types
 
     def articles
       object.articles.published.by_publish_date
-    end
-
-    def geo
-      object&.address
     end
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,7 +2,6 @@
 
 # app/models/address.rb
 class Address < ApplicationRecord
-
   POSTCODE_REGEX = /\s*((GIR\s*0AA)|((([A-PR-UWYZ][0-9]{1,2})|(([A-PR-UWYZ][A-HK-Y][0-9]{1,2})|(([A-PR-UWYZ][0-9][A-HJKSTUW])|([A-PR-UWYZ][A-HK-Y][0-9][ABEHMNPRVWXY]))))\s*[0-9][ABD-HJLNP-UW-Z]{2}))\s*/i
 
   validates :street_address, :postcode, :country_code, presence: true
@@ -35,7 +34,7 @@ class Address < ApplicationRecord
   def full_street_address
     [ street_address,
       street_address2,
-      street_address3,
+      street_address3
     ].reject(&:blank?).join(', ')
   end
 
@@ -95,7 +94,7 @@ class Address < ApplicationRecord
   class << self
     # location - The raw location field
     # components - Array containing parts of an event's location field, excluding the postcode.
-    def search(location, components, postcode)
+    def search(_location, components, postcode)
 
       # Find the first Address whose first address line contains any one of the
       # address lines in the components argument. Case insensitive.
@@ -113,17 +112,17 @@ class Address < ApplicationRecord
       postcode = standardised_postcode(postcode)
 
       # Find address by postcode if postcode is long enough to be a valid.
-      if ! address  &&  postcode  &&  postcode.length >= 'A1 1AA'.length
+      if !address && postcode && postcode.length >= 'A1 1AA'.length
         address = Address.find_by(postcode: postcode)
       end
 
       if address
         partner = address.partners.first
-        partner.present? ? [ :place_id, partner.id ] : [ :address_id, address.id ]
+        partner.present? ? [:place_id, partner.id] : [:address_id, address.id]
       else
         # Make a new address.
         address = Address.build_from_components(components, postcode)
-        [ :address_id, address.try(:id) ]
+        [:address_id, address.try(:id)]
       end
     end
 
@@ -131,10 +130,10 @@ class Address < ApplicationRecord
       return if components.blank?
 
       address = Address.new(
-        street_address:  components[0]&.strip,
+        street_address: components[0]&.strip,
         street_address2: components[1]&.strip,
         street_address3: components[2]&.strip,
-        postcode:        postcode
+        postcode: postcode
       )
       address if address.save
     end
@@ -145,7 +144,7 @@ class Address < ApplicationRecord
     # before the final three characters.
     def standardised_postcode(pc)
       return unless pc
-      pc.gsub(/\s+/, "").strip.upcase.insert(-4, ' ')
+      pc.gsub(/\s+/, '').strip.upcase.insert(-4, ' ')
     end
   end
 end

--- a/test/integration/graphql/event_integration_test.rb
+++ b/test/integration/graphql/event_integration_test.rb
@@ -4,13 +4,13 @@ require 'test_helper'
 
 class GraphQLEventTest < ActionDispatch::IntegrationTest
   setup do
-    partner_address = FactoryBot.create(:bare_address_1, neighbourhood: neighbourhoods(:one))
-    @partner = FactoryBot.create(:partner, address: partner_address)
+    partner_address = create(:bare_address_1, neighbourhood: neighbourhoods(:one))
+    @partner = create(:partner, address: partner_address)
 
     @address = @partner.address
     assert @address, 'Failed to create Address from partner'
 
-    @calendar = FactoryBot.create(
+    @calendar = create(
       :calendar,
       partner: @partner,
       name: 'Partner Calendar',
@@ -44,7 +44,8 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
     GRAPHQL
 
     result = PlaceCalSchema.execute(query_string)
-    # puts JSON.pretty_generate(result.as_json)
+    refute_field result, 'errors'
+
     data = result['data']
 
     assert data.has_key?('eventConnection'), 'result is missing key `eventConnection`'
@@ -54,6 +55,7 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
     edges = connection['edges']
 
     assert edges.length == 5
+    # TODO: Actually test that the events we are getting back are the ones we want
   end
 
   test 'can show specific event' do
@@ -88,7 +90,7 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
     GRAPHQL
 
     result = PlaceCalSchema.execute(query_string)
-    assert result.has_key?('errors') == false, 'errors are present'
+    refute_field result, 'errors'
 
     data = result['data']
     assert_field data, 'event', 'Data structure does not contain event key'
@@ -146,16 +148,11 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def verify_correct_number_of_items(count_got, count_wanted, desc)
-    assert count_got == count_wanted, "#{desc}: wanted=#{count_wanted}, got=#{count_got}"
-  end
-
   test 'returns events from today' do
     now_time = DateTime.new(1990, 1, 1, 0, 0, 0)
     build_time_events now_time
 
     DateTime.stub :now, now_time do
-
       query_string = <<-GRAPHQL
       query {
         eventsByFilter {
@@ -167,14 +164,14 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
       GRAPHQL
 
       result = PlaceCalSchema.execute(query_string)
-      assert result.has_key?('errors') == false, 'errors are present'
+      refute_field result, 'errors'
 
       data = result['data']
       assert data.has_key?('eventsByFilter'), 'Data structure does not contain event key'
 
       events = data['eventsByFilter']
-      verify_correct_number_of_items events.length, 10, 'was expecting only events in the future'
-      # assert events.length == 10, 'was expecting only events in the future'
+      assert_equal events.length, 10, 'was expecting only events in the future'
+      # TODO: Actually test that the events we are getting back are the ones we want
     end
   end
 
@@ -183,7 +180,6 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
     build_time_events now_time
 
     DateTime.stub :now, now_time do
-
       query_string = <<-GRAPHQL
       query {
         eventsByFilter(fromDate: "1985-01-01 00:00") {
@@ -195,14 +191,14 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
       GRAPHQL
 
       result = PlaceCalSchema.execute(query_string)
-      assert result.has_key?('errors') == false, 'errors are present'
+      refute_field result, 'errors'
 
       data = result['data']
       assert data.has_key?('eventsByFilter'), 'Data structure does not contain event key'
 
       events = data['eventsByFilter']
-      verify_correct_number_of_items events.length, 15, 'was expecting to see all events'
-      # assert events.length == 15, 'was expecting to see all events'
+      assert_equal events.length, 15, 'was expecting to see all events'
+      # TODO: Actually test that the events we are getting back are the ones we want
     end
   end
 
@@ -223,170 +219,196 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
       GRAPHQL
 
       result = PlaceCalSchema.execute(query_string)
-      assert result.has_key?('errors') == false, 'errors are present'
+      refute_field result, 'errors'
 
       data = result['data']
       assert data.has_key?('eventsByFilter'), 'Data structure does not contain event key'
 
       events = data['eventsByFilter']
-      verify_correct_number_of_items events.length, 5, 'was expecting to see only some future events'
-      # assert events.length == 5, 'was expecting to see only some future events'
+      assert_equal events.length, 5, 'was expecting to see only some future events'
+      # TODO: Actually test that the events we are getting back are the ones we want
     end
   end
 
   # this should mainly be tested elsewhere
   #   (the same place service area scoping is tested)
   test 'can scope to neighbourhood (via partner address)' do
-
-    Partner.transaction do
-      3.times do
-        @partner.events.create!(
-          dtstart: DateTime.now + 1.hours,
-          summary: "partner 1: An event summary",
-          description: 'Longer text covering the event in more detail',
-          address: @address
-        )
-      end
-
-
-      other_address = FactoryBot.create(:bare_address_2, neighbourhood: neighbourhoods(:two))
-      other_partner = FactoryBot.create(:moss_side_partner, address: other_address)
-
-      5.times do
-        other_partner.events.create!(
-          dtstart: DateTime.now + 1.hours,
-          summary: "partner 2: An event summary",
-          description: 'Longer text covering the event in more detail',
-          address: other_address
-        )
-      end
-
-      query_string = <<-GRAPHQL
-      query {
-        eventsByFilter(neighbourhoodId: #{other_address.neighbourhood_id}) {
-          id
-          name
-        }
-      }
-      GRAPHQL
-
-      result = PlaceCalSchema.execute(query_string)
-      # puts JSON.pretty_generate(result.as_json)
-      assert result.has_key?('errors') == false, 'errors are present'
-
-      data = result['data']
-      assert data.has_key?('eventsByFilter'), 'Data structure does not contain event key'
-
-      events = data['eventsByFilter']
-      verify_correct_number_of_items events.length, 5, 'was expecting to see only events from other_partner'
-      # assert events.length == 5, 'was expecting to see only events from other_partner'
+    3.times do
+      @partner.events.create!(
+        dtstart: DateTime.now + 1.hours,
+        summary: "partner 1: An event summary",
+        description: 'Longer text covering the event in more detail',
+        address: @address
+      )
     end
+
+    other_address = create(:bare_address_2, neighbourhood: neighbourhoods(:two))
+    other_partner = create(:moss_side_partner, address: other_address)
+
+    5.times do
+      other_partner.events.create!(
+        dtstart: DateTime.now + 1.hours,
+        summary: "partner 2: An event summary",
+        description: 'Longer text covering the event in more detail',
+        address: other_address
+      )
+    end
+
+    query_string = <<-GRAPHQL
+    query {
+      eventsByFilter(neighbourhoodId: #{other_address.neighbourhood_id}) {
+        id
+        name
+      }
+    }
+    GRAPHQL
+
+    result = PlaceCalSchema.execute(query_string)
+    refute_field result, 'errors'
+
+    data = result['data']
+    assert data.has_key?('eventsByFilter'), 'Data structure does not contain event key'
+
+    events = data['eventsByFilter']
+    assert_equal events.length, 5, 'was expecting to see only events from other_partner'
+    # TODO: Actually test that the events we are getting back are the ones we want
   end
 
   test 'can scope to neighbourhood (via partner service area)' do
+    neighbourhood_good = neighbourhoods(:one)
+    neighbourhood_bad  = neighbourhoods(:two)
 
-    Partner.transaction do
-      neighbourhood_good = neighbourhoods(:one)
-      neighbourhood_bad  = neighbourhoods(:two)
+    @partner.service_areas.create! neighbourhood: neighbourhood_good
+    @partner.update! address: nil
 
-      @partner.service_areas.create! neighbourhood: neighbourhood_good
-      @partner.update! address: nil
-
-      5.times do
-        @partner.events.create!(
-          dtstart: DateTime.now + 1.hours,
-          summary: "partner in good neighbourhood: An event summary",
-          description: 'Longer text covering the event in more detail',
-          address: @address
-        )
-      end
-
-      other_partner = FactoryBot.build(:moss_side_partner, address: nil)
-      other_partner.service_areas.build neighbourhood: neighbourhood_bad
-      other_partner.save!
-
-      3.times do
-        other_partner.events.create!(
-          dtstart: DateTime.now + 1.hours,
-          summary: "partner in bad neighbourhood: An event summary",
-          description: 'Longer text covering the event in more detail',
-          address: FactoryBot.create(:bare_address_2)
-        )
-      end
-
-      query_string = <<-GRAPHQL
-      query {
-        eventsByFilter(neighbourhoodId: #{neighbourhood_good.id}) {
-          id
-          name
-        }
-      }
-      GRAPHQL
-
-      result = PlaceCalSchema.execute(query_string)
-      # puts JSON.pretty_generate(result.as_json)
-      assert result.has_key?('errors') == false, 'errors are present'
-
-      data = result['data']
-      assert data.has_key?('eventsByFilter'), 'Data structure does not contain event key'
-
-      events = data['eventsByFilter']
-      verify_correct_number_of_items events.length, 5, 'was expecting to see only events within neighbourhood_good service area'
-      # assert events.length == 5, 'was expecting to see only events within neighbourhood_good service area'
+    5.times do
+      @partner.events.create!(
+        dtstart: DateTime.now + 1.hours,
+        summary: "partner in good neighbourhood: An event summary",
+        description: 'Longer text covering the event in more detail',
+        address: @address
+      )
     end
+
+    other_partner = FactoryBot.build(:moss_side_partner, address: nil)
+    other_partner.service_areas.build neighbourhood: neighbourhood_bad
+    other_partner.save!
+
+    3.times do
+      other_partner.events.create!(
+        dtstart: DateTime.now + 1.hours,
+        summary: "partner in bad neighbourhood: An event summary",
+        description: 'Longer text covering the event in more detail',
+        address: create(:bare_address_2)
+      )
+    end
+
+    query_string = <<-GRAPHQL
+    query {
+      eventsByFilter(neighbourhoodId: #{neighbourhood_good.id}) {
+        id
+        name
+      }
+    }
+    GRAPHQL
+
+    result = PlaceCalSchema.execute(query_string)
+    refute_field result, 'errors'
+
+    data = result['data']
+    assert data.has_key?('eventsByFilter'), 'Data structure does not contain event key'
+
+    events = data['eventsByFilter']
+    assert_equal events.length, 5, 'was expecting to see only events within neighbourhood_good service area'
+    # TODO: Actually test that the events we are getting back are the ones we want
   end
+
   # this should mainly be tested elsewhere
   test 'can scope to tag (via partner tags)' do
+    have_tag = create(:tag)
+    have_not_tag = create(:tag)
 
-    Partner.transaction do
-      have_tag = FactoryBot.create(:tag)
-      have_not_tag = FactoryBot.create(:tag)
+    @partner.tags << have_not_tag
 
-      @partner.tags << have_not_tag
+    2.times do
+      @partner.events.create!(
+        dtstart: DateTime.now + 1.hours,
+        summary: 'partner 1: An event summary',
+        description: 'Longer text covering the event in more detail',
+        address: @address
+      )
+    end
 
-      2.times do
-        @partner.events.create!(
-          dtstart: DateTime.now + 1.hours,
-          summary: "partner 1: An event summary",
-          description: 'Longer text covering the event in more detail',
-          address: @address
-        )
-      end
+    other_address = create(:bare_address_2, neighbourhood: neighbourhoods(:two))
+    other_partner = create(:moss_side_partner,
+                           address: other_address,
+                           tags: [have_tag])
 
+    6.times do
+      other_partner.events.create!(
+        dtstart: DateTime.now + 1.hours,
+        summary: 'partner 2: An event summary',
+        description: 'Longer text covering the event in more detail',
+        address: other_address
+      )
+    end
 
-      other_address = FactoryBot.create(:bare_address_2, neighbourhood: neighbourhoods(:two))
-      other_partner = FactoryBot.create(:moss_side_partner, address: other_address)
+    query_string = <<-GRAPHQL
+    query {
+      eventsByFilter(tagId: #{have_tag.id}) {
+        id
+        name
+      }
+    }
+    GRAPHQL
 
-      other_partner.tags << have_tag
+    result = PlaceCalSchema.execute(query_string)
+    refute_field result, 'errors'
 
-      6.times do
-        other_partner.events.create!(
-          dtstart: DateTime.now + 1.hours,
-          summary: "partner 2: An event summary",
-          description: 'Longer text covering the event in more detail',
-          address: other_address
-        )
-      end
+    data = assert_field result, 'data'
+    events = assert_field data, 'eventsByFilter'
+    assert_equal events.length, 6, 'was expecting to see only events from have_tag'
+    # TODO: Actually test that the events we are getting back are the ones we want
+  end
 
-      query_string = <<-GRAPHQL
+  test 'test that we have geo location' do
+    event = create(:event,
+                   address: create(:address,
+                                   latitude: 69.420666,
+                                   longitude: -2.666666))
+
+    query_string = <<-GRAPHQL
       query {
-        eventsByFilter(tagId: #{have_tag.id}) {
-          id
-          name
+        eventConnection {
+          edges {
+            node {
+              id
+              address {
+                geo {
+                  longitude
+                  latitude
+                }
+              }
+            }
+          }
         }
       }
-      GRAPHQL
+    GRAPHQL
 
-      result = PlaceCalSchema.execute(query_string)
-      # puts JSON.pretty_generate(result.as_json)
-      assert result.has_key?('errors') == false, 'errors are present'
+    result = PlaceCalSchema.execute(query_string)
+    refute_field result, 'errors'
 
-      data = result['data']
-      assert data.has_key?('eventsByFilter'), 'Data structure does not contain event key'
+    data = assert_field result, 'data'
+    connection = assert_field data, 'eventConnection'
+    edges = assert_field connection, 'edges'
 
-      events = data['eventsByFilter']
-      verify_correct_number_of_items events.length, 6,'was expecting to see only events from have_tag'
-      # assert events.length == 6, 'was expecting to see only events from have_tag'
-    end
+    assert_equal edges.length, 1
+    data_event = assert_field edges.first, 'node'
+
+    assert_field_equals data_event, 'id', value: event.id.to_s
+    address = assert_field data_event, 'address'
+    geo = assert_field address, 'geo'
+    assert_field_equals geo, 'longitude', value: event.address.longitude.to_s
+    assert_field_equals geo, 'latitude', value: event.address.latitude.to_s
   end
 end

--- a/test/integration/graphql/partners_integration_test.rb
+++ b/test/integration/graphql/partners_integration_test.rb
@@ -314,9 +314,11 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
           edges {
             node {
               id
-              geo {
-                longitude
-                latitude
+              address {
+                geo {
+                  longitude
+                  latitude
+                }
               }
             }
           }
@@ -335,43 +337,9 @@ class GraphQLPartnerTest < ActionDispatch::IntegrationTest
     data_partner = assert_field edges.first, 'node'
 
     assert_field_equals data_partner, 'id', value: partner.id.to_s
-    geo = assert_field data_partner, 'geo'
+    address = assert_field data_partner, 'address'
+    geo = assert_field address, 'geo'
     assert_field_equals geo, 'longitude', value: partner.address.longitude.to_s
     assert_field_equals geo, 'latitude', value: partner.address.latitude.to_s
-  end
-
-  test 'test that we have geo location with nil' do
-    partner = create(:partner,
-                     address: nil,
-                     service_area_neighbourhoods: [create(:neighbourhood)])
-
-    query_string = <<-GRAPHQL
-      query {
-        partnerConnection {
-          edges {
-            node {
-              id
-              geo {
-                longitude
-                latitude
-              }
-            }
-          }
-        }
-      }
-    GRAPHQL
-
-    result = PlaceCalSchema.execute(query_string)
-    refute_field result, 'errors'
-
-    data = assert_field result, 'data'
-    connection = assert_field data, 'partnerConnection'
-    edges = assert_field connection, 'edges'
-
-    assert_equal edges.length, 1
-    data_partner = assert_field edges.first, 'node'
-
-    assert_field_equals data_partner, 'id', value: partner.id.to_s
-    assert_field_equals data_partner, 'geo', value: nil
   end
 end


### PR DESCRIPTION
Fixes #1165

- Removes `GeoCoordinates` type from `partner_type`
- Adds `GeoCoordinates` type into `address_type`
- Adds gql test for `geo` field returned via `eventsConnection`
- Small formatting changes on `address.rb`
- Remove some redunant gql testing code
  - Remove `verify_correct_number_of_items` and swap out for `assert_equals`
    (They do the same thing)
  - Switch to using `refute_field` for result `errors`, make sure we
    consistently test for result error blocks
  - Remove redundant `Partner.transaction` blocks
  - Add TODO for property depth testing rather than just array length
    testing (The latter is shallow and we might miss some bugs)