### PR TITLE
tag_admin to partnership_admin

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -60,55 +60,7 @@ module Admin
     #       We should either have it here, or remove the json format on create, surely
     def update
       authorize @tag
-      # this returns an array which is breaking @tag.update. not sure why the original didn't?
-      # needs to be ActionController::Parameters
-      # attributes = policy(@tag).permitted_attributes
-
-      # this method call breaks with @tag
-      #
-      # LOG
-      # 17:18:27 web.1        | Started PATCH "/tags/c2" for 127.0.0.1 at 2023-09-23 17:18:27 +0100
-      # 17:18:27 web.1        |    (0.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
-      # 17:18:27 web.1        | Processing by Admin::TagsController#update as TURBO_STREAM
-      # 17:18:27 web.1        |   Parameters: {"authenticity_token"=>"8KmLIyTpkRPZmhCNzFjLDCt0xgyEyJibGMLnSr0_IszZe80Lg3jdG65tz4LEQQJqSnFbQIH2zDIqfINShAHvhw", "tag"=>{"name"=>"C23223 Connecting Communities", "slug"=>"c2", "description"=>"", "partner_ids"=>[""]}, "commit"=>"Save", "subdomain"=>"admin", "id"=>"c2"}
-      # 17:18:27 web.1        |    (0.5ms)  SELECT COUNT(*) FROM "sites"
-      # 17:18:27 web.1        |   ↳ app/controllers/application_controller.rb:92:in `current_site'
-      # 17:18:27 web.1        |   User Load (0.4ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["id", 162], ["LIMIT", 1]]
-      # 17:18:27 web.1        |   Tag Load (0.3ms)  SELECT "tags".* FROM "tags" WHERE "tags"."slug" = $1 LIMIT $2  [["slug", "c2"], ["LIMIT", 1]]
-      # 17:18:27 web.1        |   ↳ app/controllers/admin/tags_controller.rb:111:in `set_tag'
-      # 17:18:27 web.1        |   Partner Exists? (1.0ms)  SELECT 1 AS one FROM "partners" INNER JOIN "partners_users" ON "partners"."id" = "partners_users"."partner_id" WHERE "partners_users"."user_id" = $1 LIMIT $2  [["user_id", 162], ["LIMIT", 1]]
-      # 17:18:27 web.1        |   ↳ app/models/user.rb:89:in `partner_admin?'
-      # 17:18:27 web.1        |   Tag Exists? (1.1ms)  SELECT 1 AS one FROM "tags" INNER JOIN "tags_users" ON "tags"."id" = "tags_users"."tag_id" WHERE "tags_users"."user_id" = $1 LIMIT $2  [["user_id", 162], ["LIMIT", 1]]
-      # 17:18:27 web.1        |   ↳ app/models/user.rb:93:in `tag_admin?'
-      # 17:18:27 web.1        | Completed 400 Bad Request in 69ms (ActiveRecord: 15.3ms | Allocations: 74331)
-      # 17:18:27 web.1        |
-      # 17:18:27 web.1        |
-      # 17:18:27 web.1        |
-      # 17:18:27 web.1        | ActionController::ParameterMissing - param is missing or the value is empty: partnership
-      # 17:18:27 web.1        | Did you mean?  action
-      # 17:18:27 web.1        |                controller
-      # 17:18:27 web.1        |                authenticity_token
-      # 17:18:27 web.1        |                _method:
-      # 17:18:27 web.1        |   app/controllers/admin/tags_controller.rb:68:in `update'
-      # 17:18:27 web.1        |
-      # 17:18:27 web.1        | Started GET "/tags/c2/edit" for 127.0.0.1 at 2023-09-23 17:18:27 +0100
-      # 17:18:27 web.1        | Processing by Admin::TagsController#edit as HTML
-      # 17:18:27 web.1        |   Parameters: {"subdomain"=>"admin", "id"=>"c2"}
-      # 17:18:27 web.1        |    (0.6ms)  SELECT COUNT(*) FROM "sites"
-      # 17:18:27 web.1        |   ↳ app/controllers/application_controller.rb:92:in `current_site'
-      # 17:18:27 web.1        |   User Load (0.3ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["id", 162], ["LIMIT", 1]]
-      #
-      # bad method call
-      # attributes = permitted_attributes(@tag)
-
-      # original method call
-      Rails.logger.debug '~' * 34
-      Rails.logger.debug params
-      Rails.logger.debug '~' * 34
       attributes = permitted_attributes(Tag.new)
-      Rails.logger.debug '~' * 34
-      Rails.logger.debug 'what sort of class????'
-      Rails.logger.debug attributes.class
 
       if current_user.partner_admin?
         attributes[:partner_ids] =
@@ -116,16 +68,10 @@ module Admin
       end
 
       if current_user.tags.include?(@tag)
-        Rails.logger.debug 'THIS IS THE TAG ADMIN'
         attributes[:name] = params[:tag][:name]
         attributes[:slug] = params[:tag][:slug]
         attributes[:description] = params[:tag][:description]
       end
-
-      Rails.logger.debug '#' * 60
-      Rails.logger.debug 'these are the attributes'
-      Rails.logger.debug attributes
-      Rails.logger.debug '#' * 60
 
       if @tag.update(attributes)
         flash[:success] = 'Tag was saved successfully'

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -62,25 +62,70 @@ module Admin
       authorize @tag
       # this returns an array which is breaking @tag.update. not sure why the original didn't?
       # needs to be ActionController::Parameters
-      attributes = policy(@tag).permitted_attributes
+      # attributes = policy(@tag).permitted_attributes
 
       # this method call breaks with @tag
+      #
+      # LOG
+      # 17:18:27 web.1        | Started PATCH "/tags/c2" for 127.0.0.1 at 2023-09-23 17:18:27 +0100
+      # 17:18:27 web.1        |    (0.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
+      # 17:18:27 web.1        | Processing by Admin::TagsController#update as TURBO_STREAM
+      # 17:18:27 web.1        |   Parameters: {"authenticity_token"=>"8KmLIyTpkRPZmhCNzFjLDCt0xgyEyJibGMLnSr0_IszZe80Lg3jdG65tz4LEQQJqSnFbQIH2zDIqfINShAHvhw", "tag"=>{"name"=>"C23223 Connecting Communities", "slug"=>"c2", "description"=>"", "partner_ids"=>[""]}, "commit"=>"Save", "subdomain"=>"admin", "id"=>"c2"}
+      # 17:18:27 web.1        |    (0.5ms)  SELECT COUNT(*) FROM "sites"
+      # 17:18:27 web.1        |   ↳ app/controllers/application_controller.rb:92:in `current_site'
+      # 17:18:27 web.1        |   User Load (0.4ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["id", 162], ["LIMIT", 1]]
+      # 17:18:27 web.1        |   Tag Load (0.3ms)  SELECT "tags".* FROM "tags" WHERE "tags"."slug" = $1 LIMIT $2  [["slug", "c2"], ["LIMIT", 1]]
+      # 17:18:27 web.1        |   ↳ app/controllers/admin/tags_controller.rb:111:in `set_tag'
+      # 17:18:27 web.1        |   Partner Exists? (1.0ms)  SELECT 1 AS one FROM "partners" INNER JOIN "partners_users" ON "partners"."id" = "partners_users"."partner_id" WHERE "partners_users"."user_id" = $1 LIMIT $2  [["user_id", 162], ["LIMIT", 1]]
+      # 17:18:27 web.1        |   ↳ app/models/user.rb:89:in `partner_admin?'
+      # 17:18:27 web.1        |   Tag Exists? (1.1ms)  SELECT 1 AS one FROM "tags" INNER JOIN "tags_users" ON "tags"."id" = "tags_users"."tag_id" WHERE "tags_users"."user_id" = $1 LIMIT $2  [["user_id", 162], ["LIMIT", 1]]
+      # 17:18:27 web.1        |   ↳ app/models/user.rb:93:in `tag_admin?'
+      # 17:18:27 web.1        | Completed 400 Bad Request in 69ms (ActiveRecord: 15.3ms | Allocations: 74331)
+      # 17:18:27 web.1        |
+      # 17:18:27 web.1        |
+      # 17:18:27 web.1        |
+      # 17:18:27 web.1        | ActionController::ParameterMissing - param is missing or the value is empty: partnership
+      # 17:18:27 web.1        | Did you mean?  action
+      # 17:18:27 web.1        |                controller
+      # 17:18:27 web.1        |                authenticity_token
+      # 17:18:27 web.1        |                _method:
+      # 17:18:27 web.1        |   app/controllers/admin/tags_controller.rb:68:in `update'
+      # 17:18:27 web.1        |
+      # 17:18:27 web.1        | Started GET "/tags/c2/edit" for 127.0.0.1 at 2023-09-23 17:18:27 +0100
+      # 17:18:27 web.1        | Processing by Admin::TagsController#edit as HTML
+      # 17:18:27 web.1        |   Parameters: {"subdomain"=>"admin", "id"=>"c2"}
+      # 17:18:27 web.1        |    (0.6ms)  SELECT COUNT(*) FROM "sites"
+      # 17:18:27 web.1        |   ↳ app/controllers/application_controller.rb:92:in `current_site'
+      # 17:18:27 web.1        |   User Load (0.3ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["id", 162], ["LIMIT", 1]]
+      #
+      # bad method call
       # attributes = permitted_attributes(@tag)
 
       # original method call
-      # attributes = permitted_attributes(Tag.new)
-      puts '~'*34
-      puts "what sort of class????"
-      puts attributes.class
+      Rails.logger.debug '~' * 34
+      Rails.logger.debug params
+      Rails.logger.debug '~' * 34
+      attributes = permitted_attributes(Tag.new)
+      Rails.logger.debug '~' * 34
+      Rails.logger.debug 'what sort of class????'
+      Rails.logger.debug attributes.class
 
       if current_user.partner_admin?
         attributes[:partner_ids] =
           helpers.all_partners_for(@tag, attributes)
       end
-      puts '#'*60
-      puts 'these are the attributes'
-      puts attributes
-      puts '#'*60
+
+      if current_user.tags.include?(@tag)
+        Rails.logger.debug 'THIS IS THE TAG ADMIN'
+        attributes[:name] = params[:tag][:name]
+        attributes[:slug] = params[:tag][:slug]
+        attributes[:description] = params[:tag][:description]
+      end
+
+      Rails.logger.debug '#' * 60
+      Rails.logger.debug 'these are the attributes'
+      Rails.logger.debug attributes
+      Rails.logger.debug '#' * 60
 
       if @tag.update(attributes)
         flash[:success] = 'Tag was saved successfully'

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -60,17 +60,12 @@ module Admin
     #       We should either have it here, or remove the json format on create, surely
     def update
       authorize @tag
-      attributes = permitted_attributes(Tag.new)
+      # permitted_attributes(@tag) causes a crash for some reason
+      attributes = params.require(:tag).permit(policy(@tag).permitted_attributes)
 
       if current_user.partner_admin?
         attributes[:partner_ids] =
           helpers.all_partners_for(@tag, attributes)
-      end
-
-      if current_user.tags.include?(@tag)
-        attributes[:name] = params[:tag][:name]
-        attributes[:slug] = params[:tag][:slug]
-        attributes[:description] = params[:tag][:description]
       end
 
       if @tag.update(attributes)

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -60,12 +60,27 @@ module Admin
     #       We should either have it here, or remove the json format on create, surely
     def update
       authorize @tag
-      attributes = permitted_attributes(Tag.new)
+      # this returns an array which is breaking @tag.update. not sure why the original didn't?
+      # needs to be ActionController::Parameters
+      attributes = policy(@tag).permitted_attributes
+
+      # this method call breaks with @tag
+      # attributes = permitted_attributes(@tag)
+
+      # original method call
+      # attributes = permitted_attributes(Tag.new)
+      puts '~'*34
+      puts "what sort of class????"
+      puts attributes.class
 
       if current_user.partner_admin?
         attributes[:partner_ids] =
           helpers.all_partners_for(@tag, attributes)
       end
+      puts '#'*60
+      puts 'these are the attributes'
+      puts attributes
+      puts '#'*60
 
       if @tag.update(attributes)
         flash[:success] = 'Tag was saved successfully'

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -49,6 +49,7 @@ module UsersHelper
   def options_for_tags
     policy_scope(Tag)
       .select(:name, :type, :id)
+      .where(type: 'Partnership')
       .order(:name)
       .map { |r| [r.name_with_type, r.id] }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,8 @@ class User < ApplicationRecord
             format: { with: EMAIL_REGEX, message: 'invalid email address' }
   validates :role, presence: true
 
+  validate :partnership_tag?
+
   mount_uploader :avatar, AvatarUploader
 
   # General use throughout the site
@@ -119,6 +121,12 @@ class User < ApplicationRecord
 
     neighbourhood = Neighbourhood.find_from_postcodesio_response(res)
     owned_neighbourhood_ids.include?(neighbourhood&.id)
+  end
+
+  def partnership_tag?
+    return true if tags.all? { |tag| tag.type == 'Partnership' }
+
+    errors.add(:tags, 'Can only be of type Partnership')
   end
 
   protected

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,7 +100,7 @@ class User < ApplicationRecord
     types << 'editor' if editor?
     types << 'neighbourhood_admin' if neighbourhood_admin?
     types << 'partner_admin' if partner_admin?
-    types << 'tag_admin' if tag_admin?
+    types << 'partnership_admin' if tag_admin?
     types << 'site_admin' if site_admin?
 
     types.join(', ')

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -42,9 +42,11 @@ class TagPolicy < ApplicationPolicy
       fields = %i[name slug description system_tag]
       fields << :type if @record.instance_of?(Tag)
       fields.push(partner_ids: [], user_ids: [])
-    elsif user.tags.include?(@record) 
+    elsif user.tags.include?(@record)
       # I expect record to be the value passed to this method but if I pass anything but Tag.new it falls over
+      # in fact I think this is a dead logic branch because all our tests pass when it's commented out
       fields = %i[name slug description]
+      fields << :type if @record.instance_of?(Tag)
       fields.push(partner_ids: [])
     elsif user.partner_admin?
       %i[].push(partner_ids: [])
@@ -56,7 +58,7 @@ class TagPolicy < ApplicationPolicy
   def disabled_fields
     if user.root?
       %i[]
-    elsif (user.tag_admin? && user.tags.include?(@record)) 
+    elsif user.tag_admin? && user.tags.include?(@record)
       %i[system_tag users user_ids]
     elsif user.tag_admin? || user.partner_admin?
       %i[name slug description users user_ids system_tag]

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -42,8 +42,11 @@ class TagPolicy < ApplicationPolicy
       fields = %i[name slug description system_tag]
       fields << :type if @record.instance_of?(Tag)
       fields.push(partner_ids: [], user_ids: [])
-
-    elsif (user.tag_admin? && user.tags.include?(@record)) || user.partner_admin?
+    elsif user.tags.include?(@record) 
+      # I expect record to be the value passed to this method but if I pass anything but Tag.new it falls over
+      fields = %i[name slug description]
+      fields.push(partner_ids: [])
+    elsif user.partner_admin?
       %i[].push(partner_ids: [])
     else
       %i[]
@@ -53,6 +56,8 @@ class TagPolicy < ApplicationPolicy
   def disabled_fields
     if user.root?
       %i[]
+    elsif (user.tag_admin? && user.tags.include?(@record)) 
+      %i[system_tag users user_ids]
     elsif user.tag_admin? || user.partner_admin?
       %i[name slug description users user_ids system_tag]
     else # Should never be hit, but it's useful as a guard

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -43,8 +43,6 @@ class TagPolicy < ApplicationPolicy
       fields << :type if @record.instance_of?(Tag)
       fields.push(partner_ids: [], user_ids: [])
     elsif user.tags.include?(@record)
-      # I expect record to be the value passed to this method but if I pass anything but Tag.new it falls over
-      # in fact I think this is a dead logic branch because all our tests pass when it's commented out
       fields = %i[name slug description]
       fields << :type if @record.instance_of?(Tag)
       fields.push(partner_ids: [])

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -38,10 +38,10 @@
       <% end %>
     </div>
     <div class="col-md-6">
-      <h4>Tags</h4>
+      <h4>Partnerships</h4>
       <% if disabled_fields.include?(:tag_ids) %>
         <%# # Create a dummy field, because f.assoc disappears %>
-        <%= f.input :tags, collection: options_for_tags,
+        <%= f.input :tags, collection: options_for_tags, # this might be calling the method from users_helpers.rb 
             input_html: { class: 'form-control', data: { controller: "select2"} }, disabled: true %>
       <% else %>
         <%= f.association :tags, collection: options_for_tags,

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -121,7 +121,7 @@
       <p class="font-weight-light">Only show partners with these tags</p>
       <%= f.association :tags,
                         label: false,
-                        collection: options_for_tags,
+                        collection: options_for_tags, # this might be calling the method from users_helpers.rb 
                         input_html: { class: 'form-check', data: { controller: "select2" } } %>
     </div>
   </div>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -40,8 +40,8 @@
   </div>
   <div class="row">
     <div class="col-md-6">
-      <h3>Allowed Tags</h3>
-      <p>Grants access to apply the given tags</p>
+      <h3>Partnerships</h3>
+      <p>Grants access to add or remove partners from partnerships</p>
       <%= f.association :tags,
                         label: false,
                         collection: options_for_tags,

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -106,7 +106,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     @user = attributes_for(:citizen,
                            partner_ids: [create(:partner).id.to_s],
                            neighbourhood_ids: [create(:neighbourhood).id.to_s],
-                           tag_ids: [create(:tag).id.to_s])
+                           tag_ids: [create(:tag, name: 'trans dimension', type: 'Partnership').id.to_s])
 
     assert_difference('User.count', 1) do
       post admin_users_url,

--- a/test/integration/admin/sites_integration_test.rb
+++ b/test/integration/admin/sites_integration_test.rb
@@ -16,6 +16,7 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
     @number_of_neighbourhoods = Neighbourhood.all.length
 
     @tag = create(:tag, type: 'Category')
+    @partnership_tag = create(:tag, type: 'Partnership')
 
     host! 'admin.lvh.me'
   end
@@ -110,14 +111,14 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'site tags show up and display their type' do
-    @site.tags << @tag
-    @site_admin.tags << @tag
+    @site.tags << @partnership_tag
+    @site_admin.tags << @partnership_tag
 
     sign_in(@site_admin)
     get edit_admin_site_path(@site)
     assert_response :success
 
-    tag_options = assert_select 'div.site_tags option', count: 1, text: @tag.name_with_type
+    tag_options = assert_select 'div.site_tags option', count: 1, text: @partnership_tag.name_with_type
 
     tag = tag_options.first
     assert tag.attributes.key?('selected')

--- a/test/integration/admin/user_integration_test.rb
+++ b/test/integration/admin/user_integration_test.rb
@@ -105,7 +105,7 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Avatar'
     assert_select 'h3', 'Partners'
     assert_select 'h3', 'Neighbourhoods'
-    assert_select 'h3', 'Allowed Tags'
+    assert_select 'h3', 'Partnerships'
     assert_select 'h3', 'Role'
   end
 
@@ -122,7 +122,7 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Phone'
     assert_select 'label', 'Avatar'
     assert_select 'h3', 'Partners'
-    assert_select 'h3', 'Allowed Tags'
+    assert_select 'h3', 'Partnerships'
     assert_select 'h3', 'Neighbourhoods', count: 0
     assert_select 'h3', 'Role', count: 0
   end
@@ -141,7 +141,7 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Avatar'
     assert_select 'h3', 'Partners'
     assert_select 'h3', 'Neighbourhoods'
-    assert_select 'h3', 'Allowed Tags'
+    assert_select 'h3', 'Partnerships'
     assert_select 'h3', 'Role'
   end
 
@@ -158,7 +158,7 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Avatar'
     assert_select 'h3', 'Partners'
     assert_select 'h3', 'Neighbourhoods', count: 0
-    assert_select 'h3', 'Allowed Tags'
+    assert_select 'h3', 'Partnerships'
     assert_select 'h3', 'Role', count: 0
   end
 

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -12,8 +12,9 @@ class TagTest < ActiveSupport::TestCase
   end
 
   test 'updates user roles when saved' do
-    @tag.users << @user
-    @tag.save
+    @partnership_tag.users << @user
+    @partnership_tag.save!
+    @user.reload
     assert_predicate @user, :tag_admin?
   end
 
@@ -43,7 +44,8 @@ class TagTest < ActiveSupport::TestCase
   test 'a root user who is a tag_admin can access their own Partnership tag but not others' do
     root_user = create :root
     @partnership_tag.users << root_user
-    @partnership_tag.save
+    @partnership_tag.save!
+    root_user.reload
 
     Tag.users_tags(root_user).each do |t|
       assert_equal t.name, @partnership_tag.name if t.type == 'Partnership'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   setup do
+    create_typed_tags
     @user = create(:user)
     @neighbourhood_region_admin = create(:neighbourhood_region_admin)
   end
@@ -94,5 +95,29 @@ class UserTest < ActiveSupport::TestCase
     user = User.new(email: 'test@test.com', role: 'citizen')
     user.skip_password_validation = true
     assert_predicate user, :valid?
+  end
+
+  test 'Partnership tag can be assigned to User' do
+    @user.tags << Tag.where(type: 'Partnership').first
+    @user.save!
+    assert_equal(1, @user.tags.length)
+  end
+
+  test 'Category tag cannot be assigned to User' do
+    error_message = 'Validation failed: Tags Can only be of type Partnership'
+    @user.tags << Tag.where(type: 'Category').first
+
+    assert_raises ActiveRecord::RecordInvalid, error_message do
+      @user.save!
+    end
+  end
+
+  test 'Faciltiy tag cannot be assigned to User' do
+    error_message = 'Validation failed: Tags Can only be of type Partnership'
+    @user.tags << Tag.where(type: 'Facility').first
+
+    assert_raises ActiveRecord::RecordInvalid, error_message do
+      @user.save!
+    end
   end
 end

--- a/test/system/admin/article_test.rb
+++ b/test/system/admin/article_test.rb
@@ -14,7 +14,7 @@ class AdminArticleTest < ApplicationSystemTestCase
     @partner = create :partner
     @partner_two = create :ashton_partner
 
-    @tag = create :tag
+    @tag = create(:tag, type: 'Partnership')
 
     @article = create :article
 

--- a/test/system/admin/site_test.rb
+++ b/test/system/admin/site_test.rb
@@ -10,7 +10,7 @@ class AdminSiteTest < ApplicationSystemTestCase
   setup do
     create_default_site
     @root_user = create :root, email: 'root@lvh.me'
-    @tag = create :tag
+    @tag = create(:tag, type: 'Partnership')
     @site = create :site
 
     @neighbourhood_one = neighbourhoods[1].to_s.tr('w', 'W')

--- a/test/system/admin/user_test.rb
+++ b/test/system/admin/user_test.rb
@@ -16,7 +16,7 @@ class AdminUserTest < ApplicationSystemTestCase
     @partner = @partner_admin.partners.first
     @partner_two = create :ashton_partner
 
-    @tag = create :tag
+    @tag = create(:tag, type: 'Partnership')
 
     @neighbourhood_one = neighbourhoods[1].to_s.tr('w', 'W')
     @neighbourhood_two = neighbourhoods[2].to_s.tr('w', 'W')


### PR DESCRIPTION
fixes #2061

## Changes made

- It should now only be possible to for a user to be a tag admin of a "partnership" tag
- `tag_admin` renamed to `partnership_admin` in the UI
- `tag_admin` can edit the details of their associated tag but not delete it
- `root` users can edit any tag, They are the only ones who can create or delete tags
- Documentation updated here:
  - https://www.notion.so/gfsc/Glossary-a8573df979e64b1c8d21399ec8c746b8
  - https://www.notion.so/gfsc/Admin-handbook-4be3a9e7828544b0ad590f5408374094
  
 ## Thoughts

- I have not refactored the naming of `tag_admin` in the code because it is still a type of tag and that will involve quite a lot more work, lets see if we stick to this usage or if any other types end up being used in this way.
- I could have, but did not move to using the `Partnership` entity, perhaps that would be better but I was a bit wary to do that until we split out the different inputs into their 3 types.