### PR TITLE
Fix: Don't try to hash non string inputs

### DIFF
--- a/app/jobs/calendar_importer/parsers/ics.rb
+++ b/app/jobs/calendar_importer/parsers/ics.rb
@@ -33,7 +33,9 @@ module CalendarImporter::Parsers
     def download_calendar
       # Why are we doing this?
       url = @url.gsub(%r{webcal://}, 'https://') # Remove the webcal:// and just use the part after it
-      HTTParty.get(url, follow_redirects: true)
+      response = HTTParty.get(url, follow_redirects: true)
+      return '' unless response.success?
+      response.body
     end
 
     def import_events_from(data)
@@ -51,11 +53,6 @@ module CalendarImporter::Parsers
       end
 
       @events
-    end
-
-    def digest(data)
-      # read file to get contents before creating digest
-      Digest::MD5.hexdigest(data)
     end
 
     def parse_remote_calendars(data)

--- a/app/jobs/calendar_importer/parsers/ics.rb
+++ b/app/jobs/calendar_importer/parsers/ics.rb
@@ -35,6 +35,7 @@ module CalendarImporter::Parsers
       url = @url.gsub(%r{webcal://}, 'https://') # Remove the webcal:// and just use the part after it
       response = HTTParty.get(url, follow_redirects: true)
       return '' unless response.success?
+
       response.body
     end
 


### PR DESCRIPTION
Fixes #1493 

There was a bug where non-string responses were being passed into string expecting methods (and crashing). Turns out the method in question was already defined on a base class in a more robust manner. So let's use that!