### PR TITLE
Simplify and clarify calendar contact form information

### DIFF
--- a/app/controllers/admin/calendars_controller.rb
+++ b/app/controllers/admin/calendars_controller.rb
@@ -105,10 +105,7 @@ module Admin
         :importer_mode,
         :public_contact_name,
         :public_contact_phone,
-        :public_contact_email,
-        :partnership_contact_name,
-        :partnership_contact_phone,
-        :partnership_contact_email
+        :public_contact_email
       )
     end
   end

--- a/app/views/admin/calendars/_form.html.erb
+++ b/app/views/admin/calendars/_form.html.erb
@@ -65,23 +65,13 @@
     <div class="row">
       <div class="col-md-6">
         <h4>Public Contact</h4>
-        <p>This is the information that will be shown to the public for any enquiries about the event. If it's not set, it uses the information from the Organiser.</p>
+        <p>The contact info for the email account that manages this calendar</p>
         <label>Name</label>
         <%= f.text_field :public_contact_name, class: "form-control" %>
         <label>Email</label>
         <%= f.email_field :public_contact_email, class: "form-control" %>
         <label>Phone Number</label>
         <%= f.text_field :public_contact_phone, class: "form-control" %>
-      </div>
-      <div class="col-md-6">
-        <h4>Partnership Contact</h4>
-        <p><em>If different from public contact:</em> The contact person for PlaceCal. Use this to store an additional contact such as the public contact's manager.</p>
-        <label>Name</label>
-        <%= f.text_field :partnership_contact_name, class: "form-control" %>
-        <label>Email</label>
-        <%= f.email_field :partnership_contact_email, class: "form-control" %>
-        <label>Phone Number</label>
-        <%= f.text_field :partnership_contact_phone, class: "form-control" %>
       </div>
     </div>
 

--- a/app/views/admin/calendars/_form.html.erb
+++ b/app/views/admin/calendars/_form.html.erb
@@ -64,7 +64,6 @@
     <h3 class="mt-5">Contact Information</h3>
     <div class="row">
       <div class="col-md-6">
-        <h4>Public Contact</h4>
         <p>The contact info for the email account that manages this calendar</p>
         <label>Name</label>
         <%= f.text_field :public_contact_name, class: "form-control" %>

--- a/db/migrate/20220720151156_remove_calendar_contact_info_fields.rb
+++ b/db/migrate/20220720151156_remove_calendar_contact_info_fields.rb
@@ -1,0 +1,7 @@
+class RemoveCalendarContactInfoFields < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :calendars, :partnership_contact_name, :string
+    remove_column :calendars, :partnership_contact_email, :string
+    remove_column :calendars, :partnership_contact_phone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_11_161804) do
+ActiveRecord::Schema.define(version: 2022_07_20_151156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,9 +76,6 @@ ActiveRecord::Schema.define(version: 2022_07_11_161804) do
     t.text "critical_error"
     t.string "page_access_token"
     t.boolean "is_working", default: true, null: false
-    t.string "partnership_contact_name"
-    t.string "partnership_contact_email"
-    t.string "partnership_contact_phone"
     t.string "public_contact_name"
     t.string "public_contact_email"
     t.string "public_contact_phone"

--- a/test/factories/calendar.rb
+++ b/test/factories/calendar.rb
@@ -13,10 +13,6 @@ FactoryBot.define do
     public_contact_email { 'public@communitygroup.com'}
     public_contact_phone { '0161 0000000' }
 
-    partnership_contact_name { 'Back Office Manager' }
-    partnership_contact_email { 'backoffice@communitygroup.com' }
-    partnership_contact_phone { '0161 0000001' }
-
     partner
 
     place


### PR DESCRIPTION
Fixes #1338 

- Change of copy on the 'public contact' area
- Removal of partnership contact form area