### PR TITLE
lockdown partnership tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -30,8 +30,11 @@ class Tag < ApplicationRecord
   validate :check_editable_fields
 
   scope :users_tags, lambda { |user|
-    where id: user.tags_users.distinct.pluck(:tag_id)
-  }
+                       partnership_tags = Tag.where(type: 'Partnership', id: user.tags_users.distinct.pluck(:tag_id)).pluck(:id)
+                       other_tags = Tag.where("type != 'Partnership'").pluck(:id)
+
+                       Tag.where(id: partnership_tags + other_tags)
+                     }
 
   def name_with_type
     s_type = type || 'Tag'

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -30,6 +30,8 @@ class Tag < ApplicationRecord
   validate :check_editable_fields
 
   scope :users_tags, lambda { |user|
+                       return Tag.all if user.role == 'root'
+
                        partnership_tags = Tag.where(type: 'Partnership', id: user.tags_users.distinct.pluck(:tag_id)).pluck(:id)
                        other_tags = Tag.where("type != 'Partnership'").pluck(:id)
 

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -12,7 +12,7 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
 
     @neighbourhood_region_admin = create(:neighbourhood_region_admin)
 
-    @tag = create(:tag)
+    @tag = create(:tag, type: 'Category')
 
     host! 'admin.lvh.me'
   end

--- a/test/integration/admin/sites_integration_test.rb
+++ b/test/integration/admin/sites_integration_test.rb
@@ -12,7 +12,7 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
     @neighbourhoods = create_list(:neighbourhood, 5)
     @number_of_neighbourhoods = Neighbourhood.all.length
 
-    @tag = create(:tag)
+    @tag = create(:tag, type: 'Category')
 
     host! 'admin.lvh.me'
   end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -9,7 +9,6 @@ class TagTest < ActiveSupport::TestCase
     @partnership_tag = Tag.where(type: 'Partnership').first
     @user = create(:user)
     @partner = create(:partner)
-    # puts @partnership_tag.as_json
   end
 
   test 'updates user roles when saved' do

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -4,9 +4,12 @@ require 'test_helper'
 
 class TagTest < ActiveSupport::TestCase
   setup do
-    @tag = create(:tag)
+    create_typed_tags
+    @tag = Tag.first
+    @partnership_tag = Tag.where(type: 'Partnership').first
     @user = create(:user)
     @partner = create(:partner)
+    # puts @partnership_tag.as_json
   end
 
   test 'updates user roles when saved' do
@@ -31,5 +34,61 @@ class TagTest < ActiveSupport::TestCase
 
     assert @tag.errors.key?(:name)
     assert @tag.errors.key?(:slug)
+  end
+
+  test 'a root user can access all tags' do
+    root_user = create :root
+    assert_equal Tag.users_tags(root_user), Tag.all
+  end
+
+  test 'a tag_admin can access their own Partnership tag but not others' do
+    @partnership_tag.users << @user
+    @partnership_tag.save
+
+    Tag.users_tags(@user).each do |t|
+      assert_equal t.name, @partnership_tag.name if t.type == 'Partnership'
+    end
+  end
+
+  test 'a tag_admin can access Facility tags' do
+    @partnership_tag.users << @user
+    @partnership_tag.save
+
+    facility_tag = Tag.where(type: 'Facility').first
+
+    Tag.users_tags(@user).each do |t|
+      assert_equal t.name, facility_tag.name if t.type == 'Facility'
+    end
+  end
+
+  test 'a tag_admin can access Category tags' do
+    @partnership_tag.users << @user
+    @partnership_tag.save
+
+    category_tag = Tag.where(type: 'Category').first
+
+    Tag.users_tags(@user).each do |t|
+      assert_equal t.name, category_tag.name if t.type == 'Category'
+    end
+  end
+
+  test 'a non tag_admin cannot access any Partnership tags' do
+    assert_equal(0, Tag.users_tags(@user).where(type: 'Partnership').count)
+  end
+
+  test 'a regular user can access Facility tags' do
+    facility_tag = Tag.where(type: 'Facility').first
+
+    Tag.users_tags(@user).each do |t|
+      assert_equal t.name, facility_tag.name if t.type == 'Facility'
+    end
+  end
+
+  test 'a regular user can access Category tags' do
+    category_tag = Tag.where(type: 'Category').first
+
+    Tag.users_tags(@user).each do |t|
+      assert_equal t.name, category_tag.name if t.type == 'Category'
+    end
   end
 end

--- a/test/system/admin/tag_test.rb
+++ b/test/system/admin/tag_test.rb
@@ -16,6 +16,7 @@ class AdminTagTest < ApplicationSystemTestCase
     @partner = @partner_admin.partners.first
     @partner_two = create :ashton_partner
     @tag = create(:tag, name: 'Arts & Crafts')
+    create_typed_tags
 
     # logging in as root user
     visit '/users/sign_in'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -189,3 +189,10 @@ def from_site_slug(site, path)
   host = Rails.application.routes.default_url_options[:host]
   "http://#{site.slug}.#{host}/#{path}"
 end
+
+def create_typed_tags
+  create(:tag, name: 'free wifi', type: 'Facility')
+  create(:tag, name: 'housing', type: 'Category')
+  create(:tag, name: 'trans dimension', type: 'Partnership')
+  create(:tag, name: 'system changers', type: 'Partnership')
+end


### PR DESCRIPTION
fixes #1713

- Roots can see every Tag
- Partnership admins can see their own Partnership Tag(s), plus all Categories and Facilities in all relevant dropdown menus
- Everyone else can only see all Categories and Facilities in all relevant dropdown menus

I won't open the ticket to implement on the backed as this what we did here, it ended up being more efficient this way.