### PR TITLE
Update the readme + add a makefile to simplify setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,4 @@ doc/**/*.css
 doc/**/*.js
 .yardoc
 ./tags
-Makefile
 doc/rdoc

--- a/README.md
+++ b/README.md
@@ -34,40 +34,25 @@ To run PlaceCal locally you will need:
 - [Graphviz](https://voormedia.github.io/rails-erd/install.html) for documentation diagrams
 - Chrome/Chromium for system tests along with a matching version of [Chromedriver](https://chromedriver.chromium.org/)
 
-## Quickstart
+## Quickstart with docker for GFSC devs
 
-With that said, here's what you need to get rolling.
+Make sure all of the above dependencies are installed and ask someone to add your public ssh key to the server.
 
-### Set up Postgresql locally
-
-If you don't already have Postgresql installed and running, here's how you can set it up with Docker.
-
-**Skip these steps if you already have Postgresql set up.**
-
-Creating a Postgresql Docker image is reasonably quick:
+Then make sure the docker daemon is running, and run
 
 ```sh
-docker network create placecal-network
-docker create --name placecal-db --network placecal-network --network-alias postgres -p 5432:5432 --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5 -e 'POSTGRES_DB=placecal_db' -e 'POSTGRES_USER=postgres' -e 'POSTGRES_PASSWORD=foobar' -e 'POSTGRES_PORT=5432' postgres:14.1
-docker start placecal-db
+make all
 ```
 
-Make a copy of `.env.example` in `.env` in the root directory of the application. These will be loaded in as environment variables when you start the development server.
+Local site is now running at `lvh.me:3000`
 
-You can now set the following in `.env`:
+Some other useful commands for developing can be found in the makefile.
 
-```sh
-POSTGRES_HOST=localhost
-POSTGRES_USER=postgres
-PGPASSWORD=foobar
-```
+## Quickstart for everyone else
 
-### Clone this Git repository
+### Set up Postgresql locally with docker
 
-```sh
-git clone https://github.com/geeksforsocialchange/PlaceCal.git
-cd PlaceCal
-```
+If you don't already have Postgresql installed and running, you can set it up with docker, just run `make docker`. To tear down the docker setup, run `make clean`.
 
 ### Run the setup script
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Make sure all of the above dependencies are installed and ask someone to add you
 Then make sure the docker daemon is running, and run
 
 ```sh
-make all
+make setup
 ```
 
 Local site is now running at `lvh.me:3000`

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Make sure all of the above dependencies are installed and ask someone to add you
 Then make sure the docker daemon is running, and run
 
 ```sh
-make setup
+make setup_with_docker
 ```
 
 Local site is now running at `lvh.me:3000`

--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
 #REQUIREMENTS BEFORE RUNNING MAKE ALL: ruby, yarn, docker, graphviz, imagemagick, nvm, postgres
-.PHONY: test
+.PHONY: test setup
 
-all: install_dependencies docker setup_env setup_db seed_db create_user run
+all: update test
 
-test_all: update test
+setup: install_dependencies docker setup_env setup_db seed_GFSC_prod_copy_db create_user run
 
 docker: setup_docker_network setup_docker_container setup_env
 
@@ -40,10 +40,10 @@ setup_env:
 	echo PGUSER=postgres >> .env
 
 setup_db:
-	bundle exec rails db:setup db:migrate db:seed
+	bundle exec rails db:setup db:migrate
 	bundle exec rails import:all_events
 
-seed_db:
+seed_GFSC_prod_copy_db:
 	rails db:dump_production_and_restore_other restore_on_local=1
 
 create_user:

--- a/makefile
+++ b/makefile
@@ -1,0 +1,59 @@
+#REQUIREMENTS BEFORE RUNNING MAKE ALL: ruby, yarn, docker, graphviz, imagemagick, nvm, postgres
+.PHONY: test
+
+all: install_dependencies docker setup_env setup_db seed_db create_user run
+
+test_all: update test
+
+docker: setup_docker_network setup_docker_container setup_env
+
+run:
+	docker start placecal-db || true
+	bin/dev
+
+down:
+	docker stop placecal-db
+
+# does not remove postgres image, just placecal container & network
+clean:
+	docker stop placecal-db || true
+	docker container rm placecal-db || true
+	docker network rm placecal-network
+
+install_dependencies:
+	yarn
+	bundle install
+
+setup_docker_network:
+	docker network create placecal-network
+
+setup_docker_container:
+	docker create --name placecal-db --network placecal-network --network-alias postgres -p 5432:5432 --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5 -e 'POSTGRES_DB=placecal_dev' -e 'POSTGRES_USER=postgres' -e 'PGUSER=postgres' -e 'POSTGRES_PASSWORD=foobar' -e 'POSTGRES_PORT=5432' postgres:14.1
+	docker start placecal-db 
+
+setup_env:
+	cp .env.example .env
+	echo POSTGRES_HOST=localhost >> .env
+	echo POSTGRES_USER=postgres >> .env
+	echo PGPASSWORD=foobar >> .env
+	echo PGHOST=localhost >> .env
+	echo PGUSER=postgres >> .env
+
+setup_db:
+	bundle exec rails db:setup db:migrate db:seed
+	bundle exec rails import:all_events
+
+seed_db:
+	rails db:dump_production_and_restore_other restore_on_local=1
+
+create_user:
+	bundle exec rails runner "User.create!(email: 'info@placecal.org', password: 'password', password_confirmation: 'password', role: :root)"
+
+update:
+	bin/update
+
+test:
+	time sh -c "rails test --pride && rails test:system && rubocop"
+
+tags:
+	find app/ lib/ test/ -iname '*.rb' | xargs etags

--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
 #REQUIREMENTS BEFORE RUNNING MAKE ALL: ruby, yarn, docker, graphviz, imagemagick, nvm, postgres
 .PHONY: test setup
 
-all: update test
+all: test
 
-setup: install_dependencies docker setup_env setup_db seed_GFSC_prod_copy_db create_user run
+setup_with_docker: install_dependencies docker setup_env setup_db seed_GFSC_prod_copy_db create_user run
 
 docker: setup_docker_network setup_docker_container setup_env
 
@@ -48,9 +48,6 @@ seed_GFSC_prod_copy_db:
 
 create_user:
 	bundle exec rails runner "User.create!(email: 'info@placecal.org', password: 'password', password_confirmation: 'password', role: :root)"
-
-update:
-	bin/update
 
 test:
 	time sh -c "rails test --pride && rails test:system && rubocop"


### PR DESCRIPTION
fixes #1748

This PR aims to improve the setup & running experience for any future & current GFSC devs, especially those using docker. Using all of the helpful notes I've been given, I've distilled the list of things needed to be done to get a working version of PlaceCal with a copy of some viable data running locally. 

To enable quick replication of these steps I have also:
- simplified the readme by making explicit a quick setup route for GFSC developers, and extracting some of the larger chunks of code into a makefile
- Added a makefile that contains all the commands needed to set up a GFSC environment (contains no sensitive information)
- Added other commands to the makefile required to run & tear down the environment, set up a docker db
- Added Ivan's makefile commands to run tests and use tags in linux. 

Totally fine if everyone disagrees this should be in the repo. In my mind, if it's a useful time saving script for one of us it's probably worth sharing with everyone else, but understand that this is at odds with reducing code bloat so if we hate the idea of adding this please let me know.

Also should add the most pain actually came from setting up ruby & postgres, once I had those in place the rest of this was sort of ok!