### PR TITLE
fix: redirect to find my placecal on main site

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -200,6 +200,10 @@ class ApplicationController < ActionController::Base
     @site = current_site
   end
 
+  def redirect_from_default_site
+    redirect_to '/find-placecal' if default_site?
+  end
+
   def set_navigation
     return @navigation if @navigation
     return if self.class == MountainView::StyleguideController

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,6 +7,7 @@ class EventsController < ApplicationController
   before_action :set_sort, only: :index
   before_action :set_primary_neighbourhood, only: :index
   before_action :set_site
+  before_action :redirect_from_default_site
 
   # GET /events
   # GET /events.json

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -5,6 +5,7 @@ class NewsController < ApplicationController
 
   before_action :set_article, only: %i[show]
   before_action :set_site
+  before_action :redirect_from_default_site
 
   def index
     @offset = params[:offset].to_i

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -6,6 +6,7 @@ class PartnersController < ApplicationController
   before_action :set_primary_neighbourhood, only: [:index]
   before_action :set_site
   before_action :set_title, only: %i[index show]
+  before_action :redirect_from_default_site
 
   PAGINATION_THRESHOLD = 20
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,5 +108,4 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   if Rails.env.development?
     mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: "/api/v1/graphql"
   end
-
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -4,28 +4,50 @@ require 'test_helper'
 
 class EventsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    neighbourhoods = [ create(:neighbourhood), create(:neighbourhood), create(:neighbourhood) ]
-    # Deliberately saving address twice. (create + save) Second time overwrites neighbourhood.
-    addresses = neighbourhoods.map {|n| a=create(:address); a.neighbourhood=n; a.save; a}
+    neighbourhoods = create_list(:neighbourhood, 3)
     date = DateTime.now.beginning_of_day
-    @events = addresses.map { |a| e=build(:event); e.address=a; e.dtstart=date; e.dtend=date+1.hour; e.save; e }
-    default_site = create_default_site
-    default_site.neighbourhoods.append(neighbourhoods)
-    default_site.save
+
+    # Deliberately saving address twice. (create + save) Second time overwrites neighbourhood.
+    addresses = neighbourhoods.map do |n|
+      a = create(:address)
+      a.neighbourhood = n
+      a.save
+      a
+    end
+
+    @events = addresses.map do |a|
+      e = build(:event, address: a, dtstart: date, dtend: date + 1.hour)
+      e.save
+      e
+    end
+
+    @slugless_site = create_default_site
+
+    @default_site = create(:site)
+    @default_site.neighbourhoods << neighbourhoods
+    @default_site.save
+
     @site = build(:site)
     @site.neighbourhoods.append(neighbourhoods.first)
     @site.neighbourhoods.append(neighbourhoods.second)
     @site.save
   end
 
-  test 'should get index without subdomain' do
+  test 'slugless site redirects to find my placecal' do
     get events_url
-    assert_response :success
-    assert_select "ol.events li", 3
+    assert_response :redirect
   end
 
+  # It looks like PlaceCal had aggregate /events functionality or something?
+  # test 'should get index without subdomain' do
+  #   get events_url
+  #   assert_response :success
+  #   assert_select "ol.events li", 3
+  # end
+
   test 'should get index with configured subdomain' do
-    get url_for controller: :events, subdomain: @site.slug
+    get from_site_slug(@site, events_path)
+
     assert_response :success
     assert_select "ol.events li", 2
   end
@@ -36,7 +58,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should show event' do
-    get event_url(@events[0])
+    get from_site_slug(@default_site, event_path(@events[0]))
     assert_response :success
   end
 
@@ -60,7 +82,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       )
     end
 
-    get url_for(controller: :events, subdomain: @site.slug)
+    get from_site_slug(@site, events_path)
     assert_response :success
 
     events = assigns(:events).values.first

--- a/test/controllers/partners_controller_test.rb
+++ b/test/controllers/partners_controller_test.rb
@@ -30,9 +30,11 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
       for_nbd
     end
 
-    default_site = create_default_site
-    default_site.neighbourhoods.append(neighbourhoods)
-    default_site.save
+    @slugless_site = create_default_site
+
+    @default_site = create(:site)
+    @default_site.neighbourhoods.append(neighbourhoods)
+    @default_site.save
 
     @site = build(:site)
     @site.neighbourhoods.append(neighbourhoods.first)
@@ -41,9 +43,7 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get index without subdomain' do
     get url_for controller: "partners", subdomain: false
-    assert_response :success
-
-    assert_select "ul.partners li", 6
+    assert_response :redirect
   end
 
   # test 'should get places_index without subdomain' do
@@ -53,7 +53,8 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
   # end
 
   test 'should get index with configured subdomain' do
-    get url_for controller: "partners", subdomain: @site.slug
+    get from_site_slug(@site, partners_path)
+
     assert_response :success
     assert_select "ul.partners li", 3
   end
@@ -76,7 +77,7 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
 
   test 'should show partner' do
     # Choose a manager to show. That will exercise more of the markup.
-    get partner_url(@partners.first.first)
+    get from_site_slug(@site, partner_path(@partners.first.first))
     assert_response :success
   end
 
@@ -87,7 +88,7 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
     partner.save!
 
     # Choose a manager to show. That will exercise more of the markup.
-    get partner_url(partner)
+    get from_site_slug(@site, partner_path(partner))
     assert_response :success
   end
 
@@ -97,7 +98,7 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
 
     partner.events += create_list(:event, 3, calendar: calendar, dtstart: Time.now)
 
-    get partner_url(partner)
+    get from_site_slug(@site, partner_path(partner))
 
     events = assigns(:events).values.first
     assert events.length == 3

--- a/test/integration/events_integration_test.rb
+++ b/test/integration/events_integration_test.rb
@@ -5,7 +5,9 @@ require 'test_helper'
 class EventsIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     # Create a default site and a neighbourhood one
-    @default_site = create_default_site
+    @slugless_site = create_default_site
+
+    @default_site = create(:site)
     @neighbourhood_site = create(:site_local)
     @regional_neighbourhood_site = create(:site_local)
 
@@ -36,8 +38,13 @@ class EventsIntegrationTest < ActionDispatch::IntegrationTest
     @regional_neighbourhood_site.neighbourhoods << @ward.region
   end
 
-  test 'default site index page shows all events that are on today and local info' do
+  test 'site with no slug redirects to find my placecal' do
     get events_url
+    assert_response :redirect
+  end
+
+  test 'default site index page shows all events that are on today and local info' do
+    get from_site_slug(@default_site, events_path)
     assert_response :success
     assert_select 'title', count: 1, text: "Events & activities in your area | #{@default_site.name}"
     assert_select 'div.hero h4', text: 'The Community Calendar'
@@ -46,7 +53,7 @@ class EventsIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'neighbourhood site index page shows all events that are on today and local info' do
-    get "http://#{@neighbourhood_site.slug}.lvh.me/events"
+    get from_site_slug(@neighbourhood_site, events_path)
     assert_response :success
     assert_select 'title', count: 1, text: "Events & activities in your area | #{@neighbourhood_site.name}"
     assert_select 'div.hero h4', text: "Neighbourhood's Community Calendar"
@@ -55,7 +62,7 @@ class EventsIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'regional site index page shows all events that are on today and local info' do
-    get "http://#{@regional_neighbourhood_site.slug}.lvh.me/events"
+    get from_site_slug(@regional_neighbourhood_site, events_path)
     assert_response :success
     assert_select 'title', count: 1, text: "Events & activities in your area | #{@regional_neighbourhood_site.name}"
     assert_select 'div.hero h4', text: "Neighbourhood's Community Calendar"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -286,3 +286,8 @@ def suppress_stdout
   yield
   $stdout = stdout
 end
+
+def from_site_slug(site, path)
+  host = Rails.application.routes.default_url_options[:host]
+  "http://#{site.slug}.#{host}/#{path}"
+end


### PR DESCRIPTION
Redirect to find-my-placecal endpoint for `/events`, `/partners` and `/news`

Fixes #1333