### PR TITLE
Only show client root users the sites they're an admin for

### DIFF
--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -41,10 +41,10 @@ class SitePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user.root?
-        scope.all
-      elsif user.site_admin?
+      if user.site_admin?
         scope.where(site_admin: user)
+      elsif user.root?
+        scope.all
       else
         scope.none
       end

--- a/test/integration/admin/sites_integration_test.rb
+++ b/test/integration/admin/sites_integration_test.rb
@@ -5,8 +5,11 @@ require 'test_helper'
 class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     @root = create(:root)
+    @another_root = create(:root)
 
     @site = create(:site)
+    @another_site = create(:site, name: 'another', site_admin: @another_root)
+
     @site_admin = @site.site_admin
 
     @neighbourhoods = create_list(:neighbourhood, 5)
@@ -24,6 +27,24 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_select 'title', text: 'Sites | PlaceCal Admin'
     assert_select 'h1', text: 'Sites'
+  end
+
+  test 'Admin site index shows only sites assigned to signed in admin if any are assigned' do
+    sign_in(@another_root)
+    get admin_sites_path
+    assert_response :success
+
+    assert_select 'td', text: @another_site.name
+    assert_select 'td', text: @site.name, count: 0
+  end
+
+  test 'Admin site index shows all sites to signed in admin if none are assigned' do
+    sign_in(@root)
+    get admin_sites_path
+    assert_response :success
+
+    assert_select 'td', text: @another_site.name
+    assert_select 'td', text: @site.name
   end
 
   test 'root : can get new site' do


### PR DESCRIPTION
Fixes #1746 

### Description

- Modifies the site scope to allow access to only the sites a root user is an admin for if they are an admin for any
- If the root user is an admin for none, allows access to all sites
- Adds tests to assert working as expected

### Some qs!

- We still have an 'Add new site' button visible for the site admin roots - is this functionality we want them to have, or should this be removed too?
- The original issue ticket asked for `"Create a partner"  and "create a calendar" links where the site list used to be` . After discussing as a team it was agreed that we didn't want to remove the site list completely for any root user, which I thought made this redundant. Im now wondering though which type of root user was this for the benefit of, and do we actually want this in addition to showing the site list?