### PR TITLE
Remove yarn as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
 	"devDependencies": {
 		"husky": "8.0.3",
 		"lint-staged": "13.1.2",
-		"prettier": "2.8.1",
-		"yarn": "^1.22.19"
+		"prettier": "2.8.1"
 	},
 	"scripts": {
 		"build": "node esbuild.config.js",


### PR DESCRIPTION
## Description

- Revert change made in [#1910](https://github.com/geeksforsocialchange/PlaceCal/pull/1910/commits/ca074c5fd44476c93ee6d5493f5daa6b73a339a2) to add yarn as a dev dependency to prevent build breaking on staging