### PR TITLE
Improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,9 @@
 name: Bug
 about: Create a bug report
 title: "[Bug]: "
-labels: bug
+labels:
+  - bug
+  - needs triage
 ---
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,9 @@
 ---
 name: Feature
 about: Create a feature request
-labels: enhancement
+labels:
+  - enhancement
+  - needs triage
 ---
 
 ## User story

--- a/.github/ISSUE_TEMPLATE/technical_debt.md
+++ b/.github/ISSUE_TEMPLATE/technical_debt.md
@@ -1,0 +1,15 @@
+---
+name: Technical debt
+about: Log some technical debt to be paid back
+labels:
+  - tech debt
+  - needs triage
+---
+
+## Description
+
+What needs doing?
+
+## Motivation
+
+Why is it important?


### PR DESCRIPTION
This sets the "needs triage" label on all new issues to support that as a new workflow.

It also created a new technical debt template to reduce the amount of skipping outside of the templates being done.