### PR TITLE
Fix: cleaning up HTML before parsing into markdown

### DIFF
--- a/app/jobs/calendar_importer/events/base.rb
+++ b/app/jobs/calendar_importer/events/base.rb
@@ -52,10 +52,13 @@ module CalendarImporter::Events
         # if we get HTML then remove all the attributes from all of
         # the tags so it doesn't interfere with the kramdown step
         doc.css('*').each do |tag|
+          # rubocop:disable Style/HashEachMethods
           tag.keys.each do |attribute_name|
             next if tag.name == 'a' && attribute_name == 'href'
+
             tag.remove_attribute attribute_name
           end
+          # rubocop:enable Style/HashEachMethods
         end
 
         if footer.present?

--- a/app/jobs/calendar_importer/events/base.rb
+++ b/app/jobs/calendar_importer/events/base.rb
@@ -31,9 +31,11 @@ module CalendarImporter::Events
       input = input.to_s.strip
       return '' if input.blank?
 
+      # attempt to get rid of broken UTF-8
       clean_text = sanitize_invalid_char(input)
       input_mode = 'markdown'
 
+      # do we have HTML? yeah let's get rid of that
       doc = Nokogiri::HTML.fragment(clean_text)
       if doc.css('*').length.positive?
         input_mode = 'html'
@@ -47,6 +49,15 @@ module CalendarImporter::Events
 
         doc.css('h1', 'h2').each { |header| header.name = 'h3' }
 
+        # if we get HTML then remove all the attributes from all of
+        # the tags so it doesn't interfere with the kramdown step
+        doc.css('*').each do |tag|
+          tag.keys.each do |attribute_name|
+            next if tag.name == 'a' && attribute_name == 'href'
+            tag.remove_attribute attribute_name
+          end
+        end
+
         if footer.present?
           doc << '<br/><br/>'
           doc << footer
@@ -56,6 +67,7 @@ module CalendarImporter::Events
         clean_text = ActionController::Base.helpers.sanitize(body_text, tags: ALLOWED_TAGS)
       end
 
+      # convert HTML tags into markdown kramdown
       Kramdown::Document.new(clean_text, input: input_mode).to_kramdown.strip
     end
 

--- a/test/jobs/calendar_importer/event_base_html_sanitize_test.rb
+++ b/test/jobs/calendar_importer/event_base_html_sanitize_test.rb
@@ -23,9 +23,12 @@ class EventBaseHtmlSanitizeTest < ActiveSupport::TestCase
 
   test 'returns content if HTML is input' do
     input = <<-HTML
-      <h1>A title!</h1>
+      <h1 id="title">A title!</h1>
       <p>This is input</p>
-      <p>Another Paragraph</p>
+      <p class="content">
+        Another Paragraph. <a href="http://example.com/thing">A link</a>
+      </p>
+
       <ul>
         <li>One</li>
         <li>Two</li>
@@ -41,11 +44,15 @@ class EventBaseHtmlSanitizeTest < ActiveSupport::TestCase
 
       This is input
 
-      Another Paragraph
+      Another Paragraph. [A link][1]
 
       * One
       * Two
       * Three
+
+
+
+      [1]: http://example.com/thing
     MARKDOWN
 
     assert_equal expected_output.strip, output


### PR DESCRIPTION
Fixes #1530 

Strip HTML tags of their attributes (but keep <a> tag hrefs)