### PR TITLE
Duplicate neighbourhoods

### DIFF
--- a/app/helpers/neighbourhoods_helper.rb
+++ b/app/helpers/neighbourhoods_helper.rb
@@ -10,4 +10,12 @@ module NeighbourhoodsHelper
 
     "[untitled #{neighbourhood.id}]"
   end
+
+  def link_to_neighbourhood(neighbourhood)
+    text = neighbourhood.name
+    text += " - (#{neighbourhood.release_date.year}/#{neighbourhood.release_date.month})" if neighbourhood.legacy_neighbourhood?
+
+    html = link_to(text, edit_admin_neighbourhood_path(neighbourhood))
+    html.html_safe # rubocop:disable Rails/OutputSafety
+  end
 end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -3,7 +3,8 @@
 module PartnersHelper
   def options_for_service_area_neighbourhoods
     # Remove the primary neighbourhood from the list
-    @all_neighbourhoods.filter { |e| e.name != '' }
+    @all_neighbourhoods.latest_release
+                       .filter { |e| e.name != '' }
                        .collect { |e| { name: e.contextual_name, id: e.id } }
   end
 

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
 module PartnersHelper
-  def options_for_service_area_neighbourhoods
-    # Remove the primary neighbourhood from the list
-    @all_neighbourhoods.latest_release
-                       .filter { |e| e.name != '' }
-                       .collect { |e| { name: e.contextual_name, id: e.id } }
+  def options_for_service_area_neighbourhoods(for_partner)
+    legacy_neighbourhoods = for_partner.service_area_neighbourhoods.where.not(release_date: Neighbourhood::LATEST_RELEASE_DATE)
+
+    scope = Neighbourhood.find_latest_neighbourhoods_maybe_with_legacy_neighbourhoods(@all_neighbourhoods, legacy_neighbourhoods)
+
+    scope
+      .order(:name)
+      .all
+      .collect do |ward|
+        name = ward.contextual_name
+        name += " - #{ward.release_date.year}/#{ward.release_date.month}" if ward.legacy_neighbourhood?
+
+        { name: name, id: ward.id }
+      end
   end
 
   def options_for_partner_tags

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -47,7 +47,7 @@ module PartnersHelper
   def service_area_links(partner)
     partner.service_area_neighbourhoods
            .order(:name)
-           .map { |hood| link_to hood.name, edit_admin_neighbourhood_path(hood) }
+           .map { |hood| link_to_neighbourhood(hood) }
            .join(', ')
            .html_safe
   end

--- a/app/helpers/sites_helper.rb
+++ b/app/helpers/sites_helper.rb
@@ -3,7 +3,8 @@
 module SitesHelper
   def options_for_sites_neighbourhoods
     # Remove the primary neighbourhood from the list
-    @all_neighbourhoods.filter { |e| e.name != '' }
+    @all_neighbourhoods.latest_release
+                       .filter { |e| e.name != '' }
                        .collect { |e| { name: e.contextual_name, id: e.id } }
   end
 

--- a/app/helpers/sites_helper.rb
+++ b/app/helpers/sites_helper.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
 module SitesHelper
-  def options_for_sites_neighbourhoods
-    # Remove the primary neighbourhood from the list
-    @all_neighbourhoods.latest_release
-                       .filter { |e| e.name != '' }
-                       .collect { |e| { name: e.contextual_name, id: e.id } }
+  def options_for_sites_neighbourhoods(for_site)
+    legacy_neighbourhoods = for_site.neighbourhoods.where.not(release_date: Neighbourhood::LATEST_RELEASE_DATE)
+
+    scope = Neighbourhood.find_latest_neighbourhoods_maybe_with_legacy_neighbourhoods(@all_neighbourhoods, legacy_neighbourhoods)
+
+    scope
+      .order(:name)
+      .all
+      .collect do |ward|
+        name = ward.contextual_name
+        name += " - #{ward.release_date.year}/#{ward.release_date.month}" if ward.legacy_neighbourhood?
+
+        { name: name, id: ward.id }
+      end
   end
 
   def options_for_tags

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -29,8 +29,9 @@ module UsersHelper
     policy_scope(Partner).all.order(:name).pluck(:name, :id)
   end
 
-  def options_for_neighbourhoods
+  def options_for_user_neighbourhoods
     policy_scope(Neighbourhood)
+      .latest_release
       .where('name is not null and name != \'\'')
       .order(:name)
       .all

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -29,13 +29,21 @@ module UsersHelper
     policy_scope(Partner).all.order(:name).pluck(:name, :id)
   end
 
-  def options_for_user_neighbourhoods
-    policy_scope(Neighbourhood)
-      .latest_release
-      .where('name is not null and name != \'\'')
+  def options_for_user_neighbourhoods(for_user)
+    legacy_neighbourhoods = for_user.neighbourhoods.where.not(release_date: Neighbourhood::LATEST_RELEASE_DATE)
+
+    scope = Neighbourhood.find_latest_neighbourhoods_maybe_with_legacy_neighbourhoods(policy_scope(Neighbourhood), legacy_neighbourhoods)
+
+    scope
       .order(:name)
       .all
-      .collect { |ward| [ward.contextual_name, ward.id] }
+      .collect do |ward|
+        if ward.legacy_neighbourhood?
+          ["#{ward.contextual_name} - #{ward.release_date.year}/#{ward.release_date.month}", ward.id]
+        else
+          [ward.contextual_name, ward.id]
+        end
+      end
   end
 
   def options_for_tags

--- a/app/models/neighbourhood.rb
+++ b/app/models/neighbourhood.rb
@@ -35,6 +35,10 @@ class Neighbourhood < ApplicationRecord
 
   scope :latest_release, -> { where release_date: LATEST_RELEASE_DATE }
 
+  def legacy_neighbourhood?
+    release_date < Neighbourhood::LATEST_RELEASE_DATE
+  end
+
   def shortname
     if name_abbr.present?
       name_abbr
@@ -113,6 +117,15 @@ class Neighbourhood < ApplicationRecord
     def find_from_postcodesio_response(res)
       ons_id = res['codes']['admin_ward']
       Neighbourhood.where(unit_code_value: ons_id).first
+    end
+
+    def find_latest_neighbourhoods_maybe_with_legacy_neighbourhoods(scope, legacy_neighbourhoods)
+      scope = scope
+              .where('name is not null and name != \'\'')
+              .latest_release
+
+      scope = scope.or(where(id: legacy_neighbourhoods.pluck(:id))) if legacy_neighbourhoods.any?
+      scope
     end
   end
 

--- a/app/models/neighbourhood.rb
+++ b/app/models/neighbourhood.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Neighbourhood < ApplicationRecord
+  # WARNING: this must be updated for every new ONS dataset
+  #    see /lib/tasks/neighbourhoods.rake
+  LATEST_RELEASE_DATE = DateTime.new(2023, 5).freeze
+
   has_ancestry
   has_many :sites_neighbourhoods, dependent: :destroy
   has_many :sites, through: :sites_neighbourhoods
@@ -28,6 +32,8 @@ class Neighbourhood < ApplicationRecord
             allow_blank: true
 
   before_update :inject_parent_name_field
+
+  scope :latest_release, -> { where release_date: LATEST_RELEASE_DATE }
 
   def shortname
     if name_abbr.present?

--- a/app/views/admin/neighbourhoods/index.html.erb
+++ b/app/views/admin/neighbourhoods/index.html.erb
@@ -9,6 +9,7 @@ var columns = [
   ]
 </script>
 
+
 <%= render partial: "layouts/admin/datatable", locals: {
     title: "Neighbourhoods",
     model: :neighbourhoods,
@@ -25,3 +26,4 @@ var columns = [
 <p><%= link_to safe_neighbourhood_name(root), admin_neighbourhood_path(root) %></p>
 <% end %>
 
+<h5>Latest Release Date: <%= Neighbourhood::LATEST_RELEASE_DATE %></h5>

--- a/app/views/admin/neighbourhoods/index.html.erb
+++ b/app/views/admin/neighbourhoods/index.html.erb
@@ -26,4 +26,4 @@ var columns = [
 <p><%= link_to safe_neighbourhood_name(root), admin_neighbourhood_path(root) %></p>
 <% end %>
 
-<h5>Latest Release Date: <%= Neighbourhood::LATEST_RELEASE_DATE %></h5>
+<h5>ONS Latest Release Date Loaded: <%= Neighbourhood::LATEST_RELEASE_DATE %></h5>

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -42,6 +42,11 @@
         <%= render 'address_fields', f: a %>
         <% end %>
 
+  <% if @partner&.address&.neighbourhood&.legacy_neighbourhood? %>
+  <p>
+    <em>WARNING</em>: The address for this partner is out of date. It will keep working but you may want to update it to your latest address.
+  </p>
+  <% end %>
 	<% if partner_has_unmappable_postcode?(@partner) %>
 	<p>
 	  The Postcode you were trying to lookup has not been added to our system yet. Please contact us for further assistance.
@@ -120,9 +125,9 @@
       <%= render 'opening_times', f: f %>
     </div>
   </div>
-  <hr>  
+  <hr>
   <h2>Tags</h2>
-  
+
   <p>What partnerships, categories and facilities does this partner have or belong to?</p>
   <p>Partners may have up to 3 category tags.</p>
 
@@ -147,4 +152,4 @@
 </div>
 
 <div id="map-pin-div" data-url="<%= image_path('icons/map/map-marker.png') %>"></div>
- 
+

--- a/app/views/admin/partners/_service_area_fields.html.erb
+++ b/app/views/admin/partners/_service_area_fields.html.erb
@@ -2,7 +2,7 @@
     <%# The style width setting here is applied to dynamically created elements, we do not know why. %>
     <%# TODO: Fix the dynamic styling so that width does not get applied, so we can remove this smell %>
     <%= f.input :neighbourhood_id,
-                collection: options_for_service_area_neighbourhoods,
+                collection: options_for_service_area_neighbourhoods(@partner),
                 include_blank: false,
                 value_method: ->(obj) { obj[:id] },
                 label_method: ->(obj) { obj[:name] },

--- a/app/views/admin/partners/edit.html.erb
+++ b/app/views/admin/partners/edit.html.erb
@@ -5,7 +5,7 @@
 <% if current_user.root? -%>
   <%# Show the Neighbourhood the partner is related to via Address %>
   <% if @partner.address&.neighbourhood&.present? -%>
-    <p>In neighbourhood <%= link_to @partner.address.neighbourhood.name, edit_admin_neighbourhood_path(@partner.address.neighbourhood) %>.</p>
+    <p>Address in neighbourhood <%= link_to_neighbourhood(@partner.address.neighbourhood) %>.</p>
   <% end -%>
 
   <%# Show a list of Service Areas that the partner is related to %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -65,7 +65,14 @@
       <%= f.simple_fields_for :sites_neighbourhood do |sn| %>
         <% primary_neighbourhood = (@all_neighbourhoods.where(id: @primary_neighbourhood_id).first if @primary_neighbourhood_id.present?) %>
         <% if primary_neighbourhood.present? %>
-          <h3><span class="badge badge-secondary"><%= primary_neighbourhood.contextual_name %></span></h3>
+          <h3>
+            <span class="badge badge-secondary">
+              <%= primary_neighbourhood.contextual_name %>
+              <% if primary_neighbourhood.legacy_neighbourhood? %>
+                (<%= primary_neighbourhood.release_date.year %>/<%= primary_neighbourhood.release_date.month %>)
+              <% end %>
+            </span>
+          </h3>
           <%= sn.hidden_field :relation_type, value: "Primary" %>
           <%= sn.hidden_field :neighbourhood_id, value: primary_neighbourhood.id %>
           <% if primary_neighbourhood.legacy_neighbourhood? %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -69,7 +69,7 @@
           <%= sn.hidden_field :neighbourhood_id, value: @primary_neighbourhood_id %>
         <% else %>
           <%= sn.hidden_field :relation_type, value: "Primary" %>
-          <%= sn.input :neighbourhood_id, collection: options_for_sites_neighbourhoods, include_blank: false,
+          <%= sn.input :neighbourhood_id, collection: options_for_sites_neighbourhoods(@site), include_blank: false,
               value_method: ->(obj) { obj[:id] }, label_method: ->(obj) { obj[:name] },
               input_html: { class: 'form-control col-6', data: { controller: "select2" } },
               label: '', label_html: { hidden: true } %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -63,10 +63,18 @@
       <p class="font-weight-light">This neighbourhood will be listed in the main PlaceCal directory. It cannot be changed after the site is created.</p>
 
       <%= f.simple_fields_for :sites_neighbourhood do |sn| %>
-        <% if @primary_neighbourhood_id %>
-          <h3><span class="badge badge-secondary"><%= @all_neighbourhoods.find(@primary_neighbourhood_id).contextual_name %></span></h3>
+        <% primary_neighbourhood = (@all_neighbourhoods.where(id: @primary_neighbourhood_id).first if @primary_neighbourhood_id.present?) %>
+        <% if primary_neighbourhood.present? %>
+          <h3><span class="badge badge-secondary"><%= primary_neighbourhood.contextual_name %></span></h3>
           <%= sn.hidden_field :relation_type, value: "Primary" %>
-          <%= sn.hidden_field :neighbourhood_id, value: @primary_neighbourhood_id %>
+          <%= sn.hidden_field :neighbourhood_id, value: primary_neighbourhood.id %>
+          <% if primary_neighbourhood.legacy_neighbourhood? %>
+          <p>
+            Warning: This neighbourhood not from the current release
+            (<%= primary_neighbourhood.release_date.year %>/<%= primary_neighbourhood.release_date.month %>).
+            Please contact a PlaceCal admin.
+          </p>
+          <% end %>
         <% else %>
           <%= sn.hidden_field :relation_type, value: "Primary" %>
           <%= sn.input :neighbourhood_id, collection: options_for_sites_neighbourhoods(@site), include_blank: false,

--- a/app/views/admin/sites/_sites_neighbourhood_fields.html.erb
+++ b/app/views/admin/sites/_sites_neighbourhood_fields.html.erb
@@ -4,7 +4,7 @@
     <% if f.object.relation_type != 'Primary'  %>
         <%# If the sites neighbourhood's relation_type is primary we do not render it %>
         <%# so it does not submit a primary relation as being a secondary one or remove it %>
-      <%= f.input :neighbourhood_id, collection: options_for_sites_neighbourhoods, include_blank: false,
+      <%= f.input :neighbourhood_id, collection: options_for_sites_neighbourhoods(@site), include_blank: false,
           value_method: ->(obj) { obj[:id] },
           label_method: ->(obj) { obj[:name] },
           input_html: { class: 'form-control', data: { controller: "select2" }, style: "width: 599.8px;" },

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -25,7 +25,7 @@
 
         <%= f.association :neighbourhoods,
           label: false,
-          collection: options_for_neighbourhoods,
+          collection: options_for_user_neighbourhoods,
           input_html: { class: 'form-control', data: { controller: "select2" } } %>
 
       <% else %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -25,7 +25,7 @@
 
         <%= f.association :neighbourhoods,
           label: false,
-          collection: options_for_user_neighbourhoods,
+          collection: options_for_user_neighbourhoods(f.object),
           input_html: { class: 'form-control', data: { controller: "select2" } } %>
 
       <% else %>

--- a/doc/updating-neighbourhoods.md
+++ b/doc/updating-neighbourhoods.md
@@ -1,5 +1,7 @@
 # Updating neighbourhoods
 
+_PLEASE READ CAREFULLY._
+
 Placecal depends upon data from ONS (Office of National Statistics) and postcodes.io to map postcodes to neighbourhoods.
 
 These are how Sites find their Partners or Events through Addresses or Service Areas.
@@ -21,7 +23,7 @@ load_csv(
 )
 ```
 
-With the correct name and Date (!!THIS IS VERY IMPORTANT!!). Just put it after the rest. You can now run the rest of the procedure. The new dataset file and modified script must be commited to the repo and merged on to main when it comes to updating staging or production.
+With the correct name and Date (!!THIS IS VERY IMPORTANT!!) - just year and month will suffice.
 
 ## Perform the update
 
@@ -30,6 +32,35 @@ Once done there is only one command to run
 ```bash
 rails neighbourhoods:import
 ```
+
+You may wish to check this by openning a rails console and running `Neighbourhood.group(:release_date).count` and seeing how many neighbourhoods by release data are present.
+
+Example:
+
+```
+irb(main):002:0> Neighbourhood.group(:release_date).count
+   (6.3ms)  SELECT COUNT(*) AS count_all, "neighbourhoods"."release_date" AS neighbourhoods_release_date FROM "neighbourhoods" GROUP BY "neighbourhoods"."release_date"
+=> {Mon, 01 May 2023 01:00:00.000000000 BST +01:00=>8844, Sun, 01 Dec 2019 00:00:00.000000000 GMT +00:00=>3827}
+```
+
+## Adjust the neighbourhood model
+
+If you are adding a new ONS dataset (currently May 2023) you _MUST_ change the value in `/app/models/neighbourhood.rb`! Which looks something like
+
+```ruby
+# frozen_string_literal: true
+
+class Neighbourhood < ApplicationRecord
+  # WARNING: this must be updated for every new ONS dataset
+  #    see /lib/tasks/neighbourhoods.rake
+  LATEST_RELEASE_DATE = DateTime.new(2023, 5).freeze  <----
+
+  ...
+```
+
+## Deploying
+
+The new dataset file and modified script/model must be commited to the repo and merged on to main when it comes to updating staging or production. Warning: between the time that your new code has been deployed to staging/production and the time the new import script has been run nobody will be able to select any neighbourhoods (as your updates will be filtering for the latest neighbourhoods which you have not inserted yet).
 
 ## Fin
 

--- a/test/controllers/admin/partner_edit_site_test.rb
+++ b/test/controllers/admin/partner_edit_site_test.rb
@@ -13,7 +13,8 @@ class PartnerEditSiteTest < ActionDispatch::IntegrationTest
       unit_code_key: 'WD19CD',
       unit_code_value: 'E05011368',
       unit_name: 'Hulme',
-      name: 'Hulme'
+      name: 'Hulme',
+      release_date: Neighbourhood::LATEST_RELEASE_DATE
     )
     assert_predicate @neighbourhood, :valid?
 
@@ -104,7 +105,7 @@ class PartnerEditSiteTest < ActionDispatch::IntegrationTest
         unit_code_value: '123456789',
         unit_name: 'name',
         name: "Neighbourhood #{i}",
-        release_date: DateTime.new(2023, 7)
+        release_date: Neighbourhood::LATEST_RELEASE_DATE
       )
       assert_predicate hood, :valid?
       other_user.neighbourhoods << hood
@@ -129,7 +130,7 @@ class PartnerEditSiteTest < ActionDispatch::IntegrationTest
         unit_code_value: '123456789',
         unit_name: 'name',
         name: "Neighbourhood #{i}",
-        release_date: DateTime.new(2023, 7)
+        release_date: Neighbourhood::LATEST_RELEASE_DATE
       )
     end
   end

--- a/test/factories/neighbourhood.rb
+++ b/test/factories/neighbourhood.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     unit_code_key { 'CTRY19CD' }
     unit_code_value { 'E92000001' }
     unit_name { 'England' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
   end
 
   factory :bare_neighbourhood, class: 'Neighbourhood' do
@@ -30,7 +30,7 @@ FactoryBot.define do
     unit_code_key { 'RGN19CD' }
     unit_code_value { 'E12000002' }
     unit_name { 'North West' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |region|
       region.parent = create(:neighbourhood_country)
@@ -45,7 +45,7 @@ FactoryBot.define do
     unit_code_key { 'CTY19CD' }
     unit_code_value { 'E11000001' }
     unit_name { 'Greater Manchester' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |county|
       county.parent = create(:neighbourhood_region)
@@ -60,7 +60,7 @@ FactoryBot.define do
     unit_code_key { 'LAD19CD' }
     unit_code_value { 'E08000003' }
     unit_name { 'Manchester' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |district|
       district.parent = create(:neighbourhood_county)
@@ -77,7 +77,7 @@ FactoryBot.define do
       "E0#{5_011_368 + n}"
     end
     unit_name { 'Hulme' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |ward|
       ward.parent = create(:neighbourhood_district)
@@ -92,7 +92,7 @@ FactoryBot.define do
     unit_code_key { 'WD19CD' }
     unit_code_value { 'E05011377' }
     unit_name { 'Rusholme' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |ward|
       ward.parent = create(:neighbourhood_district)
@@ -107,7 +107,7 @@ FactoryBot.define do
     unit_code_key { 'WD19CD' }
     unit_code_value { 'E05011372' }
     unit_name { 'Moss Side' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |ward|
       ward.parent = create(:neighbourhood_district)
@@ -122,7 +122,7 @@ FactoryBot.define do
     unit_code_key { 'LAD19CD' }
     unit_code_value { 'E11000001' }
     unit_name { 'Tameside' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |district|
       district.parent = create(:neighbourhood_county)
@@ -137,7 +137,7 @@ FactoryBot.define do
     unit_code_key { 'WD19CD' }
     unit_code_value { 'E05000800' }
     unit_name { 'Ashton Hurst' }
-    release_date { DateTime.new(2019, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |ward|
       ward.parent = create(:ashton_neighbourhood_district)
@@ -152,7 +152,7 @@ FactoryBot.define do
     unit_code_key { 'LAD23CD' }
     unit_code_value { 'E11000001' }
     unit_name { 'Tameside' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |district|
       district.parent = create(:neighbourhood_county)
@@ -167,7 +167,7 @@ FactoryBot.define do
     unit_code_key { 'WD23CD' }
     unit_code_value { 'E05000800' }
     unit_name { 'Ashton Hurst' }
-    release_date { DateTime.new(2023, 7) }
+    release_date { Neighbourhood::LATEST_RELEASE_DATE }
 
     after :create do |ward|
       ward.parent = create(:ashton_neighbourhood_district)

--- a/test/fixtures/neighbourhoods.yml
+++ b/test/fixtures/neighbourhoods.yml
@@ -7,7 +7,7 @@ one:
   unit_code_key: "WD19CD"
   unit_code_value: "E05011368"
   unit_name: "Hulme"
-  release_date: "2023-07-01 00:00:00.000000000 +0000"
+  release_date: <%= Neighbourhood::LATEST_RELEASE_DATE %>
 
 two:
   name: "Ashton Hurst"
@@ -16,7 +16,7 @@ two:
   unit_code_key: "WD19CD"
   unit_code_value: "E05000800"
   unit_name: "Ashton Hurst"
-  release_date: "2023-07-01 00:00:00.000000000 +0000"
+  release_date: <%= Neighbourhood::LATEST_RELEASE_DATE %>
 
 # this must match up with the geocode stub API data in test_helper.rb
 moss_side:
@@ -26,4 +26,4 @@ moss_side:
   unit_code_key: "WD19CD"
   unit_code_value: "E05011372"
   unit_name: "Moss Side"
-  release_date: "2023-07-01 00:00:00.000000000 +0000"
+  release_date: <%= Neighbourhood::LATEST_RELEASE_DATE %>

--- a/test/models/neighbourhoods_test.rb
+++ b/test/models/neighbourhoods_test.rb
@@ -45,4 +45,20 @@ class NeighbourhoodsAncestryTest < ActiveSupport::TestCase
     hood = Neighbourhood.new(name: 'neighbourhood', name_abbr: 'hood')
     assert_equal('hood', hood.abbreviated_name)
   end
+
+  test 'latest_release_date scope limits neighbourhoods to the latest version only' do
+    Neighbourhood.delete_all
+
+    3.times do |n|
+      # neighbourhoods with current release date
+      create :neighbourhood_country, name: "Country X#{n}"
+    end
+
+    5.times do |n|
+      create :neighbourhood_country, name: "Country Y#{n}", release_date: DateTime.new(1990, 1)
+    end
+
+    found = Neighbourhood.latest_release.count
+    assert_equal 3, found
+  end
 end

--- a/test/models/neighbourhoods_test.rb
+++ b/test/models/neighbourhoods_test.rb
@@ -61,4 +61,32 @@ class NeighbourhoodsAncestryTest < ActiveSupport::TestCase
     found = Neighbourhood.latest_release.count
     assert_equal 3, found
   end
+
+  test '::find_latest_neighbourhoods_maybe_with_legacy_neighbourhoods' do
+    Neighbourhood.delete_all
+
+    latest_neighbourhoods =
+      Array.new(5) do |n|
+        # neighbourhoods with current release date
+        create :neighbourhood_country, name: "Country X#{n}"
+      end
+
+    obsolete_neighbourhoods =
+      Array.new(9) do |n|
+        create :neighbourhood_country, name: "Country Y#{n}", release_date: DateTime.new(1990, 1)
+      end
+
+    # finds only latest neighbourhoods
+    found = Neighbourhood.find_latest_neighbourhoods_maybe_with_legacy_neighbourhoods(Neighbourhood, [])
+    assert_equal 5, found.count
+
+    # but can include legacy neighbourhoods that are directly referenced
+    legacy_neighbourhoods = [
+      obsolete_neighbourhoods[0],
+      obsolete_neighbourhoods[2]
+    ]
+
+    found = Neighbourhood.find_latest_neighbourhoods_maybe_with_legacy_neighbourhoods(Neighbourhood, legacy_neighbourhoods)
+    assert_equal 7, found.count
+  end
 end


### PR DESCRIPTION
Closes #2017 

For such a simple issue this has struck a nerve at the core of our data models.

Tasks covered:
- latest neighbourhood release date is defined in Neighbourhood model
- a scope to only find `latest_release` in Neighbourhood
- update to UX so neighbourhood pickers only show latest neighbourhoods BUT will also show only the legacy neighbourhoods that have already been selected by that entity.
  - sites, partners (service areas) and users
- latest version is displayed on admin neighbourhood page
- Neighbourhood updating documentation: added text covering how to set the `latest_release` date in the Neighbourhood model

## Other work

There is a rake task `rails placecal:find_obsolete_neighbourhoods` that will look at every user, site and partner to see if they are linking to a legacy neighbourhood. Output is in markdown suitable for uploading to notion. This can be used by the client support team to possibly reach out to users to adjust their neighbourhoods.

## Example Neighbourhood picker logic

When a user has a legacy neighbourhood the picker looks like
![Screenshot_2023-08-17_17-07-51](https://github.com/geeksforsocialchange/PlaceCal/assets/109223824/7e28d815-e5c7-428c-ba18-6869776d6558)


When a user has no legacy neighbourhoods only the latest set is used
![Screenshot_2023-08-17_17-08-40](https://github.com/geeksforsocialchange/PlaceCal/assets/109223824/79a5823b-4b5a-4df0-8dcc-dd987dd5fafd)

## Caveats

Problems found that would be out of scope for this PR:
- we need to prune legacy neighbourhoods that aren't linked to anything
- there are neighbourhoods that can be auto-replaced (in certain circumstances)
- sites' primary neighbourhoods that are linked to a legacy neighbourhood cannot currently be changed in the UX
- there is no way for users to tell if a partner's address is linked to a legacy neighbourhood.
- i have left the address postcode lookup routine (`find_from_postcodesio_response`) so it can find any neighbourhood (legacy or current) so that partners with obsolete addresses will keep working. because this method is only called with responses from a postcodes.io request i am assuming only the latest neighbourhoods will be found.
  -  (but obsolete partner address information is printed out in the `find_obsolete_neighbourhoods` script mentioned earlier)