### PR TITLE
Use pg 1.4.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    pg (1.3.5)
+    pg (1.4.3)
     popper_js (1.16.0)
     pry (0.14.1)
       coderay (~> 1.1)


### PR DESCRIPTION
Homebrew no longer has a `postgresql` package, instead requiring version specification (eg `postgresql@14`). `pg` 1.3.5 looks for `libpq` in at `$(brew --prefix)/opt/postgresql/` but there's nothing there anymore. The `pg` gem resolved this in later versions of itself.