### PR TITLE
Fix husky lint check

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	},
 	"lint-staged": {
 		"*.{css,html,js,json,md,scss,yml}": "prettier --write",
-		"{*.{rb,jbuilder,rake,ru},.simplecov,Gemfile,Rakefile}": "bundle exec rubocop --autocorrect"
+		"{*.{rb,jbuilder,rake,ru},.simplecov,Gemfile,Rakefile}": "bundle exec rubocop --force-exclusion --autocorrect"
 	},
 	"engines": {
 		"node": "16.13.1"


### PR DESCRIPTION
Closes #1971 

When linting in before-commit hook, make rubocop honor the ignore list so it doesn't try to lint things like `db/schema.rb` and so on.