### PR TITLE
fix: use email rather than name when displaying partners users

### DIFF
--- a/app/views/admin/partners/edit.html.erb
+++ b/app/views/admin/partners/edit.html.erb
@@ -54,7 +54,7 @@
 
     <ul>
       <% @partner.users.each do |p_user| -%>
-        <li><%= link_to p_user.full_name, edit_admin_user_path(p_user) %></li>
+        <li><%= link_to p_user.email, edit_admin_user_path(p_user) %></li>
       <% end -%>
     </ul>
 


### PR DESCRIPTION
Fixes: #1283 