### PR TITLE
change how sites are dynamically pulled in

### DIFF
--- a/app/components/featured_partnerships_component.rb
+++ b/app/components/featured_partnerships_component.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 class FeaturedPartnershipsComponent < ViewComponent::Base
+  def initialize(sites:)
+    super
+    @sites = sites
+  end
 end

--- a/app/components/featured_partnerships_component/featured_partnerships_component.html.erb
+++ b/app/components/featured_partnerships_component/featured_partnerships_component.html.erb
@@ -1,44 +1,9 @@
 <div class="featured_partnerships">
   <h1 class="featured_partnerships--title">Visit a Partnership</h1>
-
-  hello
+	<%= render(FourColGridComponent.new()) do %>
+		<% @sites.each do |site| %>
+        <%= render(PartnershipCardComponent.new(site: site)) %>
+		<% end %>
+	<% end %>
   
-  <div class="featured_partnerships--container">
-    <div class="featured_partnerships--item">
-      <%= render(
-	  PartnershipCardComponent.new(
-	  title: '[cCc] Trans Dimension',
-	  logo_url: asset_path('/assets/partnerships/trans-dimension.png'),
-	  link_url: 'https://trans-dimension.co.uk',
-	  summary: '[cCc] A summary of the Trans Dimension partnership in text')
-	  ) %>
-    </div>
-    <div class="featured_partnerships--item">
-      <%= render(
-	  PartnershipCardComponent.new(
-	  title: '[cCc] Trans Dimension',
-	  logo_url: asset_path('/assets/partnerships/trans-dimension.png'),
-	  link_url: 'https://trans-dimension.co.uk',
-	  summary: '[cCc] A summary of the Trans Dimension partnership in text')
-	  ) %>
-    </div>
-    <div class="featured_partnerships--item">
-      <%= render(
-	  PartnershipCardComponent.new(
-	  title: '[cCc] Trans Dimension',
-	  logo_url: asset_path('/assets/partnerships/trans-dimension.png'),
-	  link_url: 'https://trans-dimension.co.uk',
-	  summary: '[cCc] A summary of the Trans Dimension partnership in text')
-	  ) %>
-    </div>
-    <div class="featured_partnerships--item">
-      <%= render(
-	  PartnershipCardComponent.new(
-	  title: '[cCc] Trans Dimension',
-	  logo_url: asset_path('/assets/partnerships/trans-dimension.png'),
-	  link_url: 'https://trans-dimension.co.uk',
-	  summary: '[cCc] A summary of the Trans Dimension partnership in text')
-	  ) %>
-    </div>
-  </div>
 </div>

--- a/app/components/featured_partnerships_component/featured_partnerships_component.scss
+++ b/app/components/featured_partnerships_component/featured_partnerships_component.scss
@@ -8,35 +8,6 @@
 	color: $home-background-3;
 	font-family: $sans-serif;
 	font-size: 2.22222rem;
-	margin: 0;
+	margin: 0 0 4rem;
 	text-align: center;
-}
-
-.featured_partnerships--container {
-	display: flex;
-	gap: 1rem;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-
-	@include for-tablet-portrait-up {
-		flex-direction: row;
-		flex-wrap: wrap;
-	}
-
-	@include for-tablet-landscape-up {
-		flex-wrap: nowrap;
-	}
-}
-
-.featured_partnerships--item {
-	max-width: 20rem;
-
-	@include for-tablet-portrait-up {
-		width: 40%;
-	}
-
-	@include for-tablet-landscape-up {
-		width: auto;
-	}
 }

--- a/app/components/partnership_card_component.rb
+++ b/app/components/partnership_card_component.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 class PartnershipCardComponent < ViewComponent::Base
-  def initialize(title:, logo_url:, link_url:, summary:)
+  def initialize(site:)
     super
-    @title = title
-    @logo_url = logo_url
-    @link_url = link_url
-    @summary = summary
+    @site = site
   end
 end

--- a/app/components/partnership_card_component/partnership_card_component.html.erb
+++ b/app/components/partnership_card_component/partnership_card_component.html.erb
@@ -1,9 +1,9 @@
 <div class="partnership_card">
   <div class="partnership_card--logo">
-    <img class="partnership_card--image" src="<%= @logo_url %>" atl="<%= @title %>"/>
+    <img class="partnership_card--image" src="<%= @site.domain %>/<%= @site.logo %>" alt="<%= @site.name %> logo"/>
   </div>
   <p class="partnership_card--summary">
-    <%= @summary %>
+    <%= @site.tagline %>
   </p>
-  <a href="<%= @link_url %>" class="partnership_card--link">Link</a>
+  <%= link_to "#{@site.name} calendar", "#{@site.domain}/events"  , class: 'partnership_card--link' %>
 </div>

--- a/app/components/partnership_card_component/partnership_card_component.scss
+++ b/app/components/partnership_card_component/partnership_card_component.scss
@@ -1,7 +1,16 @@
 @import "variables_mixins";
 
 .partnership_card {
+	max-width: 20rem;
 	text-align: center;
+
+	@include for-tablet-portrait-up {
+		width: 40%;
+	}
+
+	@include for-tablet-landscape-up {
+		width: auto;
+	}
 }
 
 .partnership_card--logo {

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,11 +5,17 @@ class PagesController < ApplicationController
   before_action :set_site
 
   def home
-    @sites = Site.where(is_published: true)
+    @sites = Site.published
   end
 
   def find_placecal
-    @sites = Site.where(is_published: true)
+    @sites = Site.published
+    @neighbourhoods = Site.published.select do |site|
+      site.tags.none? { |tag| tag.type == 'Neighbourhood' }
+    end
+    @partnerships = Site.published.select do |site|
+      site.tags.any? { |tag| tag.type == 'Partnership' }
+    end
   end
 
   def robots

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -36,6 +36,8 @@ class Site < ApplicationRecord
   validates :name, :slug, :domain, presence: true
   validates :place_name unless :default_site?
 
+  scope :published, -> { where(is_published: true) }
+
   mount_uploader :logo, SiteLogoUploader
   mount_uploader :footer_logo, SiteLogoUploader
   mount_uploader :hero_image, HeroImageUploader

--- a/app/views/pages/find_placecal.html.erb
+++ b/app/views/pages/find_placecal.html.erb
@@ -1,16 +1,14 @@
 
 <article class="home">
   <div class="margin">
-    <%= render(FeaturedPartnershipsComponent.new) %>
-
     <div class="card card--first center">
       <h1 class="section">Find your PlaceCal</h1>
-      <p class="alt-title-small">Pick your community to check out what’s on in your area.</p>
+      <p class="alt-title-small">Pick your community to check out what's on in your area.</p>
     </div>
-
+    <%= render(FeaturedPartnershipsComponent.new(sites: @partnerships)) %>
     <%= render(ContainerWithHeaderComponent.new(title: "[cCc]Check out a neighbourhood",  color: "green")) do %>
       <%= render(FourColGridComponent.new()) do %>
-        <% @sites.each do |site| %>
+        <% @neighbourhoods.each do |site| %>
           <%= render(NeighbourhoodHomeCardComponent.new(site: site)) %>
         <% end %>
       <% end %>


### PR DESCRIPTION
Fixes #1873

## Description

- Assigns published neighbourhood and partnership cards dynamically
- Tries to make styling a bit more uniform, but will need to be viewed with some better data to double check this is working - very confused about what exactly I'm looking at in local host as I thought I was were pulling this in from production but the published instances are not the ones we have listed - we definitely need to check this is all correct
- This was a bit of a mess and we're pushed for time so I've done what i can but am aware we could do more here! Think it just needs to be put to one side for a bit while we finalise all the content