### PR TITLE
Fetch the full Git history for deployments

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: production
+          fetch-depth: 0
       - uses: dokku/github-action@v1.3.0
         with:
           git_remote_url: "ssh://dokku@placecal.org:666/placecal"

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: main
+          fetch-depth: 0
       - uses: dokku/github-action@v1.3.0
         with:
           git_remote_url: "ssh://dokku@placecal-staging.org:666/placecal"


### PR DESCRIPTION
dokku/github-action pushes a specific commit and needs to have a local copy of that commit to do so.

Relates to #1522