### PR TITLE
Curated calendars improvements

### DIFF
--- a/app/components/case_study_component/case_study_component.html.erb
+++ b/app/components/case_study_component/case_study_component.html.erb
@@ -1,6 +1,7 @@
 
 <section class="case_study__section--outer">
   <section class="case_study__section--inner case_study__round-border--top">
+    <h3 class="case_study__title">Curated Calendars</h3>
     <%= image_tag @image_src, alt: @image_alt, class: "case_study__img" %>
     <div class="case_study__section-top">
       <%= render(PullQuoteComponent.new(source: "", context: "", options: { light_mode: true })) do %>

--- a/app/components/case_study_component/case_study_component.scss
+++ b/app/components/case_study_component/case_study_component.scss
@@ -1,5 +1,20 @@
 @import "variables_mixins";
 
+.case_study__title {
+	color: $home-background-3;
+	font-family: $sans-serif;
+	font-size: 1.8rem;
+	font-weight: 400;
+	margin: 2rem auto;
+	max-width: 25ch;
+	padding: 2rem 0 0;
+	text-align: center;
+
+	@include for-tablet-portrait-up {
+		font-size: 2.2rem;
+	}
+}
+
 .case_study__section--outer {
 	border-radius: 1.11rem;
 }
@@ -12,7 +27,7 @@
 
 .case_study__round-border--top {
 	border-radius: 1.11rem 1.11rem 0 0;
-	background-color: $base-background;
+	background-color: $home-background-3;
 }
 
 .case_study__round-border--bottom {

--- a/app/components/case_study_component/case_study_component.scss
+++ b/app/components/case_study_component/case_study_component.scss
@@ -1,7 +1,6 @@
 @import "variables_mixins";
 
 .case_study__title {
-	color: $home-background-3;
 	font-family: $sans-serif;
 	font-size: 1.8rem;
 	font-weight: 400;

--- a/app/components/featured_partnerships_component/featured_partnerships_component.html.erb
+++ b/app/components/featured_partnerships_component/featured_partnerships_component.html.erb
@@ -1,9 +1,8 @@
 <div class="featured_partnerships">
-  <h1 class="featured_partnerships--title">Interest-based Calendars</h1>
+  <h3 class="featured_partnerships--title">Curated Calendars</h3>
 	<%= render(FourColGridComponent.new()) do %>
 		<% @sites.each do |site| %>
         <%= render(PartnershipCardComponent.new(site: site)) %>
 		<% end %>
 	<% end %>
-  
 </div>

--- a/app/components/featured_partnerships_component/featured_partnerships_component.html.erb
+++ b/app/components/featured_partnerships_component/featured_partnerships_component.html.erb
@@ -1,6 +1,6 @@
 <div class="featured_partnerships">
   <h3 class="featured_partnerships--title">Curated Calendars</h3>
-	<%= render(FourColGridComponent.new()) do %>
+	<%= render(FourColGridComponent.new({partnershipCards: true})) do %>
 		<% @sites.each do |site| %>
         <%= render(PartnershipCardComponent.new(site: site)) %>
 		<% end %>

--- a/app/components/featured_partnerships_component/featured_partnerships_component.scss
+++ b/app/components/featured_partnerships_component/featured_partnerships_component.scss
@@ -7,7 +7,13 @@
 .featured_partnerships--title {
 	color: $home-background-3;
 	font-family: $sans-serif;
-	font-size: 2.22222rem;
-	margin: 0 0 4rem;
+	font-size: 1.8rem;
+	font-weight: 400;
+	margin: 2rem auto;
+	max-width: 25ch;
 	text-align: center;
+
+	@include for-tablet-portrait-up {
+		font-size: 2.2rem;
+	}
 }

--- a/app/components/four_col_grid_component.rb
+++ b/app/components/four_col_grid_component.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 class FourColGridComponent < ViewComponent::Base
+  def initialize(options = { partnershipCards: false })
+    super
+    @class = options[:partnershipCards] ? 'four_col_grid--larger' : 'four_col_grid'
+  end
 end

--- a/app/components/four_col_grid_component/four_col_grid_component.html.erb
+++ b/app/components/four_col_grid_component/four_col_grid_component.html.erb
@@ -1,3 +1,3 @@
-<ul class="four_col_grid">
+<ul class=<%= @class %>>
   <%= content %>
 </ul>

--- a/app/components/four_col_grid_component/four_col_grid_component.scss
+++ b/app/components/four_col_grid_component/four_col_grid_component.scss
@@ -14,3 +14,24 @@
 		padding: 0 2rem;
 	}
 }
+
+.four_col_grid--larger {
+	display: grid;
+	gap: 2rem 1rem;
+	grid-template-columns: repeat(
+		auto-fit,
+		minmax(clamp(16rem, calc(25% - 1rem), 18rem), 1fr)
+	);
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	@include for-tablet-portrait-up {
+		grid-template-columns: repeat(
+			auto-fit,
+			minmax(clamp(14.5rem, calc(25% - 1rem), 18rem), 1fr)
+		);
+	}
+	@include for-desktop-up {
+		padding: 0 2rem;
+	}
+}

--- a/app/components/partnership_card_component.rb
+++ b/app/components/partnership_card_component.rb
@@ -3,6 +3,10 @@
 class PartnershipCardComponent < ViewComponent::Base
   def initialize(site:)
     super
-    @site = site
+    url_concatenator = site.domain[-1] == '/' ? '' : '/'
+    @site_name = site.name
+    @site_tagline = site.tagline
+    @image_src = "#{site.domain}#{url_concatenator}#{site.logo}"
+    @link_to = "#{site.domain}#{url_concatenator}events"
   end
 end

--- a/app/components/partnership_card_component/partnership_card_component.html.erb
+++ b/app/components/partnership_card_component/partnership_card_component.html.erb
@@ -1,9 +1,9 @@
 <div class="partnership_card">
   <div class="partnership_card--logo">
-    <img class="partnership_card--image" src="<%= @site.domain %>/<%= @site.logo %>" alt="<%= @site.name %> logo"/>
+    <img class="partnership_card--image" src="<%=@image_src%>" alt="<%= @site_name %> logo"/>
   </div>
   <p class="partnership_card--summary">
-    <%= @site.tagline %>
+    <%= @site_tagline %>
   </p>
-  <%= link_to "#{@site.name} calendar", "#{@site.domain}/events"  , class: 'partnership_card--link' %>
+  <%= link_to "#{@site_name} calendar", @link_to, class: 'partnership_card--link' %>
 </div>

--- a/app/components/partnership_card_component/partnership_card_component.scss
+++ b/app/components/partnership_card_component/partnership_card_component.scss
@@ -3,14 +3,7 @@
 .partnership_card {
 	max-width: 20rem;
 	text-align: center;
-
-	@include for-tablet-portrait-up {
-		width: 40%;
-	}
-
-	@include for-tablet-landscape-up {
-		width: auto;
-	}
+	width: 100%;
 }
 
 .partnership_card--logo {
@@ -29,7 +22,6 @@
 	border-radius: 3rem;
 	display: inline-block;
 	font-weight: bold;
-	margin: 0.5rem;
 	padding: 0.5rem 2rem;
 	text-decoration: none;
 	transition: 0.3s;
@@ -44,6 +36,6 @@
 
 .partnership_card--summary {
 	color: $home-background-3;
-	height: 3rem;
+	min-height: 5rem;
 	padding: 0 2rem;
 }

--- a/app/components/partnership_card_component/partnership_card_component.scss
+++ b/app/components/partnership_card_component/partnership_card_component.scss
@@ -1,7 +1,6 @@
 @import "variables_mixins";
 
 .partnership_card {
-	max-width: 20rem;
 	text-align: center;
 	width: 100%;
 }
@@ -18,14 +17,21 @@
 }
 
 .partnership_card--link {
+	align-items: center;
 	background-color: $home-background-3;
 	border-radius: 3rem;
-	display: inline-block;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
 	font-weight: bold;
-	padding: 0.5rem 2rem;
+	padding: 0.5rem;
 	text-decoration: none;
 	transition: 0.3s;
 	width: 100%;
+	@include for-tablet-portrait-up {
+		height: 4.5rem;
+		padding: 1rem;
+	}
 }
 
 .partnership_card--link:hover {
@@ -36,6 +42,8 @@
 
 .partnership_card--summary {
 	color: $home-background-3;
-	min-height: 5rem;
 	padding: 0 2rem;
+	@include for-tablet-portrait-up {
+		min-height: 5rem;
+	}
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,17 +1,17 @@
 <article class="home">
   <div class="margin home__flow">
     <%= render(HomeStraplineComponent.new) %>
-    <%= render(FullWidthActionComponent.new(title: "Find your PlaceCal", link_text: "See calendars", link_url: find_placecal_path, color: "red")) do %>
-      Ready to get started with PlaceCal? Here you can see a list of all current PlaceCal instances, organised by interest and location.
-    <% end %>
+    <%= render(CaseStudyComponent.new(partner: "transDim" )) %>
     <%= render(ContainerWithHeaderComponent.new(title: "Place-based calendars",  color: "green")) do %>
       <%= render(FourColGridComponent.new()) do %>
-        <% @sites.each do |site| %>
+        <% @sites.take(4).each do |site| %>
           <%= render(NeighbourhoodHomeCardComponent.new(site: site)) %>
         <% end %>
       <% end %>
     <% end %>
-    <%= render(CaseStudyComponent.new(partner: "transDim" )) %>
+    <%= render(FullWidthActionComponent.new(title: "Find your PlaceCal", link_text: "See calendars", link_url: find_placecal_path, color: "red")) do %>
+      Ready to get started with PlaceCal? Here you can see a list of all current PlaceCal instances, organised by interest and location.
+    <% end %>
     <%= render(FullWidthActionComponent.new(title: "Want to create a PlaceCal for your community?", link_text: "Get in touch", link_url: get_in_touch_path, color: "green")) do %>
       Work with us to set up a PlaceCal for your community, built through on-the-ground connections with venues, organisers, and community members.
     <% end %>


### PR DESCRIPTION
Fixes #1892 
Fixes #1896

### Description

- Fixes dodgy urls forming with double `//` by checking url & only applying if necessary
- Also hides content of @site from partnership component view & only passes what is necessary
- Changes `interest-based calendars` to `curated calendars`
- Moves trans dimension case study up the page & adds a banner title to it
- Oh yes - and limited neighbourhood cards on homepage to 4 - just to avoid any extra ones accidentally creeping in