### PR TITLE
use assert_match on two substrings instead of assert equal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ doc/**/*.js
 .yardoc
 ./tags
 doc/rdoc
+
+# Ignore IDE config files
+.vscode

--- a/test/jobs/calendar_importer/parser_base_test.rb
+++ b/test/jobs/calendar_importer/parser_base_test.rb
@@ -40,8 +40,7 @@ class ParserBaseTest < ActiveSupport::TestCase
         Base.read_http_source('https://dandilion.gfsc.studio')
       end
 
-      # FIXME: more user friendly description maybe?
-      assert_equal('There was a socket error (Failed to open TCP connection to dandilion.gfsc.studio:443 (getaddrinfo: Name or service not known))', error.message)
+      assert_match(/There was a socket error.*Failed to open TCP connection to dandilion.gfsc.studio:443/, error.message)
     end
   end
 


### PR DESCRIPTION
Fixes #1751 

##Description

- Prevents test from failing in a different environment when the error message is subtly different by matching two substrings within the error message instead of looking for an exact match.
- Substrings looked for are `There was a socket error` and `Failed to open TCP connection to dandilion.gfsc.studio:443`
- These strings were chosen because they validate the principal of the test to check that the exception is correct and the URL is invalid