### PR TITLE
site admin access 

### DIFF
--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -30,12 +30,12 @@ class SitePolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    attrs = %i[id name place_name is_published tagline description
-               badge_zoom_level hero_image hero_image_credit hero_text]
+    attrs = %i[id name place_name logo footer_logo is_published tagline description
+               badge_zoom_level hero_image hero_image_credit hero_text theme ]
             .push(sites_neighbourhoods_attributes: %i[_destroy id neighbourhood_id relation_type],
                   sites_neighbourhood_attributes: %i[_destroy id neighbourhood_id relation_type])
 
-    root_attrs = %i[slug domain logo footer_logo theme site_admin_id tags sites_neighbourhoods]
+    root_attrs = %i[slug domain site_admin_id tags sites_neighbourhoods]
                  .push(tag_ids: [])
 
     return root_attrs + attrs if user.root?

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -35,7 +35,7 @@ class SitePolicy < ApplicationPolicy
             .push(sites_neighbourhoods_attributes: %i[_destroy id neighbourhood_id relation_type],
                   sites_neighbourhood_attributes: %i[_destroy id neighbourhood_id relation_type])
 
-    root_attrs = %i[slug domain logo footer_logo theme site_admin_id tags]
+    root_attrs = %i[slug domain logo footer_logo theme site_admin_id tags sites_neighbourhoods]
                  .push(tag_ids: [])
 
     return root_attrs + attrs if user.root?

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -33,10 +33,10 @@ class SitePolicy < ApplicationPolicy
     attrs = %i[id name place_name is_published tagline description
                badge_zoom_level hero_image hero_image_credit hero_text]
             .push(sites_neighbourhoods_attributes: %i[_destroy id neighbourhood_id relation_type],
-                  sites_neighbourhood_attributes: %i[_destroy id neighbourhood_id relation_type],
-                  tag_ids: [])
+                  sites_neighbourhood_attributes: %i[_destroy id neighbourhood_id relation_type])
 
-    root_attrs = %i[slug domain logo footer_logo theme site_admin_id]
+    root_attrs = %i[slug domain logo footer_logo theme site_admin_id tags]
+                 .push(tag_ids: [])
 
     return root_attrs + attrs if user.root?
 

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -43,9 +43,9 @@
         <div style="background-color: #5b4e46; padding: 1rem">
           <%= image_tag f.object.footer_logo.url, class: 'card-img-top' if f.object.footer_logo.url %>
         </div>
-      <% end %>
       </div>
     </div>
+  <% end %>
 
   <%= f.input :hero_image, hint: image_uploader_hint(@site.hero_image) %>
   <p><em>Header images should be 2260x700</em></p>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -12,14 +12,14 @@
       <% if policy(@site).permitted_attributes.include? :domain  %>
         <%= f.input :domain %>
       <% else %>
-        <p><strong>Domain</strong>: <a href="<%= @site.domain %>"><%= @site.domain %></a></p>
+        <%= f.input :domain, disabled: true  %>
       <% end %>
     </div>
     <div class="col-md-6">
       <% if policy(@site).permitted_attributes.include? :slug  %>
-        <%= f.input :slug %>
+        <%= f.input :slug, disabled: true  %>
       <% else %>
-        <p><strong>slug</strong>: <%= @site.slug %></p>
+        <%= f.input :slug, disabled: true  %>
       <% end %>
     </div>
   </div>
@@ -131,18 +131,18 @@
 
     <div class="row">
       <div class="col-md-6">
-        <p class="font-weight-light">Only show partners which are members of these Partnerships</p>
+        <p class="font-weight-light">(If selected) Only show partners which are members of these Partnerships</p>
         <% if policy(@site).permitted_attributes.include? :tags %>
           <%= f.association :tags,
                             label: false,
                             collection: options_for_tags,
                             input_html: { class: 'form-check', data: { controller: "select2" } } %>
         <% else %>
-          <ul>
-            <% @site.tags.each do |t| %>
-              <li><%= t.name %></li>
-            <% end %>
-          </ul>
+          <%= f.association :tags,
+                            disabled: true,
+                            label: false,
+                            collection: options_for_tags,
+                            input_html: { class: 'form-check', data: { controller: "select2" } } %>
         <% end %>
       </div>
     </div>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -17,7 +17,7 @@
     </div>
     <div class="col-md-6">
       <% if policy(@site).permitted_attributes.include? :slug  %>
-        <%= f.input :slug, disabled: true  %>
+        <%= f.input :slug %>
       <% else %>
         <%= f.input :slug, disabled: true  %>
       <% end %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -116,17 +116,27 @@
 
   <h2>Tags</h2>
 
-  <div class="row">
-    <div class="col-md-6">
-      <p class="font-weight-light">Only show partners with these tags</p>
-      <%= f.association :tags,
-                        label: false,
-                        collection: options_for_tags,
-                        input_html: { class: 'form-check', data: { controller: "select2" } } %>
+    <h2>Tags</h2>
+
+    <div class="row">
+      <div class="col-md-6">
+        <p class="font-weight-light">Only show partners with these tags</p>
+        <% if policy(@site).permitted_attributes.include? :tags %>
+          <%= f.association :tags,
+                            label: false,
+                            collection: options_for_tags,
+                            input_html: { class: 'form-check', data: { controller: "select2" } } %>
+        <% else %>
+          <ul>
+            <% @site.tags.each do |t| %>
+              <li><%= t.name %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
     </div>
-  </div>
-  <br>
-  <br>
+    <br>
+    <br>
 
 
   <%= f.button :submit, class: "btn btn-primary btn-lg" %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -16,7 +16,11 @@
       <% end %>
     </div>
     <div class="col-md-6">
-      <%= f.input :slug if policy(@site).permitted_attributes.include? :slug %>
+      <% if policy(@site).permitted_attributes.include? :slug  %>
+        <%= f.input :slug %>
+      <% else %>
+        <p><strong>slug</strong>: <%= @site.slug %></p>
+      <% end %>
     </div>
   </div>
   <%= f.input :hero_text, hint: 'Large text for the banner with image on the homepage, up to 120 characters', input_html: { rows: 5 } %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -9,7 +9,11 @@
   <%= f.input :tagline %>
   <div class="row">
     <div class="col-md-6">
-      <%= f.input :domain if policy(@site).permitted_attributes.include? :domain %>
+      <% if policy(@site).permitted_attributes.include? :domain  %>
+        <%= f.input :domain %>
+      <% else %>
+        <p><strong>Domain</strong>: <a href="<%= @site.domain %>"><%= @site.domain %></a></p>
+      <% end %>
     </div>
     <div class="col-md-6">
       <%= f.input :slug if policy(@site).permitted_attributes.include? :slug %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -115,15 +115,28 @@
   <h3>Other neighbourhoods to include</h3>
   <p class="font-weight-light">Information from these neighbourhoods will also be displayed on this site</p>
 
-  <div class="sites_neighbourhoods">
-    <%= f.simple_fields_for :sites_neighbourhoods do |neighbourhood| %>
-      <%= render 'sites_neighbourhood_fields', :f => neighbourhood %>
-    <% end %>
-    <div class="links">
-      <%= link_to_add_association 'Add neighbourhood', f, :sites_neighbourhoods, class: "btn btn-primary btn-sm" %>
+  <% if policy(@site).permitted_attributes.include? :sites_neighbourhoods %>
+    <div class="sites_neighbourhoods">
+      <%= f.simple_fields_for :sites_neighbourhoods do |neighbourhood| %>
+        <%= render 'sites_neighbourhood_fields', :f => neighbourhood %>
+      <% end %>
+      <div class="links">
+        <%= link_to_add_association 'Add neighbourhood', f, :sites_neighbourhoods, class: "btn btn-primary btn-sm" %>
+      </div>
+      <br></br>
     </div>
-    <br></br>
-  </div>
+  <% else %>
+    <div class="sites_neighbourhoods">
+      <ul>
+        <% @site.sites_neighbourhoods.each do |neighbourhood| %>
+          <% if neighbourhood.relation_type != 'Primary'  %>
+            <li><%= neighbourhood.name %></li>
+          <% end %>
+        <% end %>
+      </ul>
+      <br></br>
+    </div>
+  <% end %>
 
   <h2>Tags</h2>
 

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -93,7 +93,8 @@
   </div>
     <div class="col-md-6">
       <h3>Neighbourhood information display</h3>
-      <p class="font-weight-light">What level of geographical zoom should PlaceCal display on partners and events?</p>
+      <p class="font-weight-light">What level of geographical zoom should PlaceCal display in the small badge next to partners and events? eg. Hulme / Manchester</p>
+      
       <%= f.input :badge_zoom_level,
         as: :radio_buttons,
         label_method: ->(val){ Site.badge_zoom_level_label(val) } %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -138,8 +138,6 @@
     </div>
   <% end %>
 
-  <h2>Tags</h2>
-
     <h2>Partnerships</h2>
 
     <div class="row">

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -26,6 +26,8 @@
 
   <% if policy(@site).permitted_attributes.include? :site_admin_id %>
     <%= f.association(:site_admin, label_method: :admin_name, input_html: { data: { controller:  'select2' } }) %>
+  <% else %>
+    <p><strong>Admin</strong>: <%= @site.site_admin %></p>
   <% end %>
 
 

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -116,11 +116,11 @@
 
   <h2>Tags</h2>
 
-    <h2>Tags</h2>
+    <h2>Partnerships</h2>
 
     <div class="row">
       <div class="col-md-6">
-        <p class="font-weight-light">Only show partners with these tags</p>
+        <p class="font-weight-light">Only show partners which are members of these Partnerships</p>
         <% if policy(@site).permitted_attributes.include? :tags %>
           <%= f.association :tags,
                             label: false,

--- a/test/integration/admin/sites_integration_test.rb
+++ b/test/integration/admin/sites_integration_test.rb
@@ -93,8 +93,8 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Name *'
     assert_select 'label', 'Place name'
     assert_select 'label', 'Tagline'
-    assert_select 'label', text: 'Domain *', count: 0
-    assert_select 'label', text: 'Slug *', count: 0
+    assert_select 'label', text: 'Domain *', count: 1
+    assert_select 'label', text: 'Slug *', count: 1
     assert_select 'label', 'Description'
     assert_select 'label', text: 'Site admin', count: 0
 
@@ -103,11 +103,6 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', text: 'Footer logo', count: 0
     assert_select 'label', 'Hero image'
     assert_select 'label', 'Hero image credit'
-
-    # See just neighbourhoods they admin
-    cocoon_select_template = assert_select('.add_fields').first['data-association-insertion-template']
-    neighbourhoods_shown = cocoon_select_template.scan(/(option value=)/).size
-    assert_equal(2, neighbourhoods_shown)
   end
 
   test 'site tags show up and display their type' do

--- a/test/integration/admin/sites_integration_test.rb
+++ b/test/integration/admin/sites_integration_test.rb
@@ -98,9 +98,9 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', 'Description'
     assert_select 'label', text: 'Site admin', count: 0
 
-    assert_select 'label', text: 'Theme', count: 0
-    assert_select 'label', text: 'Logo', count: 0
-    assert_select 'label', text: 'Footer logo', count: 0
+    assert_select 'label', text: 'Theme', count: 1
+    assert_select 'label', text: 'Logo', count: 1
+    assert_select 'label', text: 'Footer logo', count: 1
     assert_select 'label', 'Hero image'
     assert_select 'label', 'Hero image credit'
   end


### PR DESCRIPTION
fixes #2108 


- [x] only have access to site they are admin of
- [x] fix broken UI for none Root users (see screenshot in issue comments)
- [x] explain what badge zoom is to users (I hope this is slightly clearer)
- [x] all details remain visible even if there is no permission to edit them
- [x] table is true

Attribute | Root | site_admin | verified/ticketed
| ---|---|---|---
| `badge_zoom_level` | ✅ | ✅ | ✅ | 
| `description` | ✅ | ✅ |  ✅ |
| `footer_logo` | ✅ | ✅ |  ✅ |
| `hero_image_credit` | ✅ | ✅ | ✅ | 
| `hero_image` | ✅ | ✅ | ✅ | 
| `hero_text` | ✅ | ✅ | ✅ | 
| `logo` | ✅ | ✅ | ✅ | ✅ | 
| `name` | ✅ | ✅ |✅ | 
| `place_name` | ✅ | ✅ | ✅ | 
| `tagline` | ✅ | ✅ | ✅ | 
| `theme` | ✅ | ✅ | ✅ | 
| `is_published`  | ✅ | ✅  | ✅ | 
| "other neighbourhoods" | ✅ | ❌ | ✅  |
| "tags" -> "partnerships" | ✅ | ❌ |  ✅  |
| `domain` | ✅ | ❌ | ✅  |
| `site_admin_id` | ✅ | ❌ |  ✅  |
| `slug` | ✅ | ❌ | ✅  |
| "main neighbourhood" | ❌ | ❌ | ✅ |
