### PR TITLE
Importing notices no longer halt the entire job

### DIFF
--- a/app/jobs/calendar_importer/calendar_importer_task.rb
+++ b/app/jobs/calendar_importer/calendar_importer_task.rb
@@ -62,6 +62,9 @@ class CalendarImporter::CalendarImporterTask
       active_event_uids << parsed_event.uid
 
       parsed_event.save_all_occurences
+
+    rescue CalendarImporter::EventResolver::Problem => e
+      notices << e.message
     end
 
     purge_stale_events_from_calendar all_event_uids - active_event_uids

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -149,7 +149,8 @@ class CalendarImporter::EventResolver
       place = nil
 
     else
-      raise Problem, "Calendar import strategy unknown! (#{calendar.strategy})"
+      # this shouldn't happen and should be fatal to the entire job
+      raise "Calendar import strategy unknown! (ID=#{calendar.id}, strategy=#{calendar.strategy})"
     end
 
     data.place_id = place.id if place


### PR DESCRIPTION
When importing a calendar, problems with individual events are logged to
the calendar.