### PR TITLE
Update link to PlaceCal handbook on calendar admin page

### DIFF
--- a/app/views/admin/calendars/_form.html.erb
+++ b/app/views/admin/calendars/_form.html.erb
@@ -23,7 +23,7 @@
                           hint: 'What group organises these events?' %>
 
         <%= f.input :name, hint: 'A simple description to help rememember what this calendar is' %>
-        <%= f.input :source, label: 'URL', placeholder: 'https://your-domain.com/events.ics', hint: "The source URL for your calendar feed. See the #{link_to 'PlaceCal Handbook', 'https://handbook.placecal.org/admins/supported-sources.html'} if you need help.".html_safe %>
+        <%= f.input :source, label: 'URL', placeholder: 'https://your-domain.com/events.ics', hint: "The source URL for your calendar feed. See the #{link_to 'PlaceCal Handbook', 'https://gfsc.notion.site/Supported-Event-Sources-603f67d632c24aebbb32b9be7edebfa5'} if you need help.".html_safe %>
         <%= f.input :importer_mode,
           collection: options_for_importer,
           default: 'auto',

--- a/app/views/admin/calendars/_form.html.erb
+++ b/app/views/admin/calendars/_form.html.erb
@@ -23,7 +23,7 @@
                           hint: 'What group organises these events?' %>
 
         <%= f.input :name, hint: 'A simple description to help rememember what this calendar is' %>
-        <%= f.input :source, label: 'URL', placeholder: 'https://your-domain.com/events.ics', hint: "The source URL for your calendar feed. See the #{link_to 'PlaceCal Handbook', 'https://gfsc.notion.site/Supported-Event-Sources-603f67d632c24aebbb32b9be7edebfa5'} if you need help.".html_safe %>
+        <%= f.input :source, label: 'URL', placeholder: 'https://your-domain.com/events.ics', hint: "The source URL for your calendar feed. See the #{link_to 'PlaceCal Handbook', 'https://handbook.placecal.org/admin-handbook'} if you need help.".html_safe %>
         <%= f.input :importer_mode,
           collection: options_for_importer,
           default: 'auto',


### PR DESCRIPTION
fixes #1498

- update link to placecal handbook.
- add examples of url format to handbook.
- confirm that events are now pulling through from the url noted in the issue.