### PR TITLE
Strip all HTML out of summary fields

### DIFF
--- a/app/jobs/calendar_importer/events/base.rb
+++ b/app/jobs/calendar_importer/events/base.rb
@@ -27,7 +27,7 @@ module CalendarImporter::Events
     # Convert h1 and h2 to h3
     # Strip out all shady tags
     # Convert all html to markdown
-    def html_sanitize(input, just_as_text: false)
+    def html_sanitize(input, as_plaintext: false)
       input = input.to_s.strip
       return '' if input.blank?
 
@@ -37,7 +37,7 @@ module CalendarImporter::Events
 
       # do we have HTML? yeah let's get rid of that
       doc = Nokogiri::HTML.fragment(clean_text)
-      if just_as_text
+      if as_plaintext
         clean_text = doc.text
 
       else
@@ -84,7 +84,7 @@ module CalendarImporter::Events
     def attributes
       { uid: uid&.strip,
         summary: html_sanitize(summary,
-                               just_as_text: true),
+                               as_plaintext: true),
         description: html_sanitize(description),
         raw_location_from_source: location&.strip,
         rrule: rrule,

--- a/test/jobs/calendar_importer/event_base_html_sanitize_test.rb
+++ b/test/jobs/calendar_importer/event_base_html_sanitize_test.rb
@@ -106,6 +106,16 @@ class EventBaseHtmlSanitizeTest < ActiveSupport::TestCase
     assert_equal input, output
   end
 
+  test 'it can filter out &amp; type HTML entities' do
+    event = EventBase.new(nil)
+
+    bad_text = '<p>VFD PRESENTS: Queer Comedy Nights // Britney &amp; Sarah Kendall</p>'
+    output = event.html_sanitize(bad_text, just_as_text: true)
+
+    clean_text = 'VFD PRESENTS: Queer Comedy Nights // Britney & Sarah Kendall'
+    assert_equal clean_text, output
+  end
+
   #  test 'cleans out non utf-8 input' do
   #    # pulled from https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
   #    input = '��This is a �����bad string�����'

--- a/test/jobs/calendar_importer/event_base_html_sanitize_test.rb
+++ b/test/jobs/calendar_importer/event_base_html_sanitize_test.rb
@@ -110,7 +110,7 @@ class EventBaseHtmlSanitizeTest < ActiveSupport::TestCase
     event = EventBase.new(nil)
 
     bad_text = '<p>VFD PRESENTS: Queer Comedy Nights // Britney &amp; Sarah Kendall</p>'
-    output = event.html_sanitize(bad_text, just_as_text: true)
+    output = event.html_sanitize(bad_text, as_plaintext: true)
 
     clean_text = 'VFD PRESENTS: Queer Comedy Nights // Britney & Sarah Kendall'
     assert_equal clean_text, output


### PR DESCRIPTION
Closes #1533 

Assume summary field could contain risky content (like HTML) and scrub that out before saving in DB.