### PR TITLE
Production deployment 6th July 2022

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ GEM
       activesupport (>= 4.2)
       choice (~> 0.2.0)
       ruby-graphviz (~> 1.2)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rails_autolink (1.1.6)
       rails (> 3.1)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -60,7 +60,7 @@ module Types
     end
 
     def articles_by_tag(tag_id:)
-      Article.with_tag(tag_id).global_newsfeed.order(:title)
+      Article.with_tags(tag_id).global_newsfeed.order(:title)
     end
 
     def articles_by_partner_tag(tag_id:)
@@ -102,7 +102,7 @@ module Types
     end
   end
 
-  class QueryType < Types::BaseObject 
+  class QueryType < Types::BaseObject
 
     description "The base query schema for all of PlaceCal's GraphQL queries"
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -15,6 +15,9 @@ module UsersHelper
   end
 
   def user_has_no_rights?(user)
+    return false if user.root?
+    return false if user.editor?
+
     return false if user.tag_admin?
     return false if user.neighbourhood_admin?
     return false if user.partner_admin?

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -27,20 +27,74 @@ class Article < ApplicationRecord
 
   scope :global_newsfeed, -> { published.order(published_at: :desc) }
 
-  scope :with_tag, ->(tag_id) { joins(:article_tags).where(article_tags: { tag: tag_id }) }
-
   scope :with_partner_tag, lambda { |tag_id|
     joins('left outer join article_partners on articles.id=article_partners.article_id')
     .joins('left outer join partner_tags on article_partners.partner_id = partner_tags.partner_id')
     .where('partner_tags.tag_id = ?', tag_id)
   }
 
-  scope :for_site, lambda { |site|
-    site_neighbourhood_ids = site.owned_neighbourhoods.pluck(:id)
+  scope :with_tags, lambda { |tag_ids|
+    joins(:article_tags).where(article_tags: { tag: tag_ids })
+  }
 
-    joins(partners: [:address])
-      .where(address: { neighbourhood_id: site_neighbourhood_ids } )
-      .distinct
+  scope :for_site, lambda { |site|
+
+    # this is a bit complicated but necessary
+    # the main problem to overcome is that we want articles by tag OR location
+    # (emphasis on OR).
+    #
+    # in simple AR land we would just chain scope methods like
+    #   `Article.by_tag(tags).by_location(neighbourhoods)` and be done with it
+    # each scope would set up its `joins` to pull in tables and its `wheres`
+    # to filter based on those joins. simple!
+    # but unfortunately these scopes get combined with 'AND' clauses in
+    # the `where` part.
+    #
+    # so what this does is build up the query for tags and locations like
+    # we were chaining scope methods without the conditions. we store
+    # the conditions as (clause, params) in an array as we go. when we reach
+    # the end we then extend the scope with a `where` clause that combines
+    # everything with `OR' as is needed and then return that to the
+    # calling code as a regular scope for further chaining.
+    #
+    # this also also allows us to skip an entire chunk of query if the
+    # site has no tags or locations.
+
+    site_neighbourhood_ids = site.owned_neighbourhoods.pluck(:id)
+    site_tag_ids = site.tags.pluck(:id)
+
+    # if site has no tags or neighbourhoods then just return nothing to caller
+    return none if site_neighbourhood_ids.empty? && site_tag_ids.empty?
+
+    scope = all
+
+    where_fragments = []
+    where_params = []
+
+    # articles by neighbourhood
+    if site_neighbourhood_ids.any?
+      # TODO: service areas?
+      scope = scope
+        .joins('LEFT OUTER JOIN article_partners ON articles.id=article_partners.article_id')
+        .joins('LEFT OUTER JOIN partners ON article_partners.partner_id = partners.id')
+        .joins('LEFT OUTER JOIN addresses ON partners.address_id = addresses.id')
+      where_fragments << 'addresses.neighbourhood_id IN (?)'
+      where_params << site_neighbourhood_ids
+    end
+
+    # articles by tag
+    if site_tag_ids.any?
+      scope = scope
+        .joins(' LEFT OUTER JOIN article_tags ON articles.id=article_tags.article_id')
+      where_fragments << 'article_tags.tag_id IN (?)'
+      where_params << site_tag_ids
+    end
+
+    # combine conditions with params to extend the scope
+    scope = scope
+      .where("(#{where_fragments.join(' OR ')})", *where_params)
+
+    scope.distinct('articles.id')
   }
 
   def update_published_at

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -223,6 +223,9 @@ class Partner < ApplicationRecord
          <span class='opening_times--time'>#{o} &ndash; #{c}</span>
       ).html_safe
     end
+
+  rescue JSON::ParserError
+    []
   end
 
   def valid_public_phone?

--- a/app/views/admin/pages/home.html.erb
+++ b/app/views/admin/pages/home.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title do %>Dashboard<% end %>
 
+<% if user_has_no_rights?(current_user) -%>
+  <h1 class="mt-5 mb-3">Missing Permissions</h1>
+  <p class='has-no-admin-rights-warning'>You have no admin rights. This probably means someone didn't set up your account correctly - please ask whoever invited you!</p>
+<% end -%>
+
 <% ['Partner', 'Calendar', 'User'].each do |model_name| %>
   <%- if policy(model_name.constantize).create? %>
     <%= link_to "Add New #{model_name}",
@@ -23,9 +28,9 @@
   </div>
 <% end %>
 
-<h1 class="mt-5 mb-3">Recently updated partners</h1>
-
 <% if @partners.any? %>
+
+  <h1 class="mt-5 mb-3">Recently updated partners</h1>
   <div class="card-grid">
     <% @partners.each do |partner| %>
       <%= render_component 'dashboard_card',

--- a/test/integration/admin/home_integration_test.rb
+++ b/test/integration/admin/home_integration_test.rb
@@ -13,11 +13,12 @@ class AdminHomeIntegrationTest < ActionDispatch::IntegrationTest
     @default_site = create_default_site
     get "http://admin.lvh.me"
     assert_redirected_to "http://admin.lvh.me/users/sign_in"
+
     sign_in @admin
     get "http://admin.lvh.me"
     assert_response :success
 
     assert_select 'title', text: "Dashboard | PlaceCal Admin"
-    assert_select 'h1', text: "Recently updated partners"
+    assert_select 'h1', text: "Missing Permissions"
   end
 end

--- a/test/integration/admin/home_integration_test.rb
+++ b/test/integration/admin/home_integration_test.rb
@@ -7,18 +7,30 @@ class AdminHomeIntegrationTest < ActionDispatch::IntegrationTest
 
   setup do
     @admin = create(:root)
+    @citizen = create(:citizen)
   end
 
   test "Admin home page can't be accessed without a login" do
     @default_site = create_default_site
     get "http://admin.lvh.me"
     assert_redirected_to "http://admin.lvh.me/users/sign_in"
+  end
 
+  test "Admin can access page when logged in" do
     sign_in @admin
+    get "http://admin.lvh.me"
+    assert_response :success
+
+    assert_select 'title', text: "Dashboard | PlaceCal Admin"
+  end
+
+  test "Blank citizen gets a 'no content' warning" do
+    sign_in @citizen
     get "http://admin.lvh.me"
     assert_response :success
 
     assert_select 'title', text: "Dashboard | PlaceCal Admin"
     assert_select 'h1', text: "Missing Permissions"
   end
+
 end

--- a/test/models/partner_test.rb
+++ b/test/models/partner_test.rb
@@ -76,7 +76,7 @@ class PartnerTest < ActiveSupport::TestCase
 
   test 'validate description without summary' do
     @new_partner.update(
-      name: 'Test Partner', 
+      name: 'Test Partner',
       description: 'This is a test partner used for testing :)',
       summary: ''
     )
@@ -131,5 +131,12 @@ class PartnerTest < ActiveSupport::TestCase
     assert @new_partner.errors.key?(:facebook_link), 'invalid Facebook page name saved'
     @new_partner.update(facebook_link: 'GroupName')
     refute @new_partner.errors.key?(:facebook_link), 'Valid page name not saved'
+  end
+
+  test 'deals with badly formatted opening times' do
+    partner = build(:partner)
+    partner.opening_times = '{{ $data.openingHoursSpecifications }}'
+
+    assert_equal [], partner.human_readable_opening_times
   end
 end


### PR DESCRIPTION
## #1363 partner opening times data can have invalid JSON

Some of the data in partner `opening_times` fields was badly formed.

### With badly formed JSON data:
![with bad JSON data](https://user-images.githubusercontent.com/176049/177559796-ccac9b44-481b-4734-84bb-04a69dbcf987.png)

### With valid JSON data:
![with valid JSON data](https://user-images.githubusercontent.com/176049/177559888-08618865-46f7-4e71-9087-916a4c3cb349.png)

## #1364 No rights message on admin dashboard and profile page

When citizens log in and have no tags, neighbourhoods or partners they should see a message on the dashboard and their profile page. This is not the case if the user has the root role.

### Dashboard home screen:
![Dashboard home screen](https://user-images.githubusercontent.com/176049/177566339-6951d70b-20df-4be3-944c-d3c16a022d00.png)

### Profile page (bottom):
![Profile page](https://user-images.githubusercontent.com/176049/177566452-8378ff96-beca-4bad-ae97-1eb981ac00ed.png)

## #1369 Articles on sites news page can be found by location (address) and tag

When an article has the `foo` tag applied and a site has a `foo` tag in its selected tags field, then that article should appear on the site, regardless of location. This is in addition to the previous behaviour of finding articles published from partners that have neighbourhoods in the Site's neighbourhoods.

### Articles found by both tag and address
![Screen Shot 2022-07-06 at 15 42 34](https://user-images.githubusercontent.com/176049/177577523-d7dab5ca-0c29-4024-9603-ea39ad7471fe.png)

## #1368 Blank editors don't see 'no content' warning (from #1364)

As an extension of 1364: users with editor roles do not see the blank content warning.

### As a blank citizen:
![blank-citizen](https://user-images.githubusercontent.com/176049/177580806-2563069b-b473-4a0c-a33a-de5d250084cc.png)

### As a blank root:
![blank-root](https://user-images.githubusercontent.com/176049/177580844-2f27a3d1-4d2a-4bf6-ac45-14fd247da47d.png)

### As a blank editor:
![Screen Shot 2022-07-06 at 15 55 46](https://user-images.githubusercontent.com/176049/177580894-a5c6f4b3-a2f8-4cc4-93f0-0ae69270b9cb.png)

