### PR TITLE
Partners with service areas appear on maps

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,38 +101,6 @@ class ApplicationController < ActionController::Base
     @primary_neighbourhood = current_site&.primary_neighbourhood
   end
 
-  # Takes an array of Partners and/or Addresses and returns a sanitized json
-  # array suitable for creating map markers. Does not check for duplicates.
-  def get_map_markers(locations)
-    locations.reduce([]) do |arr, loc|
-      marker =
-        if (Partner == loc.class) && (loc&.address&.latitude)
-          {
-            lat: loc.address.latitude,
-            lon: loc.address.longitude,
-            name: loc.name,
-            id: loc.id
-          }
-        elsif loc.class == Address
-          {
-            lat: loc.latitude,
-            lon: loc.longitude
-          }
-        end
-      if marker then arr << marker else arr end
-    end
-  end
-
-  # Takes a reducible collection of events and returns json map markers.
-  # Removes duplicate locations.
-  def get_map_markers_from_events(events)
-    get_map_markers(
-      @events.reduce([]) do |arr, e|
-        loc = e.place || e.address
-        if loc then arr << loc else arr end
-      end.uniq
-    )
-  end
 
   # Create a calendar from array of events
   def create_calendar(events, title = false)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -106,7 +106,7 @@ class ApplicationController < ActionController::Base
   def get_map_markers(locations)
     locations.reduce([]) do |arr, loc|
       marker =
-        if (Partner == loc.class) && (loc&.address&.latitude) && loc.service_areas.count == 0
+        if (Partner == loc.class) && (loc&.address&.latitude)
           {
             lat: loc.address.latitude,
             lon: loc.address.longitude,

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CollectionsController < ApplicationController
+  include MapMarkers
+
   before_action :set_collection, only: %i[show edit update destroy]
   before_action :set_site
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -16,7 +16,7 @@ class CollectionsController < ApplicationController
   # GET /collections/1.json
   def show
     @events = @collection.sorted_events
-    @map = get_map_markers_from_events(@events) if @events
+    @map = get_map_markers(@events) if @events
     @events = sort_events(@events, 'time')
 
     respond_to do |format|

--- a/app/controllers/concerns/map_markers.rb
+++ b/app/controllers/concerns/map_markers.rb
@@ -29,8 +29,8 @@ module MapMarkers
       next if loc.address.nil? || loc.address.latitude.blank?
 
       if addresses_only
-        # reject partner if they have no service areas?
-        next if loc.service_areas.count == 0
+        # reject partner if they have any service areas?
+        next if loc.service_areas.count > 0
       end
 
       {

--- a/app/controllers/concerns/map_markers.rb
+++ b/app/controllers/concerns/map_markers.rb
@@ -26,7 +26,7 @@ module MapMarkers
       next loc unless loc.is_a?(Partner)
 
       # reject partner with no resolvable address
-      next if loc.address&.latitude&.blank?
+      next if loc.address.nil? || loc.address.latitude.blank?
 
       if addresses_only
         # reject partner if they have no service areas?
@@ -50,19 +50,7 @@ module MapMarkers
       }
     end
 
-    locations.keep_if { |loc|
-      # puts loc.class
-      loc.is_a?(Hash) }
+    locations.keep_if { |loc| loc.is_a?(Hash) }
   end
 
-  # Takes a reducible collection of events and returns json map markers.
-  # Removes duplicate locations.
-  def get_map_markers_from_events(events)
-    get_map_markers(
-      @events.reduce([]) do |arr, e|
-        loc = e.place || e.address
-        if loc then arr << loc else arr end
-      end.uniq
-    )
-  end
 end

--- a/app/controllers/concerns/map_markers.rb
+++ b/app/controllers/concerns/map_markers.rb
@@ -1,25 +1,58 @@
 module MapMarkers
+  extend ActiveSupport::Concern
 
-  # Takes an array of Partners and/or Addresses and returns a sanitized json
+  # Takes an array of Partners, Addresses or Events and returns a sanitized json
   # array suitable for creating map markers. Does not check for duplicates.
-  def get_map_markers(locations)
-    locations.reduce([]) do |arr, loc|
-      marker =
-        if (Partner == loc.class) && (loc&.address&.latitude)
-          {
-            lat: loc.address.latitude,
-            lon: loc.address.longitude,
-            name: loc.name,
-            id: loc.id
-          }
-        elsif loc.class == Address
-          {
-            lat: loc.latitude,
-            lon: loc.longitude
-          }
-        end
-      if marker then arr << marker else arr end
+  #
+  # parameters:
+  #   @locations - Array of Partners, Addresses or Events
+  #   @addresses_only - boolean whether to skip partners that
+  #     have no service areas
+  #
+  # returns:
+  #   Array of Hashes to be consumed by the JS map front end
+  #
+  def get_map_markers(locations, addresses_only=false)
+
+    # Events
+    locations = locations.map do |loc|
+      next loc unless loc.is_a?(Event)
+
+      loc.place || loc.address
     end
+
+    # Partners
+    locations = locations.map do |loc|
+      next loc unless loc.is_a?(Partner)
+
+      # reject partner with no resolvable address
+      next if loc.address&.latitude&.blank?
+
+      if addresses_only
+        # reject partner if they have no service areas?
+        next if loc.service_areas.count == 0
+      end
+
+      {
+        lat: loc.address.latitude,
+        lon: loc.address.longitude,
+        name: loc.name,
+        id: loc.id
+      }
+    end
+
+    # Addresses
+    locations = locations.map do |loc|
+      next loc unless loc.is_a?(Address)
+      {
+        lat: loc.latitude,
+        lon: loc.longitude
+      }
+    end
+
+    locations.keep_if { |loc|
+      # puts loc.class
+      loc.is_a?(Hash) }
   end
 
   # Takes a reducible collection of events and returns json map markers.

--- a/app/controllers/concerns/map_markers.rb
+++ b/app/controllers/concerns/map_markers.rb
@@ -1,0 +1,35 @@
+module MapMarkers
+
+  # Takes an array of Partners and/or Addresses and returns a sanitized json
+  # array suitable for creating map markers. Does not check for duplicates.
+  def get_map_markers(locations)
+    locations.reduce([]) do |arr, loc|
+      marker =
+        if (Partner == loc.class) && (loc&.address&.latitude)
+          {
+            lat: loc.address.latitude,
+            lon: loc.address.longitude,
+            name: loc.name,
+            id: loc.id
+          }
+        elsif loc.class == Address
+          {
+            lat: loc.latitude,
+            lon: loc.longitude
+          }
+        end
+      if marker then arr << marker else arr end
+    end
+  end
+
+  # Takes a reducible collection of events and returns json map markers.
+  # Removes duplicate locations.
+  def get_map_markers_from_events(events)
+    get_map_markers(
+      @events.reduce([]) do |arr, e|
+        loc = e.place || e.address
+        if loc then arr << loc else arr end
+      end.uniq
+    )
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,8 @@
 
 # app/controllers/events_controller.rb
 class EventsController < ApplicationController
+  include MapMarkers
+
   before_action :set_event, only: %i[show edit update destroy]
   before_action :set_day, only: :index
   before_action :set_sort, only: :index

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PartnersController < ApplicationController
+  include MapMarkers
+
   before_action :set_partner, only: [:show, :embed]
   before_action :set_day, only: [:show, :embed]
   before_action :set_primary_neighbourhood, only: [:index]

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -21,7 +21,8 @@ class PartnersController < ApplicationController
     # Get all partners based in the neighbourhoods associated with this site.
     @partners = Partner.for_site(current_site).order(:name)
 
-    @map = get_map_markers(@partners) if @partners.detect(&:address)
+    # show only partners with no service_areas
+    @map = get_map_markers(@partners, true) if @partners.detect(&:address)
   end
 
   # # GET /places

--- a/test/controllers/concerns/map_markers_concern_test.rb
+++ b/test/controllers/concerns/map_markers_concern_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActiveSupport::TestCase
+
+  def self.context(description)
+    yield
+  end
+end
+
+class MapMarkersConcernTest < ActiveSupport::TestCase
+  class FakeController < ApplicationController
+    include MapMarkers
+  end
+
+  def controller
+    @controller ||= FakeController.new
+  end
+
+  context "get_map_markers" do
+    test "returns empty array if empty input" do
+      markers = controller.get_map_markers([])
+      assert_empty markers
+    end
+
+    test "returns payload for partners" do
+      partners = create_list(:partner, 10)
+      output = controller.get_map_markers(partners)
+      assert_equal 10, output.length
+
+      entry = output.first
+      assert_field entry, :lat
+      assert_field entry, :lon
+      assert_field entry, :name
+      assert_field entry, :id
+    end
+
+    test "returns payload for addresses" do
+      addresses = create_list(:address, 10)
+      output = controller.get_map_markers(addresses)
+      assert_equal 10, output.length
+
+      entry = output.first
+      assert_field entry, :lat
+      assert_field entry, :lon
+    end
+
+    test "skips partners with no service areas when flagged" do
+      neighbourhood = neighbourhoods(:one)
+
+      # no service areas
+      partners = create_list(:partner, 5)
+
+      # service areas
+      5.times do
+        partner = create(:partner)
+        partner.service_area_neighbourhoods << neighbourhood
+
+        partners << partner
+      end
+
+      output = controller.get_map_markers(partners, true)
+      assert_equal 5, output.length
+    end
+
+    test "cam turn events into markers" do
+      events = create_list(:event, 10)
+      output = controller.get_map_markers(events)
+      assert_equal 10, output.length
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Fixes #1346

* On Partners index page: only show partners that have physical addresses (filter out Partners with any service areas)
* On Partners show page: show all markers from physical addresses and service areas
