### PR TITLE
'Invite new partner admin' preselection doesn't stick

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -41,52 +41,51 @@ class UserPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    attrs = [ :first_name,
-              :last_name,
-              :email,
-              :phone,
-              :avatar,
-              partner_ids: []
-            ]
-    if user.root?
-      attrs << :role
-      attrs << { tag_ids: [] }
-      attrs << { neighbourhood_ids: [] }
-      attrs << :facebook_app_id
-      attrs << :facebook_app_secret
-    else
-      attrs
-    end
+    attrs = [
+      :first_name,
+      :last_name,
+      :email,
+      :phone,
+      :avatar,
+      { partner_ids: [] }
+    ]
+    root_attrs = [
+      :role,
+      :facebook_app_id,
+      :facebook_app_secret,
+      { tag_ids: [],
+        neighbourhood_ids: [] }
+    ]
+
+    user.root? ? attrs + root_attrs : attrs
   end
 
   def permitted_attributes_for_update
     if user.root?
       permitted_attributes
     elsif user.neighbourhood_admin?
-      [ partner_ids: [] ]
+      [partner_ids: []]
     end
   end
 
   def permitted_attributes_for_create
-    attrs = %i[
-      first_name
-      last_name
-      email
-      phone
-      avatar
-      partner_ids
+    attrs = [
+      :first_name,
+      :last_name,
+      :email,
+      :phone,
+      :avatar,
+      { partner_ids: [] }
     ]
-    root_attrs = %i[
-      role
-      tag_ids
-      neighbourhood_ids
-      facebook_app_id
-      facebook_app_secret
+    root_attrs = [
+      :role,
+      :facebook_app_id,
+      :facebook_app_secret,
+      { tag_ids: [],
+        neighbourhood_ids: [] }
     ]
 
-    return attrs + root_attrs if user.root?
-
-    attrs
+    user.root? ? attrs + root_attrs : attrs
   end
 
   def disabled_attributes_for_update

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -93,10 +93,13 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   it_allows_access_to_create_for(%i[root neighbourhood_admin]) do
+    @partner = create(:partner)
+    @user = attributes_for(:citizen, partner_ids: [@partner.id.to_s])
     assert_difference('User.count', 1) do
       post admin_users_url,
-           params: { user: attributes_for(:user) }
+           params: { user: @user }
     end
+    assert_equal 1, User.last.partners.length
   end
 
   it_denies_access_to_create_for(%i[citizen]) do

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -92,7 +92,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_root_url
   end
 
-  it_allows_access_to_create_for(%i[root neighbourhood_admin]) do
+  it_allows_access_to_create_for(%i[neighbourhood_admin]) do
     @partner = create(:partner)
     @user = attributes_for(:citizen, partner_ids: [@partner.id.to_s])
     assert_difference('User.count', 1) do
@@ -100,6 +100,24 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
            params: { user: @user }
     end
     assert_equal 1, User.last.partners.length
+  end
+
+  it_allows_access_to_create_for(%i[root]) do
+    @user = attributes_for(:citizen,
+                           partner_ids: [create(:partner).id.to_s],
+                           neighbourhood_ids: [create(:neighbourhood).id.to_s],
+                           tag_ids: [create(:tag).id.to_s])
+
+    assert_difference('User.count', 1) do
+      post admin_users_url,
+           params: { user: @user }
+    end
+
+    # We are just checking that the user has been created with the relations
+    # If it fails, these will be zero, so we only have to check length
+    assert_equal 1, User.last.partners.length
+    assert_equal 1, User.last.neighbourhoods.length
+    assert_equal 1, User.last.tags.length
   end
 
   it_denies_access_to_create_for(%i[citizen]) do


### PR DESCRIPTION
- Fixes `user_policy#permitted_attributes` and `user_policy#permitted_attributes_for_create`
- Adds test for `partner_ids` property when creating a new user for `neighbourhood_admin`
- Adds test for `partner_ids`, `neighbourhood_ids`, and `tag_ids` when creating a new user for `root`