### PR TITLE
add link styling to placecal build link

### DIFF
--- a/app/components/home_footer_component/home_footer_component.html.erb
+++ b/app/components/home_footer_component/home_footer_component.html.erb
@@ -63,7 +63,7 @@
 
       <p>
         <% build = ENV['GIT_REV'] ? ENV['GIT_REV'][0,7] : 'main' %>
-        Build: <tt><%= link_to build, "https://github.com/geeksforsocialchange/PlaceCal/commit/#{build}" %></tt>
+        Build: <tt><%= link_to build, "https://github.com/geeksforsocialchange/PlaceCal/commit/#{build}" , class: "footer_home__foot__link" %></tt>
       </p>
 
       <% if Rails.env.development? %>


### PR DESCRIPTION
fixes #1850 

This uses the same link styling as the privacy policy but gets a mono font from the `tt` element. Production isn't underlined but this is an accessibility issue do I haven't reproduced the exact styling.