### PR TITLE
add reset to partners category filter UI

### DIFF
--- a/app/assets/stylesheets/base/buttons.sass
+++ b/app/assets/stylesheets/base/buttons.sass
@@ -1,5 +1,4 @@
 button
-  font-family: inherit
   font-size: 100%
   margin: 0
   overflow: visible
@@ -10,11 +9,13 @@ button
 
 .btn
   display: inline-block
+  background-color: var(--base-background)
   border-color: $base-primary
   border-color: var(--base-primary)
   border-width: 2px
   border-style: solid
   border-radius: 3rem
+  color: var(--base-text)
   padding: 0.4rem 1.2rem
   margin-bottom: 0.5rem
   text-align: center

--- a/app/assets/stylesheets/base/typography.sass
+++ b/app/assets/stylesheets/base/typography.sass
@@ -176,4 +176,5 @@ br.half
 
 input
   font-family: $sans-serif
+  font-size: inherit
 

--- a/app/assets/stylesheets/base/typography.sass
+++ b/app/assets/stylesheets/base/typography.sass
@@ -173,3 +173,7 @@ br.half
 
 .regular-links a
   font-weight: $regular
+
+input
+  font-family: $sans-serif
+

--- a/app/components/breadcrumb/breadcrumb.sass
+++ b/app/components/breadcrumb/breadcrumb.sass
@@ -6,6 +6,9 @@
   +justify-content(flex-start)
   font-size: $small-font-size
   margin: 1rem 0
+  .btn
+    border-bottom-color: var(--base-primary)
+    margin-left: 0.5rem
   a
     border-bottom-style: solid
     border-bottom-color: $base-rules-dark

--- a/app/components/breadcrumb/breadcrumb.sass
+++ b/app/components/breadcrumb/breadcrumb.sass
@@ -9,6 +9,7 @@
   .btn
     border-bottom-color: var(--base-primary)
     margin-left: 0.5rem
+    line-height: normal
   a
     border-bottom-style: solid
     border-bottom-color: $base-rules-dark

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -29,7 +29,7 @@
               </div>
               <hr>
                   <a href="/partners" class="btn">Reset</a>
-                  <%= f.button :submit , 'Filter', class: 'btn' %>
+                  <%= f.button :submit , 'Filter' %>
             </div>
           <% end %>
       </div>

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -28,7 +28,8 @@
                 <% end %>
               </div>
               <hr>
-                <%= f.button :submit , 'Filter' %>
+                  <a href="/partners" class="btn">Reset</a>
+                  <%= f.button :submit , 'Filter', class: 'btn' %>
             </div>
           <% end %>
       </div>


### PR DESCRIPTION
fixes #1778

This issue is also described by David in #1780

## Description

- Add a link back to `/partners` labeled "Reset
- Some CSS fiddling to keep UI consistent, inputs were not using the correct font for example.