### PR TITLE
Remove buggy JS on calendar strategy selector

### DIFF
--- a/app/javascript/src/calendar-form.js
+++ b/app/javascript/src/calendar-form.js
@@ -4,9 +4,10 @@ import Vue from 'vue/dist/vue.esm'
 Vue.use(TurbolinksAdapter)
 
 document.addEventListener('turbo:load',  () => {
-  var element = document.getElementById('js-calendar-form')
+  /* var element = document.getElementById('js-calendar-form')
 
   if (element != null) {
+
     new Vue({
       el: element,
       data: {
@@ -19,5 +20,5 @@ document.addEventListener('turbo:load',  () => {
         }
       }
     })
-  }
+  } */
 })


### PR DESCRIPTION
It was causing some hiccoughs when the strategy was saved as it would stop the new selected value from being re-selected on page load.

Took out the Vue code that did the hiding/showing