### PR TITLE
Make Tag type visible on Partner edit page

### DIFF
--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -7,8 +7,11 @@ module PartnersHelper
                        .collect { |e| { name: e.contextual_name, id: e.id } }
   end
 
-  def options_for_tags
-    policy_scope(Tag).order(:name).pluck(:name, :id)
+  def options_for_partner_tags
+    policy_scope(Tag)
+      .select(:name, :type, :id)
+      .order(:name)
+      .map { |r| [r.name_with_type, r.id] }
   end
 
   def partner_service_area_text(partner)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -42,7 +42,7 @@ class Tag < ApplicationRecord
 
   def name_with_type
     s_type = type || 'Tag'
-    "#{s_type}:#{name}"
+    "#{s_type}: #{name}"
   end
 
   private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -40,6 +40,11 @@ class Tag < ApplicationRecord
     where(id: tag_ids.uniq)
   }
 
+  def name_with_type
+    s_type = type || 'Tag'
+    "#{s_type}:#{name}"
+  end
+
   private
 
   def check_editable_fields

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -119,7 +119,7 @@
 
         <%= f.association :tags,
                           label: false,
-                          collection: options_for_tags,
+                          collection: options_for_partner_tags,
                           input_html: { class: 'form-check', data: { controller: "select2" } } %>
 
         <div id="map-pin-div" data-url="<%= image_path('icons/map/map-marker.png') %>"></div>

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -1,142 +1,143 @@
 <div class="form">
   <%= simple_form_for @partner do |f| %>
 
-    <%= render_component "error", object: @partner %>
+  <%= render_component "error", object: @partner %>
 
-    <h2>Basic Information</h2>
+  <h2>Basic Information</h2>
 
-    <%= f.input :name, class: "form-control" %>
-    <%= f.input :slug, class: "form-control" if policy(@partner).permitted_attributes.include? :slug %>
+  <%= f.input :name, class: "form-control" %>
+  <%= f.input :slug, class: "form-control" if policy(@partner).permitted_attributes.include? :slug %>
 
-    <%= f.input :summary, class: "form-control", label: 'Summary', input_html: { maxlength: 200, rows: 2 }, as: 'text' %>
+  <%= f.input :summary, class: "form-control", label: 'Summary', input_html: { maxlength: 200, rows: 2 }, as: 'text' %>
 
-    <%= f.input :description, class: "form-control", label: 'Description', input_html: { rows: 7 } %>
+  <%= f.input :description, class: "form-control", label: 'Description', input_html: { rows: 7 } %>
 
-    <%= f.input :accessibility_info, class: "form-control", label: 'Accessibility Information', input_html: { rows: 7 } %>
+  <%= f.input :accessibility_info, class: "form-control", label: 'Accessibility Information', input_html: { rows: 7 } %>
 
-    <div class="row">
-      <div class="col-md-6" data-controller="image-preview">
-        <%= f.input :image,
+  <div class="row">
+    <div class="col-md-6" data-controller="image-preview">
+      <%= f.input :image,
           hint: image_uploader_hint(@partner.image),
           as: :file,
           input_html: { data: { action: "change->image-preview#file"} }
-        %>
-        <% if @partner.image.url  %>
-          <%= image_tag @partner.image.url,  width: '125', class: 'brand_image', data: { image_preview_target: "img"}  %>
-        <% else  %>
-          <%= image_tag "", style: 'display:none;', width: '125', class: 'brand_image', data: { image_preview_target: "img"} %>
-        <% end  %>
-      </div>
-
+          %>
+      <% if @partner.image.url  %>
+      <%= image_tag @partner.image.url,  width: '125', class: 'brand_image', data: { image_preview_target: "img"}  %>
+      <% else  %>
+      <%= image_tag "", style: 'display:none;', width: '125', class: 'brand_image', data: { image_preview_target: "img"} %>
+      <% end  %>
     </div>
 
-    <br>
-    <hr>
+  </div>
 
-    <h2>Address</h2>
+  <br>
+  <hr>
 
-    <div id='address'>
-      <div class="row">
-        <div class="col-md-6">
-          <%= f.fields_for :address, @partner.address || Address.new do |a| %>
-            <%= render 'address_fields', f: a %>
-          <% end %>
-        </div>
-        <div class="col-md-6">
-          <%= f.input :url, class: "form-control", label: 'Website address', placeholder: 'https://your-website.org' %>
+  <h2>Address</h2>
 
-          <div class="form-group url optional facebook_link form-group-invalid">
-            <%= f.label :facebook_link %>
-            <div class="input-group">
-              <div class="input-group-prepend">
-                <div class="input-group-text">https://facebook.com/</div>
-              </div>
-              <%= f.input_field :facebook_link, class: "form-control", placeholder: 'FacebookPageName' %>
-              <%= f.error :facebook_link, class: 'invalid-feedback' %>
-            </div>
-          </div>
-
-          <div class="form-group url optional twitter_handle form-group-invalid">
-            <%= f.label :twitter_handle %>
-            <div class="input-group">
-              <div class="input-group-prepend">
-                <div class="input-group-text">@</div>
-              </div>
-              <%= f.input_field :twitter_handle, class: "form-control", placeholder: 'TwitterAccount' %>
-              <%= f.error :twitter_handle, class: 'invalid-feedback' %>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <hr>
-
-    <h2>Service Areas</h2>
-
-    <p>If this partner delivers services outside the above address, such as a phone support line or outreach service, select them here.</p>
-
-    <div class="sites_neighbourhoods">
-      <%= f.simple_fields_for :service_areas do |neighbourhood| %>
-        <%= render 'service_area_fields', :f => neighbourhood %>
-      <% end %>
-      <div class="links">
-        <%= link_to_add_association 'Add Service Area', f, :service_areas, class: "btn btn-primary btn-sm" %>
-      </div>
-      <br></br>
-    </div>
-
-    <br>
-
-    <hr>
-    <h2>Contact Information</h2>
-
+  <div id='address'>
     <div class="row">
       <div class="col-md-6">
-        <h3>Public Contact</h3>
-        <p>This is the information that will be shown to the public.</p>
-        <%= f.input :public_name, class: "form-control" %>
-        <%= f.input :public_email, class: "form-control" %>
-        <%= f.input :public_phone, class: "form-control" %>
-      </div>
-      <div class="col-md-6">
-        <h3>Partnership Contact</h3>
-        <p><em>If different from public contact:</em> The contact person for PlaceCal.</p>
-        <%= f.input :partner_name, class: "form-control" %>
-        <%= f.input :partner_email, class: "form-control" %>
-        <%= f.input :partner_phone, class: "form-control" %>
-      </div>
-    </div>
-    <hr>
-    <div class="row">
-      <div class="col-lg-8 col-md-12">
-        <h2>Opening times</h2>
-        <%= render 'opening_times', f: f %>
-      </div>
-      <div class="col-lg-4 col-md-12 tags">
-        <h2>Tags</h2>
-        <p>Does this Partner provide any of the following things?</p>
-
-        <%= f.association :tags,
-                          label: false,
-                          collection: options_for_partner_tags,
-                          input_html: { class: 'form-check', data: { controller: "select2" } } %>
-
-        <div id="map-pin-div" data-url="<%= image_path('icons/map/map-marker.png') %>"></div>
-      </div>
-    </div>
-    <hr>
-    <br>
-    <div class="row">
-      <div class="col-sm-12">
-        <%= f.submit "Save Partner", class: "btn btn-primary btn-lg" %><br><br><br>
-
-        <% if policy(@partner).destroy? && !@partner.new_record? %>
-          <%= link_to "Delete Partner", @partner, method: :delete, class: "btn btn-danger btn-sm", id: 'destroy-partner'  %>
+        <%= f.fields_for :address, @partner.address || Address.new do |a| %>
+        <%= render 'address_fields', f: a %>
         <% end %>
       </div>
+      <div class="col-md-6">
+        <%= f.input :url, class: "form-control", label: 'Website address', placeholder: 'https://your-website.org' %>
+
+        <div class="form-group url optional facebook_link form-group-invalid">
+          <%= f.label :facebook_link %>
+          <div class="input-group">
+            <div class="input-group-prepend">
+              <div class="input-group-text">https://facebook.com/</div>
+            </div>
+            <%= f.input_field :facebook_link, class: "form-control", placeholder: 'FacebookPageName' %>
+            <%= f.error :facebook_link, class: 'invalid-feedback' %>
+          </div>
+        </div>
+
+        <div class="form-group url optional twitter_handle form-group-invalid">
+          <%= f.label :twitter_handle %>
+          <div class="input-group">
+            <div class="input-group-prepend">
+              <div class="input-group-text">@</div>
+            </div>
+            <%= f.input_field :twitter_handle, class: "form-control", placeholder: 'TwitterAccount' %>
+            <%= f.error :twitter_handle, class: 'invalid-feedback' %>
+          </div>
+        </div>
+      </div>
     </div>
-    <%# End form tag %>
+  </div>
+
+  <hr>
+
+  <h2>Service Areas</h2>
+
+  <p>If this partner delivers services outside the above address, such as a phone support line or outreach service, select them here.</p>
+
+  <div class="sites_neighbourhoods">
+    <%= f.simple_fields_for :service_areas do |neighbourhood| %>
+    <%= render 'service_area_fields', :f => neighbourhood %>
+    <% end %>
+    <div class="links">
+      <%= link_to_add_association 'Add Service Area', f, :service_areas, class: "btn btn-primary btn-sm" %>
+    </div>
+    <br></br>
+  </div>
+
+  <br>
+
+  <hr>
+  <h2>Contact Information</h2>
+
+  <div class="row">
+    <div class="col-md-6">
+      <h3>Public Contact</h3>
+      <p>This is the information that will be shown to the public.</p>
+      <%= f.input :public_name, class: "form-control" %>
+      <%= f.input :public_email, class: "form-control" %>
+      <%= f.input :public_phone, class: "form-control" %>
+    </div>
+    <div class="col-md-6">
+      <h3>Partnership Contact</h3>
+      <p><em>If different from public contact:</em> The contact person for PlaceCal.</p>
+      <%= f.input :partner_name, class: "form-control" %>
+      <%= f.input :partner_email, class: "form-control" %>
+      <%= f.input :partner_phone, class: "form-control" %>
+    </div>
+  </div>
+  <hr>
+  <div class="row">
+    <div class="col-lg-8 col-md-12">
+      <h2>Opening times</h2>
+      <%= render 'opening_times', f: f %>
+    </div>
+  </div>
+  <hr>  
+  <h2>Tags</h2>
+  
+  <p>What partnerships, categories and facilities does this partner have or belong to?</p>
+
+  <%= f.association :tags,
+      label: false,
+      collection: options_for_partner_tags,
+      input_html: { class: 'form-check', data: { controller: "select2" } } %>
+
+  <hr>
+  <br>
+  <div class="row">
+    <div class="col-sm-12">
+      <%= f.submit "Save Partner", class: "btn btn-primary btn-lg" %><br><br><br>
+
+      <% if policy(@partner).destroy? && !@partner.new_record? %>
+      <%= link_to "Delete Partner", @partner, method: :delete, class: "btn btn-danger btn-sm", id: 'destroy-partner'  %>
+      <% end %>
+    </div>
+  </div>
+  <%# End form tag %>
   <% end %>
 </div>
 
+<div id="map-pin-div" data-url="<%= image_path('icons/map/map-marker.png') %>"></div>
+ 

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -110,7 +110,7 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     get new_admin_partner_path(@partner)
     assert_response :success
 
-    tag_options = assert_select 'div.partner_tags option', count: 1, text: @tag.name
+    tag_options = assert_select 'div.partner_tags option', count: 1, text: @tag.name_with_type
 
     tag = tag_options.first
     assert tag.attributes.key?('selected')

--- a/test/system/admin/partner_test.rb
+++ b/test/system/admin/partner_test.rb
@@ -43,7 +43,7 @@ class AdminPartnerTest < ApplicationSystemTestCase
 
     tags = select2_node 'partner_tags'
     select2 @tag.name, @tag_pub.name, xpath: tags.path
-    assert_select2_multiple [@tag.name, @tag_pub.name], tags
+    assert_select2_multiple [@tag.name_with_type, @tag_pub.name_with_type], tags
     click_button 'Save Partner'
 
     click_link 'Partners'
@@ -52,7 +52,7 @@ class AdminPartnerTest < ApplicationSystemTestCase
     click_link @partner.name
 
     tags = select2_node 'partner_tags'
-    assert_select2_multiple [@tag.name, @tag_pub.name], tags
+    assert_select2_multiple [@tag.name_with_type, @tag_pub.name_with_type], tags
 
     service_areas = all_cocoon_select2_nodes 'sites_neighbourhoods'
     assert_select2_single @neighbourhood_one, service_areas[0]


### PR DESCRIPTION
Closes #1702 

Admins can now see what type all of the tags they are selecting from