### PR TITLE
Make online address visible in PlaceCal/GraphQL

### DIFF
--- a/app/components/event/event_component.rb
+++ b/app/components/event/event_component.rb
@@ -82,6 +82,10 @@ class EventComponent < MountainView::Presenter
     event.neighbourhood == primary_neighbourhood || primary_neighbourhood.children.include?(event.neighbourhood)
   end
 
+  def online?
+    event.online_address.present?
+  end
+
   private
 
   def fmt_time(time)

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -39,17 +39,18 @@ module Types
           description: 'The URL of the partners original page'
 
     field :onlineEventUrl, String,
-          description: 'The URL of the event. Can be an event link e.g. Eventbrite, or a Zoom/Meet/Jitsi link'
+          description: 'The URL of the online event. Can be an event link e.g. Eventbrite, or a Zoom/Meet/Jitsi link'
 
-    field :isOnlineStream, String,
-          description: 'Whether the url is to an event (e.g. Eventbrite event ticketing) or a stream (e.g. Zoom join link)'
+    field :onlineEventUrlType, String,
+          description: 'Whether the URL of the online event is a link to the live stream (direct)'\
+                       ' or to an intermediary (indirect).'
 
     def onlineEventUrl
       object&.online_address&.url
     end
 
-    def isOnlineStream
-      object&.online_address&.is_stream
+    def onlineEventUrlType
+      object&.online_address&.link_type
     end
   end
 end

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -3,41 +3,53 @@ module Types
     description 'An event represents a date in time that a partner operates their service, meetup, workout or class etc'
 
     field :id, ID,
-      null: false,
-      description: 'Our internal ID for further querying'
+          null: false,
+          description: 'Our internal ID for further querying'
 
     # Summary and name are aliases, this is left as a convenience
     #   for people used to iCal format
     field :name, String,
-      method: :summary,
-      description: 'An alias for `summary`'
+          method: :summary,
+          description: 'An alias for `summary`'
 
     field :summary, String,
-      description: 'The title of the event'
+          description: 'The title of the event'
 
     field :description, String,
-      description: 'A longer text about this event covering more detail'
+          description: 'A longer text about this event covering more detail'
 
     field :startDate, GraphQL::Types::ISO8601DateTime,
-      method: :dtstart,
-      null: false,
-      description: 'The date (and time) when this event begins'
+          method: :dtstart,
+          null: false,
+          description: 'The date (and time) when this event begins'
 
     field :endDate, GraphQL::Types::ISO8601DateTime,
-      method: :dtend,
-      description: 'The end date of this event if the event goes on for more than one day (i.e. a conference weekend)'
+          method: :dtend,
+          description: 'The end date of this event if the event goes on for more than one day (i.e. a conference weekend)'
 
     field :address, AddressType,
-      description: 'The address where this event will take place'
+          description: 'The address where this event will take place'
 
     field :organizer, PartnerType,
-      method: :partner,
-      description: 'The organising partner of this event'
+          method: :partner,
+          description: 'The organising partner of this event'
 
     field :publisherUrl, String,
-      method: :publisher_url,
-      description: 'The URL of the partners original page'
+          method: :publisher_url,
+          description: 'The URL of the partners original page'
 
+    field :onlineEventUrl, String,
+          description: 'The URL of the event. Can be an event link e.g. Eventbrite, or a Zoom/Meet/Jitsi link'
+
+    field :isOnlineStream, String,
+          description: 'Whether the url is to an event (e.g. Eventbrite event ticketing) or a stream (e.g. Zoom join link)'
+
+    def onlineEventUrl
+      object&.online_address&.url
+    end
+
+    def isOnlineStream
+      object&.online_address&.is_stream
+    end
   end
 end
-

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -21,8 +21,8 @@ module EventsHelper
     # If the online address has a web stream, we want a direct link to join that
     # Otherwise we should probably only show the online url if publisher_url is missing,
     # to avoid having two links that head to the same place
-    if online_address.is_stream?
-      link_to('Visit this web stream',
+    if online_address.link_type == :stream
+      link_to('Join this meeting',
               online_address.url,
               class: 'btn btn-primary').html_safe
     elsif @event.publisher_url.blank?

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -8,10 +8,27 @@ module EventsHelper
   def event_link(event)
     return if @event.publisher_url.blank?
 
-    link_to(
-      'Visit the webpage for this event',
-      event.publisher_url,
-      class: 'btn btn-primary'
-    ).html_safe
+    link_to('Visit the webpage for this event',
+            event.publisher_url,
+            class: 'btn btn-primary').html_safe
+  end
+
+  def online_link
+    online_address = @event&.online_address
+
+    return if online_address.nil?
+
+    # If the online address has a web stream, we want a direct link to join that
+    # Otherwise we should probably only show the online url if publisher_url is missing,
+    # to avoid having two links that head to the same place
+    if online_address.is_stream?
+      link_to('Visit this web stream',
+              online_address.url,
+              class: 'btn btn-primary').html_safe
+    elsif @event.publisher_url.blank?
+      link_to('Visit the webpage for this stream',
+              online_address.url,
+              class: 'btn btn-primary').html_safe
+    end
   end
 end

--- a/app/jobs/calendar_importer/calendar_importer.rb
+++ b/app/jobs/calendar_importer/calendar_importer.rb
@@ -31,16 +31,18 @@ class CalendarImporter::CalendarImporter
 
   private
 
+  # This validates the feed URL to ensure that we do support it, and that it's live on the internet
+  # As a side effect, it runs CalendarImporter#parser, which sets self.parser to one of the values above
+  # This ensures that self.parser is set during calendar_importer_task
   def validate_feed!
-    raise InaccessibleFeed, "The URL could not be reached for calendar #{@calendar.name}" unless is_url_accessible?
+    raise InaccessibleFeed, "The URL could not be reached for calendar #{@calendar.name}" unless url_accessible?
     raise UnsupportedFeed, 'The provided URL is not supported' unless parser.present?
   end
 
-  def is_url_accessible?
+  def url_accessible?
     response = HTTParty.get(@calendar.source, follow_redirects: true)
     response.code == 200
   rescue
     false
   end
-
 end

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -65,7 +65,8 @@ class CalendarImporter::EventResolver
       raise "Calendar import strategy unknown! (ID=#{calendar.id}, strategy=#{calendar.strategy})"
     end
 
-    # NOTE: Data is a... Calendar object? Huh??
+    # NOTE: In this context, data is a calendar object. But this doesn't make sense because
+    #       determine_online_location sees a CalendarImporter::Events::IcsEvent object?
     data.place_id = place.id if place
     data.address_id = address&.id
     data.partner_id = calendar.partner_id

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -65,6 +65,7 @@ class CalendarImporter::EventResolver
       raise "Calendar import strategy unknown! (ID=#{calendar.id}, strategy=#{calendar.strategy})"
     end
 
+    # NOTE: Data is a... Calendar object? Huh??
     data.place_id = place.id if place
     data.address_id = address&.id
     data.partner_id = calendar.partner_id
@@ -173,7 +174,7 @@ class CalendarImporter::EventResolver
       end
     end
 
-    return address, place
+    return place, address
   end
 
   def no_location_strategy(_place, _address: nil)

--- a/app/jobs/calendar_importer/events/eventbrite_event.rb
+++ b/app/jobs/calendar_importer/events/eventbrite_event.rb
@@ -67,7 +67,7 @@ module CalendarImporter::Events
     def online_event?
       return nil unless @event['online_event']
 
-      online_address = OnlineAddress.find_or_create_by(url: @event['url'])
+      online_address = OnlineAddress.find_or_create_by url: @event['url'], is_stream: false
       online_address.id
     end
   end

--- a/app/jobs/calendar_importer/events/eventbrite_event.rb
+++ b/app/jobs/calendar_importer/events/eventbrite_event.rb
@@ -67,7 +67,7 @@ module CalendarImporter::Events
     def online_event?
       return nil unless @event['online_event']
 
-      online_address = OnlineAddress.find_or_create_by url: @event['url'], is_stream: false
+      online_address = OnlineAddress.find_or_create_by url: @event['url'], link_type: 'indirect'
       online_address.id
     end
   end

--- a/app/jobs/calendar_importer/events/eventbrite_event.rb
+++ b/app/jobs/calendar_importer/events/eventbrite_event.rb
@@ -67,7 +67,7 @@ module CalendarImporter::Events
     def online_event?
       return nil unless @event['online_event']
 
-      online_address = OnlineAddress.find_or_create_by url: @event['url'], link_type: 'indirect'
+      online_address = OnlineAddress.find_or_create_by(url: @event['url'], link_type: 'indirect')
       online_address.id
     end
   end

--- a/app/jobs/calendar_importer/events/ics_event.rb
+++ b/app/jobs/calendar_importer/events/ics_event.rb
@@ -59,8 +59,8 @@ module CalendarImporter::Events
       # (The match object returns ICal Text, not a String, so we have to cast)
       # (We can't use .first here because the match object doesn't support it!)
       #
-      online_address = OnlineAddress.find_or_create_by url: link[0].to_s,
-                                                       link_type: have_direct_url_to_stream?(link[0].to_s)
+      online_address = OnlineAddress.find_or_create_by(url: link[0].to_s,
+                                                       link_type: have_direct_url_to_stream?(link[0].to_s))
       online_address.id
     end
 

--- a/app/jobs/calendar_importer/events/ics_event.rb
+++ b/app/jobs/calendar_importer/events/ics_event.rb
@@ -56,11 +56,18 @@ module CalendarImporter::Events
       # Then grab the first element of either the match object or the conference array
       # (The match object returns ICal Text, not a String, so we have to cast)
       # (We can't use .first here because the match object doesn't support it!)
-      online_address = OnlineAddress.find_or_create_by url: link[0].to_s
+      #
+      online_address = OnlineAddress.find_or_create_by url: link[0].to_s,
+                                                       is_stream: is_stream_event(link[0].to_s)
       online_address.id
     end
 
     private
+
+    def is_stream_event(link)
+      # All the other ICS links we grab are videoconferencing URLs
+      !link.include? 'facebook.com'
+    end
 
     def find_event_link
       regex = event_link_regex

--- a/app/jobs/calendar_importer/events/meetup_event.rb
+++ b/app/jobs/calendar_importer/events/meetup_event.rb
@@ -60,7 +60,7 @@ module CalendarImporter::Events
     def online_event?
       return unless @event['is_online_event']
 
-      online_address = OnlineAddress.find_or_create_by url: @event['link'], is_stream: false
+      online_address = OnlineAddress.find_or_create_by url: @event['link'], link_type: 'indirect'
       online_address.id
     end
   end

--- a/app/jobs/calendar_importer/events/meetup_event.rb
+++ b/app/jobs/calendar_importer/events/meetup_event.rb
@@ -60,7 +60,7 @@ module CalendarImporter::Events
     def online_event?
       return unless @event['is_online_event']
 
-      online_address = OnlineAddress.find_or_create_by(url: @event['link'])
+      online_address = OnlineAddress.find_or_create_by url: @event['link'], is_stream: false
       online_address.id
     end
   end

--- a/app/jobs/calendar_importer/events/meetup_event.rb
+++ b/app/jobs/calendar_importer/events/meetup_event.rb
@@ -60,7 +60,7 @@ module CalendarImporter::Events
     def online_event?
       return unless @event['is_online_event']
 
-      online_address = OnlineAddress.find_or_create_by url: @event['link'], link_type: 'indirect'
+      online_address = OnlineAddress.find_or_create_by(url: @event['link'], link_type: 'indirect')
       online_address.id
     end
   end

--- a/app/jobs/calendar_importer_job.rb
+++ b/app/jobs/calendar_importer_job.rb
@@ -14,7 +14,6 @@ class CalendarImporterJob < ApplicationJob
     report_error exception, "Internal database error"
   end
 
-
   def calendar
     @calendar ||= Calendar.find(@calendar_id)
   end

--- a/app/models/online_address.rb
+++ b/app/models/online_address.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
 class OnlineAddress < ApplicationRecord
+  extend Enumerize
+
   has_many :events
+
+  enumerize :link_type,
+            in: %i[direct indirect],
+            default: :indirect
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,6 +7,11 @@
 <div class="c c--narrow c--space-after event__fullinfo">
   <%= markdown @event.description %>
   <%= event_link(@event) %>
+
+  <br>
+
+  <%= online_link %>
+
   <div class="g two-col">
     <div class="gi gi__1-2">
       <% if @event.partner %>

--- a/db/migrate/20220524160826_add_is_stream_to_online_address.rb
+++ b/db/migrate/20220524160826_add_is_stream_to_online_address.rb
@@ -1,5 +1,0 @@
-class AddIsStreamToOnlineAddress < ActiveRecord::Migration[6.1]
-  def change
-    add_column :online_addresses, :is_stream, :boolean
-  end
-end

--- a/db/migrate/20220524160826_add_is_stream_to_online_address.rb
+++ b/db/migrate/20220524160826_add_is_stream_to_online_address.rb
@@ -1,0 +1,5 @@
+class AddIsStreamToOnlineAddress < ActiveRecord::Migration[6.1]
+  def change
+    add_column :online_addresses, :is_stream, :boolean
+  end
+end

--- a/db/migrate/20220524160826_add_link_type_to_online_address.rb
+++ b/db/migrate/20220524160826_add_link_type_to_online_address.rb
@@ -1,0 +1,5 @@
+class AddLinkTypeToOnlineAddress < ActiveRecord::Migration[6.1]
+  def change
+    add_column :online_addresses, :link_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -182,6 +182,7 @@ ActiveRecord::Schema.define(version: 2022_06_07_161025) do
     t.string "url"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_stream"
   end
 
   create_table "organisation_relationships", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -182,7 +182,7 @@ ActiveRecord::Schema.define(version: 2022_06_07_161025) do
     t.string "url"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "is_stream"
+    t.string "link_type"
   end
 
   create_table "organisation_relationships", force: :cascade do |t|

--- a/test/integration/graphql/event_integration_test.rb
+++ b/test/integration/graphql/event_integration_test.rb
@@ -410,8 +410,8 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
 
   test 'has correct details for online event' do
     online_addresses = [
-      create(:online_address, url: 'https://zoom.us/j/sdflgkjshfgls', is_stream: true),
-      create(:online_address, url: 'https://eventbrite.com/blahblahblah', is_stream: false),
+      create(:online_address, url: 'https://zoom.us/j/sdflgkjshfgls', link_type: 'direct'),
+      create(:online_address, url: 'https://eventbrite.com/blahblahblah', link_type: 'indirect'),
       nil
     ]
     events = build_list(:event, 3, partner: @partner, dtstart: Time.now, address: @address)
@@ -427,7 +427,7 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
             node {
               id
               onlineEventUrl
-              isOnlineStream
+              onlineEventUrlType
             }
           }
         }
@@ -448,7 +448,7 @@ class GraphQLEventTest < ActionDispatch::IntegrationTest
     events.each do |event|
       node = nodes[event.id]
       assert_field_equals node, 'onlineEventUrl', value: event.online_address&.url
-      assert_field_equals node, 'isOnlineStream', value: event.online_address&.is_stream&.to_s
+      assert_field_equals node, 'onlineEventUrlType', value: event.online_address&.link_type
     end
   end
 end


### PR DESCRIPTION
Fixes #1240

feat: make online_address visible in graphql
feat: add is_stream to online address
refactor: cleanup graphql tests
fix: major bug where room_number strategies failed (silently!)
feat: show link to online address on main site