### PR TITLE
Passthrough 'event' strategy if no location

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -159,6 +159,7 @@ class Event < ApplicationRecord
   end
 
   def require_location
+    return if self.calendar&.strategy == 'event'
     return unless self.address_id.blank?
 
     errors.add(:base, 'No place or address could be created or found for ' \


### PR DESCRIPTION
This is a workaround. We should remove this in the future. I consider
this the second most horrible code I've intentionally written.

- EventResolver#determine_location_for_strategy - passthrough 'event'
  strategy if no location / place / address
- Bypass validation error if strategy == 'event'
- EventResolver#save_all_occurences - Directly add error to notices