### PR TITLE
Reset password form bug

### DIFF
--- a/app/components/admin_flash/admin_flash.sass
+++ b/app/components/admin_flash/admin_flash.sass
@@ -1,0 +1,23 @@
+.flashes
+  margin: 0 1.5em
+
+.alert
+  position: relative
+  padding: 0.75rem 1.25rem
+  margin-bottom: 1rem
+  border: 1px solid transparent
+  border-radius: 0.25rem
+
+
+.alert-success
+  color: ￼#155724
+  background-color: #d4edda
+  border-color: #c3e6cb
+
+
+.alert-danger
+  color: #721c24
+  background-color: #f8d7da
+  border-color: #f5c6cb
+
+

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -3,30 +3,32 @@
     <h1 class="center fc-primary">Change your password</h1>
 
     <div class="centre form--login">
-        <%= form_for(resource, as: resource_name, 
-                         url: password_path(resource_name), 
-                         html: { method: :put, class: 'form' }) do |f| %>
-      <%= devise_error_messages! %>
-      <%= f.hidden_field :reset_password_token %>
-  
-      <div class="form__field">
-        <%= f.label :password, "New password" %>
-        <% if @minimum_password_length %>
-          <em>(<%= @minimum_password_length %> characters minimum)</em><br>
-        <% end %>
-        <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
-      </div>
-  
-      <div class="form__field">
-        <%= f.label :password_confirmation, "Confirm new password" %>
-        <%= f.password_field :password_confirmation, autocomplete: "off" %>
-      </div>
-      <br>
+      <%= form_for(resource, as: resource_name,
+                   url: password_path(resource_name),
+                   html: { method: :put, class: 'form', data: { turbo: 'false' } }) do |f| %>
 
-      <div class="actions">
-        <%= f.submit "Change my password", class: "btn btn--big btn--home-3" %>
-      </div>
-      <br>
+       <%= devise_error_messages! %>
+       <%= f.hidden_field :reset_password_token %>
+
+       <div class="form__field">
+         <%= f.label :password, "New password" %>
+         <% if @minimum_password_length %>
+           <em>(<%= @minimum_password_length %> characters minimum)</em><br>
+         <% end %>
+         <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+       </div>
+
+       <div class="form__field">
+         <%= f.label :password_confirmation, "Confirm new password" %>
+         <%= f.password_field :password_confirmation, autocomplete: "off" %>
+       </div>
+       <br>
+
+       <div class="actions">
+         <%= f.submit "Change my password", class: "btn btn--big btn--home-3" %>
+       </div>
+     <% end %>
+     <br>
     </div>
   </div>
 </article>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -3,9 +3,9 @@
     <h1 class="center fc-primary">Forgot your password?</h1>
 
     <div class="centre form--login">
-      <%= form_for(resource, as: resource_name, 
-                            url: password_path(resource_name), 
-                            html: { method: :post, class: 'form' }) do |f| %>
+      <%= form_for(resource, as: resource_name,
+                            url: password_path(resource_name),
+                            html: { method: :post, class: 'form', data: { turbo: 'false' } }) do |f| %>
       <%= devise_error_messages! %>
 
       <div class="form__field">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   #
   #   KF: Disabling this due to this comment:
   #     https://github.com/rails/jsbundling-rails/issues/40#issuecomment-1006503192
-  #   I imagine this is because asset bundling is done with esbuild now so this is just 
+  #   I imagine this is because asset bundling is done with esbuild now so this is just
   #   confusing matters and overwriting the sourcemap url.
   config.assets.debug = false
 
@@ -68,7 +68,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.action_mailer.default_url_options = { host: 'https://admin.lvh.me:3000' }
+  config.action_mailer.default_url_options = { host: 'http://lvh.me:3000' }
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :letter_opener


### PR DESCRIPTION
Fixes #1295 

- no more stimulus on reset password form or change password form
- put in styling for the flashes on root placecal site so you can see them
- changed (development environment) active mailer missconfiguration. now uses http://lvh.me:3000