### PR TITLE
Restrict creating, editing and deleting tags to root users

### DIFF
--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -14,26 +14,11 @@ class TagPolicy < ApplicationPolicy
   end
 
   def edit?
-    user.root? || user.partner_admin? || user.tag_admin?
+    user.root?
   end
 
   def update?
-    return true if user.root?
-
-    # system tags can only be edited by root
-    return false if @record.system_tag
-
-    # If the user is a tag admin and has been assigned this tag
-    return true if user.tag_admin? && user.tags.include?(@record)
-
-    # NB: We literally can't filter by partners added because otherwise itll wipe existing partners
-    #
-    # If the user is a partner admin and the tag is generally available for use
-    # Functionally, anyone who is a tag admin will be a partner admin, HOWEVER, testing code requi-
-    # Also, it probably doesn't hurt to be strict.
-    return true if user.partner_admin? || user.tag_admin?
-
-    false
+    user.root?
   end
 
   def destroy?

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -56,7 +56,13 @@
   <tbody>
     <% window_tags.each do |tag| %>
     <tr>
-      <td><%= link_to tag.name, edit_admin_tag_path(tag) %></td>
+      <td>
+	<% if policy(tag).edit? %>
+	<%= link_to tag.name, edit_admin_tag_path(tag) %>
+	<% else %>
+	<%= tag.name %>
+	<% end %>
+      </td>
       <td><%= tag.class %></td>
       <td class="text-right"><%= tag.id %></td>
     </tr>

--- a/test/controllers/admin/tags_controller_test.rb
+++ b/test/controllers/admin/tags_controller_test.rb
@@ -67,12 +67,12 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
   #   Allow tag admins to update partner_ids of public tags, and root-assigned tags
   #   Everyone else, redirect to admin_root_url
 
-  it_allows_access_to_edit_for(%i[root partner_admin tag_admin]) do
+  it_allows_access_to_edit_for(%i[root]) do
     get edit_admin_tag_url(@unassigned_root_tag)
     assert_response :success
   end
 
-  it_denies_access_to_edit_for(%i[citizen]) do
+  it_denies_access_to_edit_for(%i[citizen partner_admin tag_admin]) do
     get edit_admin_tag_url(@unassigned_root_tag)
     assert_redirected_to admin_root_url
   end

--- a/test/integration/admin/tags_integration_test.rb
+++ b/test/integration/admin/tags_integration_test.rb
@@ -10,8 +10,8 @@ class Admin::TagsTest < ActionDispatch::IntegrationTest
     @root = create(:root)
     @citizen = create(:citizen)
 
-    @tag = create(:tag)
-    @system_tag = create(:system_tag)
+    @tag = create(:tag, name: 'A Basic Tag Name')
+    @system_tag = create(:system_tag, name: 'A System Tag Name')
 
     create_default_site
     host! 'admin.lvh.me'
@@ -24,12 +24,9 @@ class Admin::TagsTest < ActionDispatch::IntegrationTest
     assert_selector 'input#tag_system_tag'
   end
 
-  test 'citizen user editing a tag cannot see system_tag option' do
-    log_in_with @citizen.email
-    visit edit_admin_tag_url(@tag)
-
-    assert_selector 'input#tag_system_tag', count: 0
-  end
+  #  test 'citizen user editing a tag cannot see system_tag option' do
+  #    should not be able to even see the admin Tags navigation link
+  #  end
 
   test 'root users can modify system tag' do
     log_in_with @root.email
@@ -44,16 +41,9 @@ class Admin::TagsTest < ActionDispatch::IntegrationTest
     assert_content 'A new tag name'
   end
 
-  test 'citizen users cannot modify tag' do
-    @citizen.tags << @tag
-    @citizen.tags << @system_tag
-
-    log_in_with @citizen.email
-
-    visit edit_admin_tag_url(@system_tag)
-
-    assert_content 'This tag is a system tag meaning that it cannot be edited by non-root admins.'
-  end
+  # test 'citizen users cannot modify tag' do
+  #   should not be able to even see the admin Tags navigation link
+  # end
 
   test 'root users can make a tag a system tag' do
     log_in_with @root.email

--- a/test/policies/tag_policy_test.rb
+++ b/test/policies/tag_policy_test.rb
@@ -15,7 +15,7 @@ class TagPolicyTest < ActiveSupport::TestCase
     @non_root.tags << @normal_tag
 
     assert allows_access(@root, @normal_tag, :update)
-    assert allows_access(@non_root, @normal_tag, :update)
+    assert denies_access(@non_root, @normal_tag, :update)
 
     assert allows_access(@root, @system_tag, :update)
     assert denies_access(@non_root, @system_tag, :update)


### PR DESCRIPTION
Closes #1712 

Only root users can CRUD tags.

Temporary fix so we can review and define proper granular tag access controls