### PR TITLE
Hide Tag "Assigned Users" field unless it's a Partnership

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -9,4 +9,8 @@ module TagsHelper
   def options_for_users
     User.all.order(:last_name).collect { |e| [e.admin_name, e.id] }
   end
+
+  def show_assigned_user_field_for(form)
+    [Tag, Partnership].include?(form.object.class)
+  end
 end

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -57,15 +57,19 @@
         input_html: { class: 'form-control', data: { controller: "select2" } } %>
   <% end %>
 
-  <h2>Assigned Users</h2>
-  <p>Grant permission to assign this tag</p>
-  <% if disabled_fields.include?(:user_ids) %>
-    <%# # Create a dummy field, because f.assoc disappears %>
-    <%= f.association :users,
+<p><%= f.object.class %></p>
+
+  <% if show_assigned_user_field_for(f) %>
+    <h2>Assigned Users</h2>
+    <p>Grant permission to assign this tag</p>
+    <% if disabled_fields.include?(:user_ids) %>
+      <%# # Create a dummy field, because f.assoc disappears %>
+      <%= f.association :users,
         input_html: { class: 'form-control', data: { controller: "select2" } }, disabled: true %>
-  <% else %>
-    <%= f.association :users, collection: options_for_users,
+    <% else %>
+      <%= f.association :users, collection: options_for_users,
         input_html: { class: 'form-control', data: { controller: "select2" } } %>
+    <% end %>
   <% end %>
 
   <span>

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -57,8 +57,6 @@
         input_html: { class: 'form-control', data: { controller: "select2" } } %>
   <% end %>
 
-<p><%= f.object.class %></p>
-
   <% if show_assigned_user_field_for(f) %>
     <h2>Assigned Users</h2>
     <p>Grant permission to assign this tag</p>

--- a/test/integration/admin/tags_integration_test.rb
+++ b/test/integration/admin/tags_integration_test.rb
@@ -120,6 +120,32 @@ class Admin::TagsTest < ActionDispatch::IntegrationTest
     assert_selector :xpath, '//input[@name="tag[slug]"][@value="alpha-facility-2"]'
   end
 
+  # Assigned user field
+  test 'shows assigned user field on New' do
+    log_in_with @root.email
+    visit new_admin_tag_url
+
+    assert_css 'h2', text: 'Assigned Users'
+  end
+
+  test 'shows assigned user field on Edit of Partnership tag' do
+    log_in_with @root.email
+
+    partnership_tag = create(:tag, type: 'Partnership')
+    visit edit_admin_tag_url(partnership_tag)
+
+    assert_css 'h2', text: 'Assigned Users'
+  end
+
+  test 'hides assigned user field on Edit of tag that is not a Partnership' do
+    log_in_with @root.email
+
+    facility_tag = create(:tag, type: 'Facility')
+    visit edit_admin_tag_url(facility_tag)
+
+    assert_css 'h2', text: 'Assigned Users', count: 0
+  end
+
   private
 
   def assert_has_flash(type, message)


### PR DESCRIPTION
Closes #1711 

On admin edit tag page: only show 'Assigned Users' input if the Tag is a plain tag or a Partnership.