### PR TITLE
Allow partner admins to add & remove categories and facilities to partners from tags page

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -61,6 +61,12 @@ module Admin
     def update
       authorize @tag
       attributes = permitted_attributes(Tag.new)
+
+      if current_user.partner_admin?
+        attributes[:partner_ids] =
+          helpers.all_partners_for(@tag, attributes)
+      end
+
       if @tag.update(attributes)
         flash[:success] = 'Tag was saved successfully'
         redirect_to admin_tags_path

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -13,4 +13,13 @@ module TagsHelper
   def show_assigned_user_field_for(form)
     [Tag, Partnership].include?(form.object.class)
   end
+
+  # prevent invisible partner ids from being overwritten when updating a tag
+  def all_partners_for(tag, attributes)
+    editable_partners = current_user.partners.pluck(:id)
+    uneditable_partners = tag.partner_ids - editable_partners
+    updated_partners = editable_partners & attributes[:partner_ids].reject(&:empty?).map(&:to_i)
+
+    uneditable_partners + updated_partners
+  end
 end

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -23,9 +23,6 @@ class TagPolicy < ApplicationPolicy
     # system tags can only be edited by root
     return false if @record.system_tag
 
-    # If the user is a tag admin and has been assigned this tag
-    return true if user.tag_admin? && user.tags.include?(@record)
-
     # NB: We literally can't filter by partners added because otherwise itll wipe existing partners
     #
     # If the user is a partner admin and the tag is generally available for use
@@ -46,7 +43,7 @@ class TagPolicy < ApplicationPolicy
       fields << :type if @record.instance_of?(Tag)
       fields.push(partner_ids: [], user_ids: [])
 
-    elsif user.tag_admin? && user.tags.include?(@record)
+    elsif (user.tag_admin? && user.tags.include?(@record)) || user.partner_admin?
       %i[].push(partner_ids: [])
     else
       %i[]
@@ -56,7 +53,7 @@ class TagPolicy < ApplicationPolicy
   def disabled_fields
     if user.root?
       %i[]
-    elsif user.tag_admin?
+    elsif user.tag_admin? || user.partner_admin?
       %i[name slug description users user_ids system_tag]
     else # Should never be hit, but it's useful as a guard
       %i[name slug description users partner_ids user_ids system_tag]

--- a/test/controllers/admin/tags_controller_test.rb
+++ b/test/controllers/admin/tags_controller_test.rb
@@ -101,13 +101,13 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
           params:  { tag: { partner_ids: [@partner.id] }, id: 'activism' }
 
     assert_redirected_to admin_tags_url
-    assert_equal [@partner.id, @unassigned_partner.id], @category_tag.reload.partner_ids
+    assert_equal [@partner.id, @unassigned_partner.id].sort, @category_tag.reload.partner_ids.sort
 
     patch admin_tag_url(@category_tag),
           params:  { tag: { partner_ids: [] }, id: 'activism' }
 
     assert_redirected_to admin_tags_url
-    assert_equal [@unassigned_partner.id], @category_tag.reload.partner_ids
+    assert_equal [@unassigned_partner.id].sort, @category_tag.reload.partner_ids.sort
   end
 
   # partner admins cannot update partners they do not admin for

--- a/test/policies/tag_policy_test.rb
+++ b/test/policies/tag_policy_test.rb
@@ -7,6 +7,9 @@ class TagPolicyTest < ActiveSupport::TestCase
     @root = create(:root)
     @non_root = create(:editor)
 
+    @partner_admin = create(:partner_admin)
+    @tag_admin = create(:tag_admin)
+
     @normal_tag = create(:tag)
     @system_tag = create(:tag, system_tag: true)
   end
@@ -16,6 +19,12 @@ class TagPolicyTest < ActiveSupport::TestCase
 
     assert allows_access(@root, @normal_tag, :update)
     assert allows_access(@non_root, @normal_tag, :update)
+
+    assert allows_access(@partner_admin, @normal_tag, :update)
+    assert denies_access(@partner_admin, @system_tag, :update)
+
+    assert allows_access(@tag_admin, @normal_tag, :update)
+    assert denies_access(@tag_admin, @system_tag, :update)
 
     assert allows_access(@root, @system_tag, :update)
     assert denies_access(@non_root, @system_tag, :update)
@@ -33,5 +42,13 @@ class TagPolicyTest < ActiveSupport::TestCase
     fields = policy.permitted_attributes
 
     assert_not fields.include?(:type), 'Expecting type field to NOT be allowed for sub-model'
+  end
+
+  test 'permitted_attributes for partner_admins are just partner_ids' do
+    policy = TagPolicy.new(@partner_admin, Tag.new)
+    fields = policy.permitted_attributes
+
+    assert_includes fields, { partner_ids: [] }
+    assert_equal(1, fields.length)
   end
 end


### PR DESCRIPTION
Fixes #1653

### Description

- Updates the tags policy to make `:partner_id` a permitted attribute for a `:partner_admin`. This allows them to add or remove a partner that they manage from a category or facility tag.
- Adds tests to assert that the tags policy is working correctly for a `:tag_admin` or `:partner_admin` user
- Removed a redundant line of code from the tag policy - note on which below.

### Some Thoughts/ problems

- The two facility tags in our production copy db are currently also `system_tags` which means they cannot be edited from the tag dashboard, and so also cannot be assigned/removed from a partner from this interface. This feels like a subtly different bug - if I create a new `facility_tag` without a `system_tag` symbol then it works as expected. Do we want `partner_admins` to be able to attach/detach tags that are also `system_tags`? Or is this a weird error and do we want to remove this ability from them in the partner interface too? If whoever is reviewing this wants me to talk them through it let me know - it's confusing to read/write!
- The acceptance criteria for the user story wanted "up to 3" category tags to be able to be assigned but there was nothing in the user story mentioning this. I couldn't tell if this was a necessary limitation or not so have opened as a new issue.
