### PR TITLE
Speeding up partner index page load time

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -19,7 +19,10 @@ class PartnersController < ApplicationController
     # @partners = Partner.managers.for_site(current_site).order(:name)
 
     # Get all partners based in the neighbourhoods associated with this site.
-    @partners = Partner.for_site(current_site).order(:name)
+    @partners = Partner
+                .for_site(current_site)
+                .includes(:service_areas, :address)
+                .order(:name)
 
     # show only partners with no service_areas
     @map = get_map_markers(@partners, true) if @partners.detect(&:address)

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -132,7 +132,7 @@ class Partner < ApplicationRecord
     end
 
     # now look for addresses and service areas
-    site_neighbourhood_ids = site.owned_neighbourhoods.map(&:id)
+    site_neighbourhood_ids = site.owned_neighbourhood_ids
 
     # skip everything if site has no neighbourhoods
     return none if site_neighbourhood_ids.empty?
@@ -157,7 +157,7 @@ class Partner < ApplicationRecord
             .where(partner_tags: { tag: tag })
 
     # now look for addresses and service areas
-    site_neighbourhood_ids = site.owned_neighbourhoods.map(&:id)
+    site_neighbourhood_ids = site.owned_neighbourhood_ids
 
     # skip everything if site has no neighbourhoods
     return none if site_neighbourhood_ids.empty?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -57,6 +57,13 @@ class Site < ApplicationRecord
     neighbourhoods.map(&:subtree).flatten
   end
 
+  def owned_neighbourhood_ids
+    neighbourhoods
+      .select(:id, :ancestry)
+      .map(&:subtree_ids)
+      .flatten
+  end
+
   # ASSUMPTION: There is no row in the sites table for the admin site, hence
   # defining the admin subdomain string here.
   ADMIN_SUBDOMAIN = 'admin'
@@ -79,7 +86,7 @@ class Site < ApplicationRecord
 
   # Should we show the neighbourhood lozenge out on this site?
   def show_neighbourhoods?
-    owned_neighbourhoods.count > 1
+    owned_neighbourhood_ids.count > 1
   end
 
   def self.badge_zoom_level_label(value)


### PR DESCRIPTION
Fixes #1532 

When pulling neighbourhoods out of the database only instantiate the fields that are required so ActiveRecord doesn't have to parse unused values