### PR TITLE
Stop semrushbot/ahrefsbot/bing spam after calendar reimport

### DIFF
--- a/config/robots/robots.production.txt
+++ b/config/robots/robots.production.txt
@@ -3,3 +3,7 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-agent: *
 # Disallow: /
+
+User-agent: *
+Disallow: /assets/
+Disallow: /events/

--- a/config/robots/robots.production.txt
+++ b/config/robots/robots.production.txt
@@ -6,4 +6,3 @@
 
 User-agent: *
 Disallow: /assets/
-Disallow: /events/


### PR DESCRIPTION
Adds a robots.txt to production to disallow web search engine scrapers from the /events/ and /assets/ pages. This is to stop us losing access to Rollbar when events on the server are refreshed and the ids become invalid. Assets has been denied to see if it reduces illegitimate bot scraping attempts.

Fixes #1230