### PR TITLE
limit tags shown to root user if they are also a (Partnership)tag_admin

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -30,7 +30,7 @@ class Tag < ApplicationRecord
   validate :check_editable_fields
 
   scope :users_tags, lambda { |user|
-                       return Tag.all if user.role == 'root'
+                       return Tag.all if user.role == 'root' && !user.tag_admin?
 
                        partnership_tags = Tag.where(type: 'Partnership', id: user.tags_users.distinct.pluck(:tag_id)).pluck(:id)
                        other_tags = Tag.where("type != 'Partnership'").pluck(:id)

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -65,11 +65,7 @@ class TagPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user.root?
-        scope.all
-      else
-        Tag.users_tags(user)
-      end
+      Tag.users_tags(user)
     end
   end
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -40,6 +40,40 @@ class TagTest < ActiveSupport::TestCase
     assert_equal Tag.users_tags(root_user), Tag.all
   end
 
+  test 'a root user who is a tag_admin can access their own Partnership tag but not others' do
+    root_user = create :root
+    @partnership_tag.users << root_user
+    @partnership_tag.save
+
+    Tag.users_tags(root_user).each do |t|
+      assert_equal t.name, @partnership_tag.name if t.type == 'Partnership'
+    end
+  end
+
+  test 'a root user who is a tag_admin can access Facility tags' do
+    root_user = create :root
+    @partnership_tag.users << root_user
+    @partnership_tag.save
+
+    facility_tag = Tag.where(type: 'Facility').first
+
+    Tag.users_tags(root_user).each do |t|
+      assert_equal t.name, facility_tag.name if t.type == 'Facility'
+    end
+  end
+
+  test 'a root user who is a tag_admin can access Category tags' do
+    root_user = create :root
+    @partnership_tag.users << root_user
+    @partnership_tag.save
+
+    category_tag = Tag.where(type: 'Category').first
+
+    Tag.users_tags(root_user).each do |t|
+      assert_equal t.name, category_tag.name if t.type == 'Category'
+    end
+  end
+
   test 'a tag_admin can access their own Partnership tag but not others' do
     @partnership_tag.users << @user
     @partnership_tag.save


### PR DESCRIPTION
fixes #1763 

- remove root user logic from policy scope
- exclude root user who is tag admin from receiving `Tag.all`
- add a tests to validate