### PR TITLE
Meetup.com events without an end time don't break the importer

### DIFF
--- a/app/jobs/calendar_importer/events/meetup_event.rb
+++ b/app/jobs/calendar_importer/events/meetup_event.rb
@@ -42,8 +42,11 @@ module CalendarImporter::Events
     end
 
     def dtend
-      return dtstart + 1.hour if @event['duration'].nil?
-      dtstart + (@event['duration'] / 1000)
+      if @event['duration'].nil?
+        dtstart + 1.hour 
+      else
+        dtstart + (@event['duration'] / 1000)
+      end
     end
 
     def occurrences_between(*)

--- a/app/jobs/calendar_importer/events/meetup_event.rb
+++ b/app/jobs/calendar_importer/events/meetup_event.rb
@@ -42,6 +42,7 @@ module CalendarImporter::Events
     end
 
     def dtend
+      return dtstart if @event['duration'].nil?
       dtstart + (@event['duration'] / 1000)
     end
 

--- a/app/jobs/calendar_importer/events/meetup_event.rb
+++ b/app/jobs/calendar_importer/events/meetup_event.rb
@@ -42,7 +42,7 @@ module CalendarImporter::Events
     end
 
     def dtend
-      return dtstart if @event['duration'].nil?
+      return dtstart + 1.hour if @event['duration'].nil?
       dtstart + (@event['duration'] / 1000)
     end
 


### PR DESCRIPTION
Meetup events with missing durations end at the same time they start
(as a default value)