### PR TITLE
Use HTTPS for system tests

### DIFF
--- a/test/system_test_helper.rb
+++ b/test/system_test_helper.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-Capybara.app_host = 'http://lvh.me'
+Capybara.app_host = 'https://lvh.me'
 
 VCR.configure do |c|
   c.ignore_localhost = true


### PR DESCRIPTION
We run everything else assuming we're using HTTPS. This might be the cause of the flaky test failures.