### PR TITLE
Squarespace URL normalizing bug fix

### DIFF
--- a/app/jobs/calendar_importer/parsers/squarespace.rb
+++ b/app/jobs/calendar_importer/parsers/squarespace.rb
@@ -17,7 +17,9 @@ module CalendarImporter
       end
 
       def download_calendar
-        json_url = "#{@url}?format=json"
+        json_url = @url
+        json_url += '?format=json' unless json_url.ends_with?('?format=json')
+
         response = HTTParty.get(json_url)
         return [] unless response.success?
 
@@ -25,7 +27,7 @@ module CalendarImporter
       end
 
       def import_events_from(data)
-        unless data['upcoming']
+        unless data.is_a?(Hash) && data['upcoming']
           Rails.logger.debug 'If you are seeing this it is likely that you are using the wrong URL'
           Rails.logger.debug 'or squarespace have changed their API'
           return []

--- a/app/jobs/calendar_importer/parsers/squarespace.rb
+++ b/app/jobs/calendar_importer/parsers/squarespace.rb
@@ -27,7 +27,9 @@ module CalendarImporter
       end
 
       def import_events_from(data)
-        unless data.is_a?(Hash) && data['upcoming']
+        return [] unless data.is_a?(Hash)
+
+        unless data['upcoming']
           Rails.logger.debug 'If you are seeing this it is likely that you are using the wrong URL'
           Rails.logger.debug 'or squarespace have changed their API'
           return []


### PR DESCRIPTION
Fixes #1617 

Some squarespace URLs already come to us with the source=json bit on the end so we shouldn't try to add it twice

