### PR TITLE
Allow tags to be set as uneditable

### DIFF
--- a/app/datatables/tag_datatable.rb
+++ b/app/datatables/tag_datatable.rb
@@ -8,6 +8,7 @@ class TagDatatable < Datatable
       slug: { source: 'Tag.slug' },
       description: { source: 'Tag.description' },
       edit_permission: { source: 'Tag.edit_permission' },
+      system_tag: { source: 'Tag.system_tag' },
       updated_at: { source: 'Tag.updated_at' }
     }
   end
@@ -20,6 +21,7 @@ class TagDatatable < Datatable
         slug: record.slug,
         description: record.description,
         edit_permission: record.edit_permission,
+        system_tag: record.system_tag,
         updated_at: record.updated_at
       }
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -28,6 +28,7 @@ class Tag < ApplicationRecord
               too_long: 'maximum length is 200 characters'
             }
   validates :edit_permission, presence: true
+  validate :check_editable_fields
 
   enumerize :edit_permission,
             in: %i[root all],
@@ -38,4 +39,13 @@ class Tag < ApplicationRecord
 
     where(id: tag_ids.uniq)
   }
+
+  private
+
+  def check_editable_fields
+    return if new_record? || !system_tag
+
+    errors.add :name, 'Cannot be changed on a system_tag' if name_changed?
+    errors.add :slug, 'Cannot be changed on a system_tag' if slug_changed?
+  end
 end

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -20,8 +20,12 @@ class TagPolicy < ApplicationPolicy
   def update?
     return true if user.root?
 
+    # system tags can only be edited by root
+    return false if @record.system_tag
+
     # If the user is a tag admin and has been assigned this tag
     return true if user.tag_admin? && user.tags.include?(@record)
+
 
     # NB: We literally can't filter by partners added because otherwise itll wipe existing partners
     #

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -43,7 +43,7 @@ class TagPolicy < ApplicationPolicy
 
   def permitted_attributes
     if user.root?
-      %i[name slug description edit_permission]
+      %i[name slug description edit_permission system_tag]
         .push(partner_ids: [], user_ids: [])
     elsif user.tag_admin? && user.tags.include?(@record)
       %i[].push(partner_ids: [])
@@ -58,9 +58,9 @@ class TagPolicy < ApplicationPolicy
     if user.root?
       %i[]
     elsif user.tag_admin? || @record.edit_permission == :all
-      %i[name slug description users edit_permission user_ids]
+      %i[name slug description users edit_permission user_ids system_tag]
     else # Should never be hit, but it's useful as a guard
-      %i[name slug description users edit_permission partner_ids user_ids]
+      %i[name slug description users edit_permission partner_ids user_ids system_tag]
     end
   end
 

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -1,8 +1,10 @@
 <%- disabled_fields = policy(@tag).disabled_fields %>
 
 <% if @tag.system_tag %>
-  <div class="alert alert-warning" role="alert">
-    WARNING: This tag is used by the PlaceCal backend and should not be edited!
+  <div class="card text-black bg-warning mb-3">
+    <div class="card-header">
+      <h6>WARNING: This tag is used by the PlaceCal backend so you cannot change the Name or Slug values.</h6>
+    </div>
   </div>
 <% end %>
 
@@ -10,10 +12,10 @@
   <%= render_component "error", object: @tag %>
 
   <%= f.input :name, class: 'form-control',
-              disabled: disabled_fields.include?(:name) %>
+              disabled: disabled_fields.include?(:name) || @tag.system_tag %>
 
   <%= f.input :slug, class: 'form-control',
-              disabled: disabled_fields.include?(:slug) %>
+              disabled: disabled_fields.include?(:slug) || @tag.system_tag %>
 
   <%= f.input :description, class: 'form-control',
               disabled: disabled_fields.include?(:description) %>

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -11,11 +11,18 @@
   <%= f.input :description, class: 'form-control',
               disabled: disabled_fields.include?(:description) %>
 
+  <% if current_user.root? -%>
+    <%= f.input :system_tag, class: 'form-control',
+      disabled: disabled_fields.include?(:system_tag),
+      hint: 'Only root users can modify this tag' %>
+  <% end -%>
+
   <%= f.input :edit_permission,
               as: :radio_buttons,
               label_method: ->(val){ edit_permission_label(val) },
               hint: 'Users with this role will be granted access to assign this tag',
               disabled: disabled_fields.include?(:edit_permission) %>
+
 
   <h2>Tagged Partners</h2>
   <p>Apply this tag to the given partners</p>

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -1,4 +1,11 @@
 <%- disabled_fields = policy(@tag).disabled_fields %>
+
+<% if @tag.system_tag %>
+  <div class="alert alert-warning" role="alert">
+    WARNING: This tag is used by the PlaceCal backend and should not be edited!
+  </div>
+<% end %>
+
 <%= simple_form_for @tag, url: (@tag.new_record? ? admin_tags_path : admin_tag_path) do |f| %>
   <%= render_component "error", object: @tag %>
 
@@ -14,7 +21,7 @@
   <% if current_user.root? -%>
     <%= f.input :system_tag, class: 'form-control',
       disabled: disabled_fields.include?(:system_tag),
-      hint: 'Only root users can modify this tag' %>
+      hint: 'This tag is read only and should not be edited' %>
   <% end -%>
 
   <%= f.input :edit_permission,

--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -1,1 +1,11 @@
-<%= render_component "admin_edit", model: :tag, title: @tag.name %>
+<% if @tag.system_tag && !current_user.root? %>
+  <% content_for :title do %><%= @tag.name%><% end %>
+
+  <h1 class="page-header"><%= @tag.name %></h1>
+
+  <!-- TODO: come up with better words here -->
+  <p>This tag is a <em>system tag</em> meaning that it cannot be edited by non-root admins.</p>
+
+<% else %>
+  <%= render_component "admin_edit", model: :tag, title: @tag.name %>
+<% end %>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -6,6 +6,7 @@ var columns = [
     {"data": "name"},
     {"data": "slug"},
     {"data": "edit_permission"},
+    {"data": "system_tag"},
     {"data": "description"},
     {"data": "updated_at"}
   ]
@@ -14,7 +15,7 @@ var columns = [
 <%= render partial: "layouts/admin/datatable", locals: {
     title: "Tags",
     model: :tags,
-    columns: %i[id name slug edit_permission description updated_at],
+    columns: %i[id name slug edit_permission system_tag description updated_at],
     data: @tags,
     source: admin_tags_path(format: :json),
     new_link: new_admin_tag_path

--- a/db/migrate/20220607161025_add_system_flag_to_tags.rb
+++ b/db/migrate/20220607161025_add_system_flag_to_tags.rb
@@ -1,0 +1,5 @@
+class AddSystemFlagToTags < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tags, :system_tag, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_01_153635) do
+ActiveRecord::Schema.define(version: 2022_06_07_161025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -344,6 +344,7 @@ ActiveRecord::Schema.define(version: 2022_06_01_153635) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "edit_permission"
+    t.boolean "system_tag", default: false
   end
 
   create_table "tags_users", force: :cascade do |t|

--- a/test/factories/tag.rb
+++ b/test/factories/tag.rb
@@ -13,5 +13,10 @@ FactoryBot.define do
       description { 'I am a tag everyone can edit' }
       edit_permission { 'all' }
     end
+
+    factory :system_tag do
+      system_tag { true }
+    end
+
   end
 end

--- a/test/integration/admin/tags_integration_test.rb
+++ b/test/integration/admin/tags_integration_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Admin::TagsTest < ActionDispatch::IntegrationTest
+  setup do
+    @root = create(:root)
+    @citizen = create(:citizen)
+
+    @tag = create(:tag)
+
+    host! 'admin.lvh.me'
+  end
+
+  test 'root user editing a tag can see system_tag option' do
+    sign_in @root
+    get edit_admin_tag_path(@tag)
+
+    assert_select 'input[name="tag[system_tag]"]'
+  end
+
+  test 'citizen user editing a tag cannot see system_tag option' do
+    sign_in @citizen
+    get edit_admin_tag_path(@tag)
+
+    assert_select 'input[name="tag[system_tag]"]', count: 0
+  end
+
+
+=begin
+  test 'neighbourhood admin : can see partner on /new' do
+    sign_in @neighbourhood_admin
+    get new_admin_article_path
+
+    assert_select 'select#article_partner_ids option', @partner.name
+  end
+
+  test 'partner admin : partner is preselected on /new' do
+    sign_in @partner_admin
+    get new_admin_article_path
+
+    assert_select 'select#article_partner_ids option[selected="selected"]', @partner.name
+  end
+
+  test 'editor : author is preselected on /new' do
+    sign_in @editor
+    get new_admin_article_path
+
+    assert_select 'select#article_author_id option[selected="selected"]', @editor.admin_name
+  end
+
+  test 'neighbourhood admin : author is preselected on /new' do
+    sign_in @neighbourhood_admin
+    get new_admin_article_path
+
+    assert_select 'select#article_author_id option[selected="selected"]', @neighbourhood_admin.admin_name
+  end
+
+  test 'partner admin : author is preselected on /new' do
+    sign_in @partner_admin
+    get new_admin_article_path
+
+    assert_select 'select#article_author_id option[selected="selected"]', @partner_admin.admin_name
+  end
+=end
+
+end

--- a/test/integration/admin/tags_integration_test.rb
+++ b/test/integration/admin/tags_integration_test.rb
@@ -58,16 +58,15 @@ class Admin::TagsTest < ActionDispatch::IntegrationTest
   test 'root users can make a tag a system tag' do
     log_in_with @root.email
 
-    visit edit_admin_tag_url(@tag)
 
     # toggle on
+    visit edit_admin_tag_url(@tag)
     check 'System tag'
     click_button 'Save'
     assert_has_flash :success, 'Tag was saved successfully'
 
     # check is toggled
     visit edit_admin_tag_url(@tag)
-    #puts page.html
     assert_selector :xpath, '//input[@name="tag[system_tag]"][@checked="checked"]'
 
     # now toggle off

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -21,4 +21,15 @@ class TagTest < ActiveSupport::TestCase
 
     assert @tag.partners.length > 0
   end
+
+  test 'system_tags cannot modify name or slug' do
+    @tag.system_tag = true
+    @tag.name = 'This is a new name'
+    @tag.slug = 'a-new-tag-slug'
+
+    refute @tag.validate
+
+    assert @tag.errors.has_key?(:name)
+    assert @tag.errors.has_key?(:slug)
+  end
 end

--- a/test/policies/tag_policy_test.rb
+++ b/test/policies/tag_policy_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TagPolicyTest < ActiveSupport::TestCase
+  def setup
+    @root = create(:root)
+    @non_root = create(:editor)
+
+    @normal_tag = create(:tag)
+    @system_tag = create(:tag, system_tag: true)
+  end
+
+  def test_update
+    @non_root.tags << @normal_tag
+
+    assert allows_access(@root, @normal_tag, :update)
+    assert allows_access(@non_root, @normal_tag, :update)
+
+    assert allows_access(@root, @system_tag, :update)
+    assert denies_access(@non_root, @system_tag, :update)
+  end
+end


### PR DESCRIPTION
Implements #1028 

Tags now have a system_tag flag. System tags can only be modified by root users.