### PR TITLE
Inherit default route options for ActionMailer from routes

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  config.action_mailer.default_url_options = routes.default_url_options
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,6 +119,7 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = routes.default_url_options
   config.action_mailer.smtp_settings = {
     address: 'smtp.mailersend.net',
     port: 587,

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -64,6 +64,7 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = routes.default_url_options
   config.action_mailer.smtp_settings = {
     address: 'smtp.mailersend.net',
     port: 587,

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = routes.default_url_options
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,7 +6,8 @@
 Rails.application.configure do
   routes.default_url_options = {
     host: ENV.fetch('SITE_DOMAIN', 'lvh.me'),
-    port: 3000
+    port: 3000,
+    protocol: 'http'
   }
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/test/system/create_admin_users_test.rb
+++ b/test/system/create_admin_users_test.rb
@@ -4,8 +4,12 @@ class CreateAdminUsersTest < ApplicationSystemTestCase
   setup do
     server = Capybara.current_session.server
     app_routes = Rails.application.routes
+
+    # Use configuration from Capybara session so URLs are generated pointing at
+    # the correct test server
     app_routes.default_url_options[:host] = server.host
     app_routes.default_url_options[:port] = server.port
+    app_routes.default_url_options[:protocol] = 'http'
   end
 
   test "visiting the index" do


### PR DESCRIPTION
In the test environment:

```
From: .../github.com/geeksforsocialchange/PlaceCal/test/system/create_admin_users_test.rb:48 CreateAdminUsersTest#test_visiting_the_index:

    43:
    44:     invitation_url = extract_invitation_link_from(email)
    45:     # puts "invitation_url=#{invitation_url}"
    46:     assert invitation_url, 'Could not find invitation URL in email'
    47:
 => 48:     binding.pry
    49:
    50:     # set password
    51:     visit invitation_url
    52:     fill_in 'New password', with: 'password'
    53:     fill_in 'Repeat password', with: 'password'

[1] pry(#<CreateAdminUsersTest>)> invitation_url
=> "https://127.0.0.1:52983/users/invitation/accept?invitation_token=fCX4-BqSAwyCwzmLNGqo\r"
```

This was due to ActionMailer using the default config, which we need to override.