### PR TITLE
Stop pinning gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ end
 # Core
 gem 'minitest-rails'
 gem 'pg'
-gem 'puma', '5.6.5'
-gem 'rails', '6.1.7'
+gem 'puma'
+gem 'rails'
 
 # Frontend
-gem 'coffee-rails', '5.0.0'
+gem 'coffee-rails'
 gem 'importmap-rails'
 gem 'jquery-rails'
 gem 'jquery-turbolinks'
@@ -42,7 +42,7 @@ gem 'carrierwave'
 gem 'image_processing'
 
 # Admin
-gem 'bootstrap', '4.6.2'
+gem 'bootstrap'
 gem 'cocoon'
 gem 'font-awesome-rails'
 gem 'select2-rails'
@@ -55,7 +55,7 @@ gem 'omniauth-facebook'
 gem 'pundit'
 
 # Maps and geolocation
-gem 'geocoder', '1.6.7'
+gem 'geocoder'
 gem 'leaflet-rails'
 
 # Styleguide
@@ -82,9 +82,9 @@ gem 'seed_migration'
 gem 'active_link_to'
 gem 'bootsnap', require: false
 gem 'enumerize'
-gem 'friendly_id', '5.3.0'
-gem 'jbuilder', '2.11.5'
-gem 'listen', '3.2.1'
+gem 'friendly_id'
+gem 'jbuilder'
+gem 'listen'
 gem 'oj'
 gem 'paper_trail'
 gem 'rollbar'
@@ -113,13 +113,13 @@ group :development do
   gem 'rubocop-rails', require: false
   gem 'rubocop-rake', require: false
   gem 'spring'
-  gem 'spring-watcher-listen', '2.0.1'
-  gem 'web-console', '4.2.0'
+  gem 'spring-watcher-listen'
+  gem 'web-console'
   gem 'yard'
 end
 
 group :test do
-  gem 'capybara-select-2', '0.5.1'
+  gem 'capybara-select-2'
   gem 'graphql-client'
   gem 'json_matchers'
   gem 'minitest-rails-capybara'
@@ -135,4 +135,4 @@ end
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Use Redis for Action Cable
-gem 'redis', '4.6.0'
+gem 'redis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,12 +529,12 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
-  bootstrap (= 4.6.2)
+  bootstrap
   byebug
-  capybara-select-2 (= 0.5.1)
+  capybara-select-2
   carrierwave
   cocoon
-  coffee-rails (= 5.0.0)
+  coffee-rails
   delayed_job_active_record
   devise
   devise_invitable
@@ -543,8 +543,8 @@ DEPENDENCIES
   eventbrite_sdk
   factory_bot_rails
   font-awesome-rails
-  friendly_id (= 5.3.0)
-  geocoder (= 1.6.7)
+  friendly_id
+  geocoder
   graphiql-rails
   graphql
   graphql-client
@@ -554,7 +554,7 @@ DEPENDENCIES
   icalendar-recurrence
   image_processing
   importmap-rails
-  jbuilder (= 2.11.5)
+  jbuilder
   jquery-rails
   jquery-turbolinks
   jsbundling-rails
@@ -563,7 +563,7 @@ DEPENDENCIES
   kramdown
   leaflet-rails
   letter_opener
-  listen (= 3.2.1)
+  listen
   minitest-rails
   minitest-rails-capybara
   minitest-reporters
@@ -572,14 +572,14 @@ DEPENDENCIES
   omniauth-facebook
   paper_trail
   pg
-  puma (= 5.6.5)
+  puma
   pundit
   rack-cors
-  rails (= 6.1.7)
+  rails
   rails-controller-testing
   rails-erd
   rails_autolink
-  redis (= 4.6.0)
+  redis
   rollbar
   rubocop-graphql
   rubocop-minitest
@@ -593,14 +593,14 @@ DEPENDENCIES
   sendgrid-actionmailer
   simple_form
   spring
-  spring-watcher-listen (= 2.0.1)
+  spring-watcher-listen
   stimulus-rails
   timecop
   turbo-rails
   uk_postcode
   vcr
   virtus
-  web-console (= 4.2.0)
+  web-console
   webmock
   whenever
   yard


### PR DESCRIPTION
We have a lockfile to pin them for us, so we don't need to pin them.

This should allow Renovate to automerge updates to them if they pass.