### PR TITLE
Update cron to run once an hour

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
 	"cron": [
 		{
 			"command": "bundle exec rails import:scan_for_calendars_needing_import",
-			"schedule": "*/10 * * * *"
+			"schedule": "0 * * * *"
 		}
 	]
 }


### PR DESCRIPTION
Fixes #2024 

## Description

The calendar importer is currently running once every ten minutes and taking close to that amount of time to complete. We think this is making staging unworkably slow so want to try running it less frequently to see if this improves things. This could also make production much quicker for users.