### PR TITLE
admin UI for indiviual sites is showing the tag type

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -38,7 +38,10 @@ module UsersHelper
   end
 
   def options_for_tags
-    policy_scope(Tag).order(:name).pluck(:name, :id)
+    policy_scope(Tag)
+      .select(:name, :type, :id)
+      .order(:name)
+      .map { |r| [r.name_with_type, r.id] }
   end
 
   def role_label(value)

--- a/test/integration/admin/sites_integration_test.rb
+++ b/test/integration/admin/sites_integration_test.rb
@@ -109,7 +109,7 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal(2, neighbourhoods_shown)
   end
 
-  test 'site tags show up' do
+  test 'site tags show up and display their type' do
     @site.tags << @tag
     @site_admin.tags << @tag
 
@@ -117,7 +117,7 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
     get edit_admin_site_path(@site)
     assert_response :success
 
-    tag_options = assert_select 'div.site_tags option', count: 1, text: @tag.name
+    tag_options = assert_select 'div.site_tags option', count: 1, text: @tag.name_with_type
 
     tag = tag_options.first
     assert tag.attributes.key?('selected')

--- a/test/system/admin/article_test.rb
+++ b/test/system/admin/article_test.rb
@@ -42,7 +42,7 @@ class AdminArticleTest < ApplicationSystemTestCase
 
     tags = select2_node 'article_tags'
     select2 @tag.name, xpath: tags.path
-    assert_select2_multiple [@tag.name], tags
+    assert_select2_multiple [@tag.name_with_type], tags
 
     click_button 'Save Article'
 
@@ -59,6 +59,6 @@ class AdminArticleTest < ApplicationSystemTestCase
     assert_select2_multiple [@partner.name, @partner_two.name], partners
 
     tags = select2_node 'article_tags'
-    assert_select2_multiple [@tag.name], tags
+    assert_select2_multiple [@tag.name_with_type], tags
   end
 end

--- a/test/system/admin/site_test.rb
+++ b/test/system/admin/site_test.rb
@@ -49,7 +49,7 @@ class AdminSiteTest < ApplicationSystemTestCase
 
     tags = select2_node 'site_tags'
     select2 @tag.name, xpath: tags.path
-    assert_select2_multiple [@tag.name], tags
+    assert_select2_multiple [@tag.name_with_type], tags
 
     new_site_name = 'TEST_NAME_123'
     fill_in 'Name', with: new_site_name
@@ -68,7 +68,7 @@ class AdminSiteTest < ApplicationSystemTestCase
     assert_select2_single @neighbourhood_two, service_areas[0]
 
     tags = select2_node 'site_tags'
-    assert_select2_multiple [@tag.name], tags
+    assert_select2_multiple [@tag.name_with_type], tags
   end
   test 'primary neighbourhood not rendering on other neighbourhoods section' do
     click_link 'Sites'
@@ -83,9 +83,9 @@ class AdminSiteTest < ApplicationSystemTestCase
     service_areas = all(:css, '.sites_neighbourhoods .select2-container', wait: 1)
 
     msg = \
-      '@site should only have a primary neighbourhood, '\
-      'if this fails either this is now rendering where '\
-      'it should\'t or another neighborhood has been added '\
+      '@site should only have a primary neighbourhood, ' \
+      'if this fails either this is now rendering where ' \
+      'it should\'t or another neighborhood has been added ' \
       'at setup and the test should be adjusted'
 
     assert_predicate service_areas.length, :zero?, msg

--- a/test/system/admin/user_test.rb
+++ b/test/system/admin/user_test.rb
@@ -47,7 +47,7 @@ class AdminUserTest < ApplicationSystemTestCase
 
     tags = select2_node 'user_tags'
     select2 @tag.name, xpath: tags.path
-    assert_select2_multiple [@tag.name], tags
+    assert_select2_multiple [@tag.name_with_type], tags
     click_button 'Update'
 
     click_link 'Users'
@@ -65,6 +65,6 @@ class AdminUserTest < ApplicationSystemTestCase
     assert_select2_multiple [@neighbourhood_one, @neighbourhood_two], neighbourhoods
 
     tags = select2_node 'user_tags'
-    assert_select2_multiple [@tag.name], tags
+    assert_select2_multiple [@tag.name_with_type], tags
   end
 end


### PR DESCRIPTION
fix #1734

- mimic the `options_for_tags` method we are using for partners
- update tests