### PR TITLE
Refinement of filter category selection

### DIFF
--- a/app/controllers/concerns/partner_category_filter.rb
+++ b/app/controllers/concerns/partner_category_filter.rb
@@ -42,6 +42,7 @@ class PartnerCategoryFilter
                     )
                     .group('tags.id')
                     .having('count(partner_tags.tag_id) > 0')
+                    .having('(count(addresses.id) > 0 OR count(service_areas.id) > 0)')
                     .order(:name)
   end
 

--- a/app/controllers/concerns/partner_category_filter.rb
+++ b/app/controllers/concerns/partner_category_filter.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class PartnerCategoryFilter
-  def initialize(params)
+  def initialize(site, params)
     @current_category_id = params[:category]
     @current_category = Category.where(id: @current_category_id).first if @current_category_id.present?
 
     @include_mode = params[:mode] # include/exclude
+    @site_neighbourhood_ids = site.neighbourhood_ids
   end
 
   def active?
@@ -27,10 +28,20 @@ class PartnerCategoryFilter
   end
 
   def categories
+    # only return categories that have partners
+    #   where those partners have addresses or service areas
+    #     in the neighbourhoods of the site
+
     @categories ||= Category
                     .joins(:partner_tags)
+                    .left_joins(:partner_tags)
+                    .left_joins(partners: %i[address service_areas])
+                    .where(
+                      '(addresses.neighbourhood_id in (:neighbourhood_ids) OR service_areas.neighbourhood_id in (:neighbourhood_ids))',
+                      neighbourhood_ids: @site_neighbourhood_ids
+                    )
                     .group('tags.id')
-                    .having('count(tag_id) > 0')
+                    .having('count(partner_tags.tag_id) > 0')
                     .order(:name)
   end
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -24,7 +24,7 @@ class PartnersController < ApplicationController
                 .includes(:service_areas, :address)
                 .order(:name)
 
-    @category_filter = PartnerCategoryFilter.new(params)
+    @category_filter = PartnerCategoryFilter.new(current_site, params)
     @partners = @category_filter.apply_to(@partners)
 
     # show only partners with no service_areas

--- a/app/models/neighbourhood.rb
+++ b/app/models/neighbourhood.rb
@@ -20,6 +20,8 @@ class Neighbourhood < ApplicationRecord
            source: :partners,
            class_name: 'Partner'
 
+  # validates :unit_code_value, presence: true, uniqueness: true
+
   # validates :name, presence: true
   validates :unit_code_value,
             length: { is: 9 },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"lodash": "4.17.21",
 		"popper.js": "1.16.1",
 		"sass": "1.62.1",
-		"select2": "4.0.13"
+		"select2": "4.0.13",
+		"yarn": "^1.22.19"
 	},
 	"devDependencies": {
 		"husky": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
 		"lodash": "4.17.21",
 		"popper.js": "1.16.1",
 		"sass": "1.62.1",
-		"select2": "4.0.13",
-		"yarn": "^1.22.19"
+		"select2": "4.0.13"
 	},
 	"devDependencies": {
 		"husky": "8.0.3",
 		"lint-staged": "13.1.2",
-		"prettier": "2.8.1"
+		"prettier": "2.8.1",
+		"yarn": "^1.22.19"
 	},
 	"scripts": {
 		"build": "node esbuild.config.js",

--- a/test/controllers/concerns/partner_category_filter_test.rb
+++ b/test/controllers/concerns/partner_category_filter_test.rb
@@ -7,28 +7,35 @@ class PartnerCategoryFilterTest < ActionDispatch::IntegrationTest
     @category = create(:category)
     @categories = create_list(:category, 4)
     @categories << @category
+
+    @neighbourhood = create(:neighbourhood)
+    @site = create(:site)
+    @site.neighbourhoods << @neighbourhood
   end
 
   test '#active?' do
     # is false by default
-    filter = PartnerCategoryFilter.new({})
+    filter = PartnerCategoryFilter.new(@site, {})
     assert_not_predicate(filter, :active?, 'is_active? should be false with no input')
-    filter = PartnerCategoryFilter.new(category: @category.id)
+    filter = PartnerCategoryFilter.new(@site, category: @category.id)
     assert_predicate filter, :active?, 'should be active'
   end
 
   test '#categories' do
     # doesn't find categories that lack partners
-    filter = PartnerCategoryFilter.new({})
+    filter = PartnerCategoryFilter.new(@site, {})
     found = filter.categories
     assert_predicate found.length, :zero?
 
     # does find categories assigned to partners
+    #   (and those partners have addresses/service areas in the given site)
     given_some_partnered_categories_exist
 
-    filter = PartnerCategoryFilter.new({})
+    filter = PartnerCategoryFilter.new(@site, {})
     found = filter.categories
     assert_equal(5, found.length)
+
+    # only shows categories that have partners who exist in this sites neighbourhoods
   end
 
   test '#apply_to' do
@@ -40,65 +47,69 @@ class PartnerCategoryFilterTest < ActionDispatch::IntegrationTest
     partner4 = create(:partner)
 
     # returns every partner if no filter category set
-    filter = PartnerCategoryFilter.new({})
+    filter = PartnerCategoryFilter.new(@site, {})
     query = filter.apply_to(Partner)
     assert_equal(4, query.count)
 
     # returns only partners assigned category (in include mode)
     partner1.tags << @category
 
-    filter = PartnerCategoryFilter.new(category: @category.id)
+    filter = PartnerCategoryFilter.new(@site, category: @category.id)
     query = filter.apply_to(Partner)
     assert_equal(1, query.count)
 
     # returns only partners NOT assigned category (in exclude mode)
-    filter = PartnerCategoryFilter.new(category: @category.id, mode: 'exclude')
+    filter = PartnerCategoryFilter.new(@site, category: @category.id, mode: 'exclude')
     query = filter.apply_to(Partner)
     assert_equal(3, query.count)
   end
 
   test '#show_filter?' do
     # is false if no partnered categories found
-    filter = PartnerCategoryFilter.new({})
+    filter = PartnerCategoryFilter.new(@site, {})
     assert_not_predicate(filter, :show_filter?)
 
     # is true when partnered categories found
     given_some_partnered_categories_exist
 
-    filter = PartnerCategoryFilter.new({})
+    filter = PartnerCategoryFilter.new(@site, {})
     assert_predicate filter, :show_filter?
   end
 
   test '#current_category?' do
     # is false when no current category set
-    filter = PartnerCategoryFilter.new({})
+    filter = PartnerCategoryFilter.new(@site, {})
     assert_not(filter.current_category?(@category))
 
     # is true when current category matches incoming category
-    filter = PartnerCategoryFilter.new(category: @category.id)
+    filter = PartnerCategoryFilter.new(@site, category: @category.id)
     assert(filter.current_category?(@category))
   end
 
   test 'modes' do
     # default to include mode
-    filter = PartnerCategoryFilter.new({})
+    filter = PartnerCategoryFilter.new(@site, {})
     assert_predicate filter, :include_mode?
     assert_not filter.exclude_mode?
 
     # is include mode when set
-    filter = PartnerCategoryFilter.new(mode: 'include')
+    filter = PartnerCategoryFilter.new(@site, mode: 'include')
     assert_predicate filter, :include_mode?
     assert_not filter.exclude_mode?
 
     # is exclude mode when set
-    filter = PartnerCategoryFilter.new(mode: 'exclude')
+    filter = PartnerCategoryFilter.new(@site, mode: 'exclude')
     assert_predicate filter, :exclude_mode?
     assert_not filter.include_mode?
   end
 
   # helpers
+  # rubocop:disable Minitest/TestMethodName, Lint/MissingCopEnableDirective
   def given_some_partnered_categories_exist
+    assert_predicate @site.neighbourhoods.count, :positive?
+
     partner = create(:partner)
+    partner.service_areas.create(neighbourhood: @site.neighbourhoods.first)
 
     @categories.each do |category|
       partner.tags << category

--- a/test/controllers/partners_controller_test.rb
+++ b/test/controllers/partners_controller_test.rb
@@ -16,6 +16,9 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
       a.save
       a
     end
+
+    @site = create(:site)
+
     # NOTE: Uhhh? What? Is this a factorybot thing? Why does create(:address, neighbourhood: n) not work here?
 
     @partners = addresses.map do |a|

--- a/test/controllers/partners_controller_test.rb
+++ b/test/controllers/partners_controller_test.rb
@@ -17,8 +17,6 @@ class PartnersControllerTest < ActionDispatch::IntegrationTest
       a
     end
 
-    @site = create(:site)
-
     # NOTE: Uhhh? What? Is this a factorybot thing? Why does create(:address, neighbourhood: n) not work here?
 
     @partners = addresses.map do |a|

--- a/test/integration/partner_category_filter_test.rb
+++ b/test/integration/partner_category_filter_test.rb
@@ -2,8 +2,8 @@
 
 require 'test_helper'
 
-class PartnerCategoryFilterTest < ActionDispatch::IntegrationTest
-  setup do
+class PartnerCategoryFilterIntegrationTest < ActionDispatch::IntegrationTest
+  def setup
     Neighbourhood.destroy_all
 
     @neighbourhood = create(:neighbourhood, unit_code_value: 'E05011368')


### PR DESCRIPTION
Fixes #1909

On site partners page: the filter only shows categories that have been applied to partners who have an address or service area in the site's neighbourhood pool.