### PR TITLE
make type mandatory on Tag

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -20,7 +20,7 @@ class Tag < ApplicationRecord
   has_many :article_tags, dependent: :destroy
   has_many :articles, through: :article_tags
 
-  validates :name, :slug, presence: true
+  validates :name, :slug, :type, presence: true
   validates :name, :slug, uniqueness: { scope: :type }
   validates :description,
             length: {

--- a/test/factories/tag.rb
+++ b/test/factories/tag.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
 
     slug { name.parameterize }
     description { 'I am a tag' }
+    type { 'Facility' }
 
     factory :system_tag do
       system_tag { true }

--- a/test/integration/event_site_integration_test.rb
+++ b/test/integration/event_site_integration_test.rb
@@ -74,7 +74,8 @@ class EventsBySiteTagTest < ActionDispatch::IntegrationTest
     tag = Tag.create!(
       name: 'Tag',
       slug: 'tag',
-      description: 'A tag about a thing'
+      description: 'A tag about a thing',
+      type: 'Facility'
     )
 
     tag_site = Site.create!(

--- a/test/system/admin/tag_test.rb
+++ b/test/system/admin/tag_test.rb
@@ -15,7 +15,7 @@ class AdminTagTest < ApplicationSystemTestCase
 
     @partner = @partner_admin.partners.first
     @partner_two = create :ashton_partner
-    @tag = create(:tag, name: 'Arts & Crafts')
+    @tag = create(:tag, name: 'TransDim', type: 'Partnership')
 
     # logging in as root user
     visit '/users/sign_in'
@@ -46,6 +46,7 @@ class AdminTagTest < ApplicationSystemTestCase
     partners = select2_node 'tag_partners'
     assert_select2_multiple [@partner.name, @partner_two.name], partners
 
+    # for Partnership tags
     users = select2_node 'tag_users'
     assert_select2_multiple [@root_user.to_s, @partner_admin.to_s], users
   end


### PR DESCRIPTION
fixes #1737

- add a validation on the model
- fix up our test data as a lot of the tags were being generated without a type