### PR TITLE
feat: add ui for public to filter partners by category tag

### DIFF
--- a/app/components/paginator/paginator.sass
+++ b/app/components/paginator/paginator.sass
@@ -80,7 +80,7 @@
     padding: 1rem
     right: 0rem
     width: 13rem
-    z-index: 100
+    z-index: 500
     box-shadow: 7px 7px 20px 0px rgba(153, 134, 117, 0.83)
     &--hidden
       display: none

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -26,6 +26,38 @@ class PartnersController < ApplicationController
 
     # show only partners with no service_areas
     @map = get_map_markers(@partners, true) if @partners.detect(&:address)
+    cat_tags = Tag.where(type: 'Category').order(:name)
+    @categories = cat_tags.filter { |t| (@partners & t.partners).length.positive? }
+  end
+
+  def tag
+    @current_tag = params[:opts][:id]
+    @include = params[:opts][:include] == '1'
+    site_partners = Partner
+                    .for_site(current_site)
+
+    tag_partners = Tag.find(@current_tag).partners.pluck(:id)
+
+    @partners = if @current_tag
+                  if @include
+                    Partner.where(id: site_partners.pluck(:id) & tag_partners)
+                           .includes(:service_areas, :address)
+                           .order(:name)
+                  else
+                    Partner.where(id: site_partners.pluck(:id) - tag_partners)
+                           .includes(:service_areas, :address)
+                           .order(:name)
+                  end
+                else
+                  site_partners.order(:name)
+                end
+
+    # show only partners with no service_areas
+    @map = get_map_markers(@partners, true) if @partners.detect(&:address)
+    cat_tags = Tag.where(type: 'Category').order(:name)
+    @categories = cat_tags.filter { |t| (@partners & t.partners).length.positive? }
+    # render 'index'
+    # render 'tag'
   end
 
   # # GET /places

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -2,9 +2,41 @@
 <%= render_component "hero", title: 'Partners in your area', subtitle: @site.tagline %>
 
 <div class="c c--lg-space-after">
-  <%= render_component "breadcrumb", trail: [['Partners', partners_path]], site_name: @site.name %>
+  <%= render_component "breadcrumb", trail: [['Partners', partners_path]], site_name: @site.name do %>
+    <% if  @categories.length > 0 %>
+      <div class="breadcrumb__filters filters">
+          <div class="js-filters-toggle filters__toggle">
+              <a href="#" data-turbo="false"><span class="icon icon--arrow-down">↓</span> <span class="filters__link">Category</span></a>
+          </div>
+          <%= simple_form_for(:opts, url:partners_tag_path, html: { class: 'filters__form'}) do |f| %>
+            <div class="filters__dropdown filters__dropdown--hidden js-filters-dropdown">
+              <div class="filters__group" >
+                <%= f.collection_radio_buttons(:id, @categories, :id, :name, { checked: @categories.first.id }) do |b| %>
+                  <div class="filters__option">
+                    <%= b.radio_button(class: "tag__button") %>
+                    <%= b.label(class: "tag__label") %>
+                  </div>
+                <% end %>
+              </div>
+              <hr>
+              <div class="filters__group">
+                <%= f.collection_radio_buttons :include,  [[1, "Include"],[0, "Exclude"]], :first, :second, { checked: 1 } do |b| %>
+                  <div class="filters__option">
+                    <%= b.radio_button(class: "include__button") %>
+                    <%= b.label(class: "include__label") %>
+                  </div>
+                <% end %>
+              </div>
+              <hr>
+                <%= f.button :submit , 'Filter' %>
+            </div>
+          <% end %>
+      </div>
+    <% end %>
+  <% end %>
+
   <hr>
-  <ul class="partners reset two-col">
+  <ul class="partners reset two-col" id="partners" >
     <% @partners.each do |partner| %>
       <%= render_component("place_partner_preview",
                            previewee: partner,
@@ -16,4 +48,6 @@
   </ul>
 </div>
 
-<%= render 'shared/map', points: @map, site: @current_site.slug %>
+<div id="map">
+  <%= render 'shared/map', points: @map, site: @current_site.slug %>
+</div>

--- a/app/views/partners/tag.turbo_stream.erb
+++ b/app/views/partners/tag.turbo_stream.erb
@@ -1,0 +1,15 @@
+<%= turbo_stream.update "partners" do %>
+  <% @partners.each do |partner| %>
+    <%= render_component("place_partner_preview",
+                         previewee: partner,
+                         primary_neighbourhood: @primary_neighbourhood,
+                         service_areas: partner.service_areas,
+                         show_neighbourhoods: @current_site.show_neighbourhoods?,
+                         badge_zoom_level: @current_site.badge_zoom_level) %>
+  <% end %>
+<% end %>
+
+
+<%= turbo_stream.update "map" do %>
+  <%= render 'shared/map', points: @map, site: @current_site.slug %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
     root 'pages#home'
   end
 
-  constraints(::Sites::Local) do
+  constraints(Sites::Local) do
     get '/' => 'sites#index'
   end
 
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
   get '/partners/:id/events/:year/:month/:day' => 'partners#show', constraints: ymd
   get '/places' => 'partners#index' # Removing separate Places view for now.
   get '/partners/:id/embed' => 'places#embed'
+  post '/partners/tag' => 'partners#tag'
 
   # news
   resources :news, only: %i[index show]

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -67,10 +67,10 @@ class TagTest < ActiveSupport::TestCase
     @partnership_tag.users << root_user
     @partnership_tag.save
 
-    category_tag = Tag.where(type: 'Category').first
+    category_tags = Tag.where(type: 'Category')
 
     Tag.users_tags(root_user).each do |t|
-      assert_equal t.name, category_tag.name if t.type == 'Category'
+      assert_includes category_tags, t if t.type == 'Category'
     end
   end
 
@@ -98,10 +98,10 @@ class TagTest < ActiveSupport::TestCase
     @partnership_tag.users << @user
     @partnership_tag.save
 
-    category_tag = Tag.where(type: 'Category').first
+    category_tags = Tag.where(type: 'Category')
 
     Tag.users_tags(@user).each do |t|
-      assert_equal t.name, category_tag.name if t.type == 'Category'
+      assert_includes category_tags, t if t.type == 'Category'
     end
   end
 
@@ -118,10 +118,10 @@ class TagTest < ActiveSupport::TestCase
   end
 
   test 'a regular user can access Category tags' do
-    category_tag = Tag.where(type: 'Category').first
+    category_tags = Tag.where(type: 'Category')
 
     Tag.users_tags(@user).each do |t|
-      assert_equal t.name, category_tag.name if t.type == 'Category'
+      assert_includes category_tags, t if t.type == 'Category'
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -187,11 +187,12 @@ end
 
 def from_site_slug(site, path)
   host = Rails.application.routes.default_url_options[:host]
-  "http://#{site.slug}.#{host}/#{path}"
+  "http://#{site.slug}.#{host}#{path}"
 end
 
 def create_typed_tags
   create(:tag, name: 'free wifi', type: 'Facility')
+  create(:tag, name: 'fruit ecosystem', type: 'Category')
   create(:tag, name: 'housing', type: 'Category')
   create(:tag, name: 'trans dimension', type: 'Partnership')
   create(:tag, name: 'system changers', type: 'Partnership')


### PR DESCRIPTION
fixes #1644

We had ambitions to make a snazzier UI but in the interest of getting something usable into the world I just reused the filter UI from the events page.

I touched a couple of files that are look out of scope.

 - I had to increase the z index of the dropdown filter menu because when there are very few partners the map element sits over the top of it.
 - Because I wanted to write some tests with multiple category tags I updated  the test_helper and that had a knock on effect in model/tag_test but I think it makes that test more comprehensive.

