### PR TITLE
Fix: scoping on site partners by tag

### DIFF
--- a/app/components/computer_access/_computer_access.html.erb
+++ b/app/components/computer_access/_computer_access.html.erb
@@ -20,7 +20,7 @@
   <% if places.any? %>
     <ul>
       <% places.each do |location| %>
-        <li><%= link_to location.name, places_url(location) %></li>
+        <li><%= link_to location.name, partner_url(location) %></li>
       <% end %>
     </ul>
   <% else %>

--- a/app/components/computer_access/_computer_access.html.erb
+++ b/app/components/computer_access/_computer_access.html.erb
@@ -20,7 +20,7 @@
   <% if places.any? %>
     <ul>
       <% places.each do |location| %>
-        <li><%= link_to location.name, partner_url(location) %></li>
+        <li><%= link_to location.name, partner_path(location) %></li>
       <% end %>
     </ul>
   <% else %>

--- a/app/components/free_public_wifi/_free_public_wifi.html.erb
+++ b/app/components/free_public_wifi/_free_public_wifi.html.erb
@@ -24,7 +24,7 @@
   <% if places.any? %>
     <ul>
       <% places.each do |location| %>
-        <li><%= link_to location.name, places_url(location) %></li>
+        <li><%= link_to location.name, partner_url(location) %></li>
       <% end %>
     </ul>
   <% else %>

--- a/app/components/free_public_wifi/_free_public_wifi.html.erb
+++ b/app/components/free_public_wifi/_free_public_wifi.html.erb
@@ -24,7 +24,7 @@
   <% if places.any? %>
     <ul>
       <% places.each do |location| %>
-        <li><%= link_to location.name, partner_url(location) %></li>
+        <li><%= link_to location.name, partner_path(location) %></li>
       <% end %>
     </ul>
   <% else %>

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -24,27 +24,13 @@ class SitesController < ApplicationController
 
   def set_places_to_get_computer_access
     tag = Tag.find_by(slug: 'computers')
-    if tag.nil?
-      @places_to_get_computer_access = []
-      return
-    end
 
-    @places_to_get_computer_access = Partner
-      .with_tags(tag)
-      .for_site(current_site)
-      .sort_by(&:name.downcase)
+    @places_to_get_computer_access = Partner.for_site_with_tag(current_site, tag)
   end
 
   def set_places_with_free_wifi
     tag = Tag.find_by(slug: 'wifi')
-    if tag.nil?
-      @places_with_free_wifi = []
-      return
-    end
 
-    @places_with_free_wifi = Partner
-      .with_tags(tag)
-      .for_site(current_site)
-      .sort_by(&:name.downcase)
+    @places_with_free_wifi = Partner.for_site_with_tag(current_site, tag)
   end
 end

--- a/test/integration/sites_integration_test.rb
+++ b/test/integration/sites_integration_test.rb
@@ -67,6 +67,10 @@ class SitesIntegrationTest < ActionDispatch::IntegrationTest
     get 'http://hulme.lvh.me'
 
     assert_select '.help__computer_access'
+
+    url = partner_path(partner)
+    selector = ".help__computer_access a[href='#{url}']"
+    assert_select selector
   end
 
   test 'show public wifi card when partners are tagged for it' do
@@ -80,5 +84,9 @@ class SitesIntegrationTest < ActionDispatch::IntegrationTest
 
     get 'http://hulme.lvh.me'
     assert_select '.help__free_public_wifi'
+
+    url = partner_path(partner)
+    selector = ".help__free_public_wifi a[href='#{url}']"
+    assert_select selector
   end
 end

--- a/test/models/partner_site_with_tag_scope_test.rb
+++ b/test/models/partner_site_with_tag_scope_test.rb
@@ -65,6 +65,10 @@ class PartnerSiteWithTagScopeTest < ActiveSupport::TestCase
       partner.tags << other_tag
     end
 
+    2.times do |n|
+      create :partner, name: "Partner with no tags #{n}", address: address_one
+    end
+
     output = Partner.for_site_with_tag(site, tag)
     assert_equal 4, output.all.length
   end

--- a/test/models/partner_site_with_tag_scope_test.rb
+++ b/test/models/partner_site_with_tag_scope_test.rb
@@ -1,0 +1,72 @@
+
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PartnerSiteWithTagScopeTest < ActiveSupport::TestCase
+
+  # this verifies that partner#for_site is behaving
+
+  # NOTE: these MUST match up with the geocoder response
+  #   defined in test/support/geocoder.rb
+  POST_CODE = 'M15 5DD'
+  UNIT = 'ward'
+  UNIT_CODE = 'E05011368' # from codes/admin_ward
+  UNIT_NAME = 'Hulme' # from admin_ward
+  UNIT_CODE_KEY = 'WD19CD'
+
+  def site
+    @site ||= create(:site)
+  end
+
+  def geocodable_neighbourhood_one
+    @geocodable_neighbourhood_one ||= create(
+      :bare_neighbourhood,
+      unit: UNIT,
+      unit_name: UNIT_NAME,
+      unit_code_key: UNIT_CODE_KEY,
+      unit_code_value: UNIT_CODE
+    )
+  end
+
+  def address_one
+    @addresss_one ||= create(
+      :bare_address_1,
+      postcode: POST_CODE # IMPORTANT!
+    )
+  end
+
+  setup do
+    Neighbourhood.destroy_all
+  end
+
+  test "empty site/tag returns nothing" do
+    tag = nil
+    output = Partner.for_site_with_tag(site, tag)
+    assert output.empty?, 'site should be empty'
+  end
+
+  test "finds partners with tag" do
+    tag = create(:tag)
+    other_tag = create(:tag)
+
+    neighbourhood = geocodable_neighbourhood_one
+    site.neighbourhoods << neighbourhood
+    site.tags << tag
+    site.tags << other_tag
+
+    4.times do |n|
+      partner = create(:partner, name: "Partner #{n}", address: address_one)
+      partner.tags << tag
+    end
+
+    6.times do |n|
+      partner = create(:partner, name: "Partner without tag #{n}", address: address_one)
+      partner.tags << other_tag
+    end
+
+    output = Partner.for_site_with_tag(site, tag)
+    assert_equal 4, output.all.length
+  end
+
+end


### PR DESCRIPTION
Fixes #1443 

A scope on partners that returns partners for a given site with a single (site) tag present. Partners can have either address OR service area in sites neighbourhoods