### PR TITLE
1238 - Add OnlineAddress and online_only import strategy

### DIFF
--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -52,8 +52,12 @@ module CalendarsHelper
       'is set to another location'.html_safe
     when 'no_location'
       '<strong>No Location</strong>: ' \
-      'Events imported will have no location information set in PlaceCal, even if it is present on' \
+      'Events imported will have no location information set in PlaceCal, even if it is present on ' \
       'the remote feed'.html_safe
+    when 'online_only'
+      '<strong>Online Only</strong>: ' \
+      'Events imported will have no physical location information set in PlaceCal, even if it is present on ' \
+      'the remote feed, but will maintain the online information'.html_safe
     else
       val
     end

--- a/app/jobs/calendar_importer/calendar_importer_task.rb
+++ b/app/jobs/calendar_importer/calendar_importer_task.rb
@@ -75,6 +75,6 @@ class CalendarImporter::CalendarImporterTask
   end
 
   def purge_stale_events_from_calendar(stale_event_uids)
-    calendar.events.upcoming.where( uid: stale_event_uids).destroy_all
+    calendar.events.upcoming.where(uid: stale_event_uids).destroy_all
   end
 end

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -47,14 +47,15 @@ class CalendarImporter::EventResolver
     strategies = {
       'event' => :event_strategy,
       'event_override' => :event_override_strategy,
-      'room_number' => :room_number_strategy,
       'place' => :place_strategy,
-      'no_location' => :no_location_strategy
+      'room_number' => :room_number_strategy,
+      'no_location' => :no_location_strategy,
+      'online_only' => :online_only_strategy
     }
 
     if strategies.keys.include?(calendar.strategy)
       strategy = strategies[calendar.strategy]
-      place, address = self.public_send(strategy, calendar.place)
+      place, address = method(strategy).call(calendar.place)
     else
       # this shouldn't happen and should be fatal to the entire job
       raise "Calendar import strategy unknown! (ID=#{calendar.id}, strategy=#{calendar.strategy})"
@@ -172,6 +173,10 @@ class CalendarImporter::EventResolver
   end
 
   def no_location_strategy(_place, _address: nil)
+    return nil, nil
+  end
+
+  def online_only_strategy(_place, _address: nil)
     return nil, nil
   end
 

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -10,8 +10,7 @@ class CalendarImporter::EventResolver
 
   attr_reader :data, :uid, :notices, :calendar
 
-  class Problem < StandardError
-  end
+  class Problem < StandardError; end
 
   def initialize(event_data, calendar, notices, from_date)
     @data = event_data
@@ -38,8 +37,6 @@ class CalendarImporter::EventResolver
   end
 
   def determine_location_for_strategy
-    place = calendar.place
-
     # this algorithm is derived from the notion doc at
     #   GFSC
     #     PlaceCal
@@ -47,107 +44,17 @@ class CalendarImporter::EventResolver
     #         PlaceCal developer handbook
     #           How does the Calendar importer detect Places and Addresses?
 
-    case calendar.strategy
-    when 'event'
-      if data.has_location?
+    strategies = {
+      'event' => :event_strategy,
+      'event_override' => :event_override_strategy,
+      'room_number' => :room_number_strategy,
+      'place' => :place_strategy,
+      'no_location' => :no_location_strategy
+    }
 
-        # place = 'attempt to match location'
-        # address = 'calendar.place.address || location'
-
-        # try to find the place
-        place = Partner.fuzzy_find_by_location(event_location_components)
-
-        # try to use that address
-        address = place&.address
-
-        # if no place, try to find an address
-        # (This only executes if there is no place given)
-        address ||= Address.search(data.location, event_location_components, data.postcode)
-
-        # if we have an address, try to use the place that address points to
-        # (Only runs if the fuzzy find and calendar.place are both nil)
-        place ||= address&.partners&.first
-
-        # NOTE: What happens if address has zero partners and the earlier assignments fail?
-        #       'place' is nil in this instance
-        # NOTE: Address.search can also return Nil if there are no event_location_components, or
-        #       if the address failed to save
-        # Both of these will cause the event to fail validation with "No place or address could be created/found (etc)"
-
-      else # no location
-        raise Problem, WARNING2_MSG if place.present?
-        # No longer an error if place is not present -- see #1198
-        # Passthrough here
-      end
-
-    when 'event_override'
-      if data.has_location?
-        # place = 'attempt to match location'
-        # address = 'calendar.place.address || location'
-        place = Partner.fuzzy_find_by_location(event_location_components)
-        address = place&.address
-        address ||= Address.search(data.location, event_location_components, data.postcode)
-
-        raise Problem, INFO1_MSG if place.nil? && address.nil?
-
-        # NOTE: Either one of 'place' or 'address' is unset here but not both
-        # NOTE: place is possibly unset here - fuzzy_find_by_location can be nil
-        # NOTE: address is possibly unset here - place might be nil or Address.search can return nil
-        #       In either case we will just drop this event on the floor
-      else # no location
-        if place.present?
-          # place = 'calendar.place'
-          # address = 'calendar.place.address'
-          place = calendar.place
-          address = place.address
-
-        else # no place, no location
-          raise Problem, WARNING1_MSG
-        end
-      end
-
-    when 'place' # location
-      # Regardless of if the data has a location, we act the same
-      # We assign address to the place's address if possible, and otherwise we exit
-
-      # This should theoretically never run ! :) (At least, it's not accounted for in Kim's table)
-      raise Problem, 'N/A - Unaccounted for in table' if calendar.place.nil?
-
-      address = calendar.place.address
-
-      # NOTE: calendar.place can be nil, in which case this event will be dropped on the floor
-      #       (Likely what is happening with Velociposse?)
-
-    when 'room_number'
-      if data.has_location?
-        if place.present?
-          # place = 'calendar.place'
-          # address = '#{location}, place.address'
-
-          # xx place = calendar.place.address
-          new_address = place.address.dup
-          address = new_address.prepend_room_number(data.location)
-          address.save
-
-        else # no place, yes location
-          raise Problem, 'N/A'
-        end
-
-      else # no location
-        if place.present?
-          # place = 'calendar.place'
-          # address = 'calendar.place.address'
-          # xx place = calendar.place.address
-          address = place.address
-
-        else # no place, no location
-          raise Problem, 'N/A'
-        end
-      end
-
-    when 'no_location'
-      place = nil
-
+    if strategies.keys.include?(calendar.strategy)
+      strategy = strategies[calendar.strategy]
+      place, address = self.public_send(strategy, calendar.place)
     else
       # this shouldn't happen and should be fatal to the entire job
       raise "Calendar import strategy unknown! (ID=#{calendar.id}, strategy=#{calendar.strategy})"
@@ -156,6 +63,116 @@ class CalendarImporter::EventResolver
     data.place_id = place.id if place
     data.address_id = address&.id
     data.partner_id = calendar.partner_id
+  end
+
+  def event_strategy(place, address: nil)
+    if data.has_location?
+      # place = 'attempt to match location'
+      # address = 'calendar.place.address || location'
+
+      # try to find the place
+      place = Partner.fuzzy_find_by_location(event_location_components)
+
+      # try to use that address
+      address = place&.address
+
+      # if no place, try to find an address
+      # (This only executes if there is no place given)
+      address ||= Address.search(data.location, event_location_components, data.postcode)
+
+      # if we have an address, try to use the place that address points to
+      # (Only runs if the fuzzy find and calendar.place are both nil)
+      place ||= address&.partners&.first
+
+      # NOTE: What happens if address has zero partners and the earlier assignments fail?
+      #       'place' is nil in this instance
+      # NOTE: Address.search can also return Nil if there are no event_location_components, or
+      #       if the address failed to save
+      # Both of these will cause the event to fail validation with "No place or address could be created/found (etc)"
+
+    else # no location
+      raise Problem, WARNING2_MSG if place.present?
+      # No longer an error if place is not present -- see #1198
+      # Passthrough here
+    end
+
+    return place, address
+  end
+
+  def event_override_strategy(place, address: nil)
+    if data.has_location?
+      # place = 'attempt to match location'
+      # address = 'calendar.place.address || location'
+      place = Partner.fuzzy_find_by_location(event_location_components)
+      address = place&.address
+      address ||= Address.search(data.location, event_location_components, data.postcode)
+
+      raise Problem, INFO1_MSG if place.nil? && address.nil?
+
+      # NOTE: Either one of 'place' or 'address' is unset here but not both
+      # NOTE: place is possibly unset here - fuzzy_find_by_location can be nil
+      # NOTE: address is possibly unset here - place might be nil or Address.search can return nil
+      #       In either case we will just drop this event on the floor
+    else # no location
+      if place.present?
+        # place = 'calendar.place'
+        # address = 'calendar.place.address'
+        place = calendar.place
+        address = place.address
+
+      else # no place, no location
+        raise Problem, WARNING1_MSG
+      end
+    end
+
+    return place, address
+  end
+
+  def place_strategy(_place, _address: nil)
+    # Regardless of if the data has a location, we act the same
+    # We assign address to the place's address if possible, and otherwise we exit
+
+    # This should theoretically never run ! :) (At least, it's not accounted for in Kim's table)
+    raise Problem, 'N/A - Unaccounted for in table' if calendar.place.nil?
+
+    return calendar.place, calendar.place.address
+
+    # NOTE: calendar.place can be nil, in which case this event will be dropped on the floor
+    #       (Likely what is happening with Velociposse?)
+  end
+
+  def room_number_strategy(place, address: nil)
+    if data.has_location?
+      if place.present?
+        # place = 'calendar.place'
+        # address = '#{location}, place.address'
+
+        # xx place = calendar.place.address
+        new_address = place.address.dup
+        address = new_address.prepend_room_number(data.location)
+        address.save
+
+      else # no place, yes location
+        raise Problem, 'N/A'
+      end
+
+    else # no location
+      if place.present?
+        # place = 'calendar.place'
+        # address = 'calendar.place.address'
+        # xx place = calendar.place.address
+        address = place.address
+
+      else # no place, no location
+        raise Problem, 'N/A'
+      end
+    end
+
+    return address, place
+  end
+
+  def no_location_strategy(_place, _address: nil)
+    return nil, nil
   end
 
   def save_all_occurences

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -32,7 +32,7 @@ class Calendar < ApplicationRecord
   # @attr [Enumerable<Symbol>] :strategy
   enumerize(
     :strategy,
-    in: %i[event place room_number event_override no_location],
+    in: %i[event place room_number event_override no_location online_only],
     default: :place,
     scope: true
   )

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,7 @@ class Event < ApplicationRecord
   belongs_to :partner, optional: true
   belongs_to :place, class_name: 'Partner', optional: true
   belongs_to :address, optional: true
+  belongs_to :online_address, optional: true
   belongs_to :calendar, optional: true
   has_and_belongs_to_many :collections
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -181,6 +181,7 @@ class Event < ApplicationRecord
                        .positive?
 
     errors.add(:base, 'Unfortunately this event is a duplicate of an ' \
-                      "existing event for calendar: #{calendar_id}")
+                      "existing event for calendar: #{calendar_id} " \
+                      "('#{calendar.name}')")
   end
 end

--- a/app/models/online_address.rb
+++ b/app/models/online_address.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class OnlineAddress < ApplicationRecord
+  has_many :events
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -18,7 +18,7 @@ class Tag < ApplicationRecord
   has_many :sites, through: :sites_tag
 
   has_many :article_tags, dependent: :destroy
-  has_many :articles, through: :articles_tags
+  has_many :articles, through: :article_tags
 
   validates :name, :slug, presence: true
   validates :name, :slug, uniqueness: true

--- a/app/views/admin/calendars/_status.html.erb
+++ b/app/views/admin/calendars/_status.html.erb
@@ -1,1 +1,1 @@
-<p class="badge badge-<%= @calendar.state_colour %>"><%= @calendar.calendar_state %></p>
+<h4><span class="badge badge-<%= @calendar.state_colour %>"><%= @calendar.calendar_state %></span></h4>

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This means that we can't tangibly run over 1hr 30m for a single calendar import.
+# This tangibly means that we don't lock up the delayed job resources forever (>4 hrs lol)
+Delayed::Worker.sleep_delay = 60
+Delayed::Worker.max_attempts = 4
+Delayed::Worker.max_run_time = 20.minutes
+
+# These are not defaults from delayed job I just grabbed them from a website somewhere
+# Delayed::Worker.destroy_failed_jobs = false
+# Delayed::Worker.read_ahead = 10
+# Delayed::Worker.default_queue_name = 'default'
+# Delayed::Worker.delay_jobs = !Rails.env.test?
+# Delayed::Worker.raise_signal_exceptions = :term
+# Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))

--- a/db/migrate/20220512144807_create_online_addresses.rb
+++ b/db/migrate/20220512144807_create_online_addresses.rb
@@ -1,0 +1,9 @@
+class CreateOnlineAddresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :online_addresses do |t|
+      t.string :url
+      t.timestamps
+    end
+    add_reference :events, :online_address, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_05_12_144807) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,7 +80,6 @@ ActiveRecord::Schema.define(version: 2022_05_12_144807) do
     t.string "public_contact_email"
     t.string "public_contact_phone"
     t.integer "notice_count"
-    t.string "source_type", default: ""
     t.string "calendar_state", default: "idle"
     t.index ["partner_id"], name: "index_calendars_on_partner_id"
     t.index ["place_id"], name: "index_calendars_on_place_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_12_135923) do
-
+ActiveRecord::Schema.define(version: 2022_05_12_144807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -136,7 +135,9 @@ ActiveRecord::Schema.define(version: 2022_05_12_135923) do
     t.string "are_spaces_available"
     t.text "footer"
     t.string "publisher_url"
+    t.bigint "online_address_id"
     t.index ["calendar_id"], name: "index_events_on_calendar_id"
+    t.index ["online_address_id"], name: "index_events_on_online_address_id"
     t.index ["place_id"], name: "index_events_on_place_id"
   end
 
@@ -171,6 +172,12 @@ ActiveRecord::Schema.define(version: 2022_05_12_135923) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["neighbourhood_id"], name: "index_neighbourhoods_users_on_neighbourhood_id"
     t.index ["user_id"], name: "index_neighbourhoods_users_on_user_id"
+  end
+
+  create_table "online_addresses", force: :cascade do |t|
+    t.string "url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "organisation_relationships", force: :cascade do |t|
@@ -392,6 +399,7 @@ ActiveRecord::Schema.define(version: 2022_05_12_135923) do
   add_foreign_key "calendars", "partners", column: "place_id"
   add_foreign_key "events", "addresses"
   add_foreign_key "events", "calendars"
+  add_foreign_key "events", "online_addresses"
   add_foreign_key "events", "partners"
   add_foreign_key "events", "partners", column: "place_id"
   add_foreign_key "organisation_relationships", "partners", column: "object_id"

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -1,18 +1,74 @@
 # frozen_string_literal: true
 
+require 'yaml'
+
 namespace :workers do
   desc 'Clear and remove all jobs'
   task purge_all: [] do
+    puts 'Force stopping all workers...'
+
     # Force stop of all workers
     Rake::Task['jobs:clear'].invoke
 
+    puts 'Purging the workers table to remove zombie jobs'
+
     # Purge the workers table to remove zombie jobs
     ActiveRecord::Base.connection.execute('truncate delayed_jobs')
+
+    puts 'Reset Calendars that have :in_worker or :in_queue'
 
     # Reset the :in_worker and :in_queue
     Calendar.where(calendar_state: %i[in_worker in_queue]).each do |c|
       c.calendar_state = :idle
       c.save!
     end
+  end
+
+  desc 'Show any salient worker errors (You should pipe this into less)'
+  task inspect_errors: [] do
+    workers = ActiveRecord::Base.connection
+                                .execute('select * from delayed_jobs')
+                                .to_a
+                                .reject { |w| w[:last_error].nil? }
+
+    workers.each { |w| pp w }
+  end
+
+  # This is patchy and we should move to a callback-based system. Works for now though
+  desc 'Synchronise Calendars with job state'
+  task sync_state: :environment do
+    puts 'Finding active workers...'
+
+    # Find all the Calendars that are actually running
+    active_calendars = ActiveRecord::Base.connection.execute('select * from delayed_jobs').to_a.map do |w|
+      # We need to strip the first line because Rails adds some non-YAML
+      handler_content = w['handler'].lines[1..].join
+      job_data = YAML.safe_load(handler_content)
+
+      # Calendar ID is the first argument to the job
+      job_data['job_data']['arguments'].first
+    end
+
+    puts 'Finding Calendars listed as active...'
+
+    # Find all the Calendars that are listed as running
+    listed_active_calendars = Calendar.where(calendar_state: %i[in_worker in_queue]).map(&:id)
+
+    pp [active: active_calendars, listed_active_calendars: listed_active_calendars]
+
+    # Prune the listed Calendars to find ones that are not running, but are listed as such
+    ids_to_unset = listed_active_calendars.reject { |calendar_id| active_calendars.include?(calendar_id) }
+
+    puts "Calendar IDs listed as running that are not running: #{ids_to_unset}"
+    puts 'Removing those calendars...' if ids_to_unset.length.positive?
+
+    # Set the Calendars that are not running as such
+    ids_to_unset.each do |id|
+      c = Calendar.find(id)
+      c.calendar_state = :idle
+      c.save!
+    end
+
+    puts 'Done.'
   end
 end

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :workers do
+  desc 'Clear and remove all jobs'
+  task purge_all: [] do
+    # Force stop of all workers
+    Rake::Task['jobs:clear'].invoke
+
+    # Purge the workers table to remove zombie jobs
+    ActiveRecord::Base.connection.execute('truncate delayed_jobs')
+
+    # Reset the :in_worker and :in_queue
+    Calendar.where(calendar_state: %i[in_worker in_queue]).each do |c|
+      c.calendar_state = :idle
+      c.save!
+    end
+  end
+end

--- a/test/factories/online_addresses.rb
+++ b/test/factories/online_addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :online_address do
+    url { "MyString" }
+  end
+end

--- a/test/helpers/calendars_helper_test.rb
+++ b/test/helpers/calendars_helper_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class CalendarsHelperTest < ActionView::TestCase
   include Devise::Test::IntegrationHelpers
-  include Pundit
+  include Pundit::Authorization
 
   setup do
     @root = create(:root)

--- a/test/jobs/calendar_importer/event_resolver_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_test.rb
@@ -1,20 +1,19 @@
 require 'test_helper'
 
 class EventsResolverTest < ActiveSupport::TestCase
+  FakeEvent = Struct.new(
+    :uid,
+    :summary,
+    :description,
+    :location,
+    :rrule,
+    :last_modified,
+    :ocurrences_between
+  )
 
-  test "no location strategy" do
-    FakeEvent = Struct.new(
-      :uid,
-      :summary,
-      :description,
-      :location,
-      :rrule,
-      :last_modified,
-      :ocurrences_between
-    )
-
-    start_date = Date.new(1990, 1, 1)
-    end_date = Date.new(1990, 1, 2)
+  setup do
+    @start_date = Date.new(1990, 1, 1)
+    @end_date = Date.new(1990, 1, 2)
 
     fake_event = FakeEvent.new(
       uid: 123,
@@ -23,16 +22,18 @@ class EventsResolverTest < ActiveSupport::TestCase
       location: 'A location',
       rrule: '',
       last_modified: '',
-      ocurrences_between: [[start_date, end_date]]
+      ocurrences_between: [[@start_date, @end_date]]
     )
 
-    event_data = CalendarImporter::Events::IcsEvent.new(fake_event, start_date, end_date)
+    @event_data = CalendarImporter::Events::IcsEvent.new(fake_event, @start_date, @end_date)
+  end
 
-    calendar = create(:calendar, strategy: 'no_location')
+  test 'online only strategy' do
+    calendar = create(:calendar, strategy: 'online_only')
     notices = []
-    from_date = start_date
+    from_date = @start_date
 
-    resolver = CalendarImporter::EventResolver.new(event_data, calendar, notices, from_date)
+    resolver = CalendarImporter::EventResolver.new(@event_data, calendar, notices, from_date)
     resolver.determine_location_for_strategy
 
     # these are not set even if present in source
@@ -41,7 +42,21 @@ class EventsResolverTest < ActiveSupport::TestCase
 
     # still sets partner
     assert_equal calendar.partner_id, resolver.data.partner_id
+  end
 
+  test 'no location strategy' do
+    calendar = create(:calendar, strategy: 'no_location')
+    notices = []
+    from_date = @start_date
+
+    resolver = CalendarImporter::EventResolver.new(@event_data, calendar, notices, from_date)
+    resolver.determine_location_for_strategy
+
+    # these are not set even if present in source
+    assert_nil resolver.data.place_id
+    assert_nil resolver.data.address_id
+
+    # still sets partner
+    assert_equal calendar.partner_id, resolver.data.partner_id
   end
 end
-

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -5,13 +5,12 @@ require 'test_helper'
 class AddressTest < ActiveSupport::TestCase
   test 'normalizes postcode' do
     Geocoder.stub :search, [] do
-
       table = [
-        [ '   w1w 5aa', 'W1W 5AA' ],
-        [ 'ng12 4fz  ', 'NG12 4FZ' ],
-        [ '  ha8  8ha ', 'HA8 8HA'],
-        [ 'W1W5AA', 'W1W 5AA' ],
-        [ 'W1W      5AA', 'W1W 5AA' ]
+        ['   w1w 5aa', 'W1W 5AA'],
+        ['ng12 4fz  ', 'NG12 4FZ'],
+        ['  ha8  8ha ', 'HA8 8HA'],
+        ['W1W5AA', 'W1W 5AA'],
+        ['W1W      5AA', 'W1W 5AA']
       ]
 
       table.each do |try_data, expected_output|

--- a/test/models/online_address_test.rb
+++ b/test/models/online_address_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AddressTest < ActiveSupport::TestCase
+  test 'can create online address with event' do
+    event = create(:event)
+    online_address = create(:online_address)
+    online_address.events << event
+    online_address.save!
+
+    assert_equal event.online_address.id, online_address.id
+    assert_equal online_address.events.first.id, event.id
+  end
+end


### PR DESCRIPTION
Fixes #1238

Draft because I want to isolate a bug that's happening and confirm I didn't add it lol

- refactor: strategy refactor
- feat: add online address model
- feat: add 'online_only' strategy to importer
- chore: make rake shut up about pundit
- feat: make calendar clear to user in error log
- feat: make import status more visible (bigger)
- feat: limit delayed job run time
- feat: add purge rake task for delayed jobs
- feat: add task for fixing calendar status