### PR TITLE
Make rg search respect gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,6 @@ doc/**/*.html
 doc/**/*.css
 doc/**/*.js
 .yardoc
-./tags/
+./tags
 Makefile
 doc/rdoc

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,6 @@ doc/**/*.html
 doc/**/*.css
 doc/**/*.js
 .yardoc
-tags
+./tags/
 Makefile
 doc/rdoc


### PR DESCRIPTION
I don't have tags set up on my system (maybe I should) but the current .gitignore breaks telescope which I use to search.

Does tags just live in a folder at root? would this meet everyones of our needs?