### PR TITLE
delink partner addresses

### DIFF
--- a/app/javascript/controllers/address_toggle_controller.js
+++ b/app/javascript/controllers/address_toggle_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="address-toggle"
+export default class extends Controller {
+	static values = { state: Boolean };
+	static targets = ["toggle"];
+
+	connect() {
+		this.addressId = this.element.querySelector(
+			"#partner_address_attributes_id"
+		);
+		this.toggleTarget.checked = this.stateValue;
+		this.stateValue ? this.linkAddress() : this.delinkAddress();
+	}
+
+	click() {
+		this.stateValue = !this.stateValue;
+		this.toggleTarget.checked = this.stateValue;
+		this.stateValue ? this.linkAddress() : this.delinkAddress();
+	}
+
+	delinkAddress() {
+		this.element.firstElementChild.removeChild(this.addressId);
+	}
+
+	linkAddress() {
+		this.element.firstElementChild.appendChild(this.addressId);
+	}
+}

--- a/app/javascript/controllers/address_toggle_controller.js
+++ b/app/javascript/controllers/address_toggle_controller.js
@@ -2,21 +2,17 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="address-toggle"
 export default class extends Controller {
-	static values = { state: Boolean };
 	static targets = ["toggle"];
 
 	connect() {
 		this.addressId = this.element.querySelector(
 			"#partner_address_attributes_id"
 		);
-		this.toggleTarget.checked = this.stateValue;
-		this.stateValue ? this.linkAddress() : this.delinkAddress();
+		this.toggleTarget.checked ? this.linkAddress() : this.delinkAddress();
 	}
 
 	click() {
-		this.stateValue = !this.stateValue;
-		this.toggleTarget.checked = this.stateValue;
-		this.stateValue ? this.linkAddress() : this.delinkAddress();
+		this.toggleTarget.checked ? this.linkAddress() : this.delinkAddress();
 	}
 
 	delinkAddress() {

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application";
 
+import AddressToggleController from "./address_toggle_controller.js";
+application.register("address-toggle", AddressToggleController);
+
 import ImagePreviewController from "./image_preview_controller.js";
 application.register("image-preview", ImagePreviewController);
 

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -37,7 +37,7 @@
 
     <div id='address'>
         <% if @partner.address %>
-        <div data-controller="address-toggle" data-address-state-value="false" class="row">
+        <div data-controller="address-toggle" class="row">
           <div class="col-md-6">
             <div class="form-group form-check">
               <input data-address-toggle-target="toggle" data-action="address-toggle#click" class="form-check-input" type="checkbox" value="" id="flexCheckDefault">

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -36,12 +36,27 @@
     <h2>Address</h2>
 
     <div id='address'>
+        <% if @partner.address %>
+        <div data-controller="address-toggle" data-address-state-value="false" class="row">
+          <div class="col-md-6">
+            <div class="form-group form-check">
+              <input data-address-toggle-target="toggle" data-action="address-toggle#click" class="form-check-input" type="checkbox" value="" id="flexCheckDefault">
+              <label class="form-check-label" for="flexCheckDefault">
+                Update address for all partners at this location
+              </label>
+            </div>
+            <%= f.fields_for :address, @partner.address do |a| %>
+              <%= render 'address_fields', f: a %>
+            <% end %>
+          </div>
+        <% else %>
       <div class="row">
-        <div class="col-md-6">
-          <%= f.fields_for :address, @partner.address || Address.new do |a| %>
-            <%= render 'address_fields', f: a %>
-          <% end %>
-        </div>
+          <div class="col-md-6">
+            <%= f.fields_for :address, Address.new do |a| %>
+              <%= render 'address_fields', f: a %>
+            <% end %>
+          </div>
+        <% end %>
         <div class="col-md-6">
           <%= f.input :url, class: "form-control", label: 'Website address', placeholder: 'https://your-website.org' %>
 

--- a/test/system/admin/partner_test.rb
+++ b/test/system/admin/partner_test.rb
@@ -117,7 +117,6 @@ class AdminPartnerTest < ApplicationSystemTestCase
   test 'possible to update a partner address without effecting other partners at same address' do
     address = create :ashton_address
     partners = create_list(:partner, 2, address: address)
-    partners.each { |p| puts "#{p.name} #{p.address_id} #{p.address}" }
     assert_equal partners[0].address_id, partners[1].address_id, 'Partners with the same address should have the same address_id'
     click_link 'Partners'
     await_datatables


### PR DESCRIPTION
fixes #1615 

If a partner has an address already when a user goes to edit it, the form adds a hidden field containing the `id` of the address that the partner belongs to. When the form is submitted it updates the address at that `id` so all partners which reference it have their addresses updated. This is useful if lots of groups use the same community space and it moves or is renamed.  It's less good if one group moves or was added to the address by mistake.

To solve this I've added a simple toggle to remove/include this field. It's off by default so that groups won't have their addresses changed by accident. If the new address exists already it will be assigned to that `id` or a new one will be created if not. If the address fields are left the same when updating it will retain the same `id`.