### PR TITLE
Bug: Events should not set their own address

### DIFF
--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -225,9 +225,9 @@ class CalendarImporter::EventResolver
 
     regexp = Regexp.new(regex_string, Regexp::IGNORECASE)
 
-    @event_location_components = data.location
-                                     .split(', ')
-                                     .map { |component| component.gsub(regexp, '').strip }
-                                     .reject(&:blank?)
+    @event_location_components = (data.location || '')
+      .split(', ')
+      .map { |component| component.gsub(regexp, '').strip }
+      .reject(&:blank?)
   end
 end

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -118,7 +118,7 @@ class CalendarImporter::EventResolver
       if place.present?
         # place = 'calendar.place'
         # address = 'calendar.place.address'
-        place = calendar.place
+        # place = calendar.place
         address = place.address
 
       else # no place, no location

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -103,6 +103,8 @@ class Address < ApplicationRecord
     # location - The raw location field
     # components - Array containing parts of an event's location field, excluding the postcode.
     def search(_location, components, postcode)
+      return nil if components.empty?
+
       # try by street name string match
       address = Address.find_by('lower(street_address) IN (?)', components.map(&:downcase))
       return address if address

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,7 +12,6 @@ class Event < ApplicationRecord
   has_and_belongs_to_many :collections
 
   validates :summary, :dtstart, :partner, presence: true
-  before_validation :set_address_from_place
   validate :require_location
   validate :unique_event
 
@@ -151,13 +150,6 @@ class Event < ApplicationRecord
   end
 
   private
-
-  # Make sure that setting the event's Place also sets the event's Address. This
-  # way we never need to choose between Event#address and Event#place.address
-  # This is particularly important for joins for neighbourhoods.
-  def set_address_from_place
-    self.address_id = self.place.address_id if self.place_id
-  end
 
   def require_location
     if calendar.present?

--- a/test/jobs/calendar_importer/event_resolver_strategy_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_strategy_test.rb
@@ -1,0 +1,114 @@
+require 'test_helper'
+require 'minitest/spec'
+
+=begin
+
+- If event location is set and calendar strategy is 'event' or 'override', that location should be used instead of the partner's place
+- if event strategy is place, then it continues to work correctly
+- if event strategy is override and location is not set, it continues to work correctly
+
+1.
+  event strategy
+  overide strategy
+  event source location is present
+  address = source.location
+
+2.
+  place strategy
+  address = source.location
+
+3.
+  override strategy
+  address = partner.location
+
+=end
+
+describe 'EventResolver strategies' do
+  # include FactoryBot::Syntax::Methods
+
+  FakeEvent = Struct.new(
+    :uid,
+    :summary,
+    :description,
+    :location,
+    :rrule,
+    :last_modified,
+    :ocurrences_between
+  )
+
+  describe 'event_strategy' do
+    let(:neighbourhood) { @neighbourhood ||= FactoryBot.create(:neighbourhood, unit_code_value: 'E05011368' ) }
+
+    let(:start_date) { Date.new(1990, 1, 1) }
+    let(:end_date) { Date.new(1990, 1, 2) }
+
+    let(:address) { FactoryBot.create(:address, neighbourhood: neighbourhood, postcode: 'M15 5DD') }
+    let(:address_partner) do
+      Partner.first.tap do |partner|
+        partner.update! address: address
+      end
+      #FactoryBot.create(:partner, address: address)
+    end
+
+    describe 'with data.location' do
+      describe 'with place' do
+        it 'uses partner place and adress' do
+          # neighbourhood =
+          puts '>>>'
+          #puts neighbourhood.to_json
+          puts Partner.count
+          puts Calendar.count
+
+          data = FakeEvent.new(
+            uid: 123,
+            summary: 'A summary',
+            description: 'A description',
+            location: address_partner.name,
+            rrule: '',
+            last_modified: '',
+            ocurrences_between: [[start_date, end_date]]
+          )
+
+          calendar = FactoryBot.create(:calendar)
+          notices = []
+          from_date = Date.new(1990, 1, 1)
+
+          resolver = CalendarImporter::EventResolver.new(data, calendar, notices, from_date)
+          place, address = resolver.event_strategy(calendar.place)
+
+        end
+      end
+
+      describe 'with address' do
+        it 'fuzzy finds address and place'
+      end
+
+      describe 'with no place or address' do
+        it 'returns nothing'
+      end
+    end
+    describe 'with no data.location' do
+      it 'stops processing with an exception'
+    end
+  end
+
+  describe 'event_overide' do
+  end
+
+  describe 'place' do
+  end
+
+  describe 'room_number' do
+  end
+
+end
+
+
+
+class FakeTest < ActiveSupport::TestCase
+  test "look at db" do
+    puts '***'
+    puts Partner.count
+    puts Calendar.count
+  end
+end


### PR DESCRIPTION
When an event is imported a factory is employed to give the event the
correct place/address. Therefore the event itself no longer has this
business logic in it

Fixes #1244