### PR TITLE
Fix: partner tag selector bug

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -265,6 +265,16 @@ class Partner < ApplicationRecord
     events.find_by_week(Time.now).count
   end
 
+  def opening_times_data
+    # FIXME: opening_times field is really just a string
+    #  even tho we use jsonb as a field type. this should
+    #  be corrected to just push raw object data into the
+    #  field and let PG deal with it.
+    return '[]' if opening_times.blank?
+
+    opening_times
+  end
+
   def human_readable_opening_times
     return [] if !opening_times || opening_times.length == 0
 

--- a/app/views/admin/partners/_opening_times.html.erb
+++ b/app/views/admin/partners/_opening_times.html.erb
@@ -1,9 +1,7 @@
 <%# We only use the active record helpers on the part of the form that will be submitted %>
 <%# Everything else is written in HTML so that the syntax matches the stimulus docs %>
 
-<% opening_times_payload = @partner.opening_times.present? ? @partner.opening_times : [] %>
-
-<div data-controller="opening-times" data-opening-times-data-value='<%= opening_times_payload %>'>
+<div data-controller="opening-times" data-opening-times-data-value='<%= @partner.opening_times_data %>'>
   <ul class="list-group" data-opening-times-target="list">
   </ul>
 

--- a/app/views/admin/partners/_opening_times.html.erb
+++ b/app/views/admin/partners/_opening_times.html.erb
@@ -1,7 +1,9 @@
 <%# We only use the active record helpers on the part of the form that will be submitted %>
 <%# Everything else is written in HTML so that the syntax matches the stimulus docs %>
 
-<div data-controller="opening-times" data-opening-times-data-value='<%= @partner.opening_times %>'>
+<% opening_times_payload = @partner.opening_times.present? ? @partner.opening_times : [] %>
+
+<div data-controller="opening-times" data-opening-times-data-value='<%= opening_times_payload %>'>
   <ul class="list-group" data-opening-times-target="list">
   </ul>
 
@@ -29,5 +31,5 @@
     <button data-action="click->opening-times#addOpeningTime" type="" class="btn btn-primary">Add</button>
   </div>
 
-  <%= f.text_area :opening_times, data: { opening_times_target: "textarea" }, hidden: true %> 
+  <%= f.text_area :opening_times, data: { opening_times_target: "textarea" }, hidden: true %>
 </div>

--- a/test/models/partner_test.rb
+++ b/test/models/partner_test.rb
@@ -139,4 +139,23 @@ class PartnerTest < ActiveSupport::TestCase
 
     assert_equal [], partner.human_readable_opening_times
   end
+
+  test 'opening_times can be unset' do
+    p = Partner.new
+    assert_equal '[]', p.opening_times_data
+
+    p = Partner.new opening_times: ''
+    assert_equal '[]', p.opening_times_data
+
+    opening_times_payload = [
+      { opens: '', closes: '' },
+      { opens: '', closes: '' },
+      { opens: '', closes: '' },
+    ].to_json
+
+    p = Partner.new(opening_times: opening_times_payload)
+
+    found = JSON.parse(p.opening_times_data)
+    assert_equal 3, found.length
+  end
 end

--- a/test/system/admin/partner_test.rb
+++ b/test/system/admin/partner_test.rb
@@ -91,4 +91,17 @@ class AdminPartnerTest < ApplicationSystemTestCase
       assert !data.include?(new_time)
     end
   end
+
+  test 'opening time picker on partner form survives missing value' do
+    @partner.update! opening_times: nil
+
+    click_sidebar 'partners'
+    await_datatables
+    click_link @partner.name
+    await_select2
+
+    # very specific bug here: if opening times has malformed data
+    #   it will crash the partner tags selector
+    assert_selector '.partner_tags ul.select2-selection__rendered'
+  end
 end

--- a/test/system/admin/partner_test.rb
+++ b/test/system/admin/partner_test.rb
@@ -100,8 +100,10 @@ class AdminPartnerTest < ApplicationSystemTestCase
     click_link @partner.name
     await_select2
 
-    # very specific bug here: if opening times has malformed data
-    #   it will crash the partner tags selector
+    # very specific bug in the view template here: if opening times has malformed data
+    #   it will cause problems for the javascript that runs the partner tags selector
+    #   (in the browser). so we verify the select2 code has worked by seeing if it has
+    #   correctly done its thing to the tag selector
     assert_selector '.partner_tags ul.select2-selection__rendered'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,7 +32,7 @@ module ActiveSupport
   class TestCase
     include FactoryBot::Syntax::Methods
 
-    parallelize(workers: :number_of_processors)
+    # parallelize(workers: :number_of_processors)
 
     fixtures :neighbourhoods
 


### PR DESCRIPTION
Closes #1460 

On admin partner edit page, partners with missing opening times value would crash JS and cause tags selector to fail.

Quick sanitisation of value and a system test to cover that scenario