### PR TITLE
Show all sites to site admin root users from admin/sites page

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -5,7 +5,7 @@ module Admin
     def home
       @tags = policy_scope(Tag).all.order(:name)
       @partners = policy_scope(Partner).order(updated_at: :desc).limit(6)
-      @sites = policy_scope(Site).order(:name)
+      @sites = policy_scope([:dashboard, Site]).order(:name)
       @errored_calendars = policy_scope(Calendar).where(is_working: false).order(last_import_at: :desc)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,6 +101,7 @@ class User < ApplicationRecord
     types << 'neighbourhood_admin' if neighbourhood_admin?
     types << 'partner_admin' if partner_admin?
     types << 'tag_admin' if tag_admin?
+    types << 'site_admin' if site_admin?
 
     types.join(', ')
   end

--- a/app/policies/dashboard/site_policy.rb
+++ b/app/policies/dashboard/site_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Dashboard::SitePolicy < SitePolicy
+  class Scope < Scope
+    def resolve
+      if user.site_admin?
+        scope.where(site_admin: user)
+      elsif user.root?
+        scope.all
+      else
+        scope.none
+      end
+    end
+  end
+end

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -41,10 +41,10 @@ class SitePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user.site_admin?
-        scope.where(site_admin: user)
-      elsif user.root?
+      if user.root?
         scope.all
+      elsif user.site_admin?
+        scope.where(site_admin: user)
       else
         scope.none
       end

--- a/test/integration/admin/home_integration_test.rb
+++ b/test/integration/admin/home_integration_test.rb
@@ -8,6 +8,10 @@ class AdminHomeIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     @admin = create(:root)
     @citizen = create(:citizen)
+    @site_admin = create(:root)
+
+    @site = create(:site)
+    @site_admin_site = create(:site, name: 'another', site_admin: @site_admin)
   end
 
   test "Admin home page can't be accessed without a login" do
@@ -31,5 +35,23 @@ class AdminHomeIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_select 'title', text: 'Dashboard | PlaceCal Admin'
     assert_select 'h1', text: 'Missing Permissions'
+  end
+
+  test 'Dashboard shows only sites assigned to signed in admin if any are assigned' do
+    sign_in(@site_admin)
+    get 'http://admin.lvh.me'
+    assert_response :success
+
+    assert_select 'h5', text: @site_admin_site.name
+    assert_select 'h5', text: @site.name, count: 0
+  end
+
+  test 'Dashboard shows all sites to signed in admin if none are assigned' do
+    sign_in(@admin)
+    get 'http://admin.lvh.me'
+    assert_response :success
+
+    assert_select 'h5', text: @site_admin_site.name
+    assert_select 'h5', text: @site.name
   end
 end

--- a/test/integration/admin/sites_integration_test.rb
+++ b/test/integration/admin/sites_integration_test.rb
@@ -29,15 +29,6 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'h1', text: 'Sites'
   end
 
-  test 'Admin site index shows only sites assigned to signed in admin if any are assigned' do
-    sign_in(@another_root)
-    get admin_sites_path
-    assert_response :success
-
-    assert_select 'td', text: @another_site.name
-    assert_select 'td', text: @site.name, count: 0
-  end
-
   test 'Admin site index shows all sites to signed in admin if none are assigned' do
     sign_in(@root)
     get admin_sites_path


### PR DESCRIPTION
Fixes #1792

## Description

- Restores all sites to admin root users, regardless of whether or not they admin for them
- BUT restricts the sites they see from their dashboard, showing them only those they admin for here if they are a site admin for any.
- Adds tests to assert this is working as expected and removes now broken test making wrong assertion

## Notes

Can whoever is checking this double check the acceptance criteria is definitely the desired behaviour :------)