### PR TITLE
Fix wrong node version creeping into builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
 	"lint-staged": {
 		"*.{css,html,js,json,md,scss,yml}": "prettier --write",
 		"{*.{rb,jbuilder,rake,ru},.simplecov,Gemfile,Rakefile}": "bundle exec rubocop --autocorrect"
+	},
+	"engines": {
+		"node": "16.13.1"
 	}
 }


### PR DESCRIPTION
## Description

Our builds are failing at the moment because they are being built with the wrong version of node. My digging is leading me down the following path:

This step is failing because of this github action

![Screenshot 2023-05-09 at 17 51 46](https://github.com/geeksforsocialchange/PlaceCal/assets/46496391/a03a06c6-655f-4f05-9e96-88eedd89aba8)

This action is failing because this version of heroku is incompatible with this version of node, which is not the version we are using elsewhere in this project

![Screenshot 2023-05-09 at 17 55 54](https://github.com/geeksforsocialchange/PlaceCal/assets/46496391/63ac7d41-7c4b-44c2-a987-d8c66fcef2d8)

This version of node is being used because we do not specify a version in engines in our package.json

![Screenshot 2023-05-09 at 17 52 03](https://github.com/geeksforsocialchange/PlaceCal/assets/46496391/e91cc458-bd92-45aa-93e2-45e53d814309)

https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
