### PR TITLE
Neighbourhood admins cannot remove all of their service areas from partners with no addresses

### DIFF
--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -83,9 +83,13 @@ module Admin
       mutated_params[:service_areas_attributes] = uniq_service_areas
 
       if @partner.update(mutated_params)
-        flash[:success] = 'Partner was successfully updated.'
+        # have to redirect on associated service area errors or form breaks
+        if @partner.errors[:service_areas].any?
+          flash[:danger] = @partner.errors[:service_areas][0]
+        else
+          flash[:success] = 'Partner was successfully updated.'
+        end
         redirect_to edit_admin_partner_path(@partner)
-
       else
         flash.now[:danger] = 'Partner was not saved.'
         set_neighbourhoods

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -359,12 +359,9 @@ class Partner < ApplicationRecord
       Set.new(user_neighbourhoods).superset?(Set.new(partner_service_areas)) &&
       partner_service_areas.any?
 
-    return if partner_service_areas.empty? && in_user_neighbourhood
-    return if address.blank? && services_user_neighbourhood
+    return if in_user_neighbourhood || services_user_neighbourhood
 
-    unless in_user_neighbourhood || services_user_neighbourhood
-      errors.add :base, 'Partners must have an address or a service area inside your neighbourhood'
-    end
+    errors.add :base, 'Partners must have an address or a service area inside your neighbourhood'
   end
 
   def check_remove_service_area(service_area_to_remove)

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -375,13 +375,10 @@ class Partner < ApplicationRecord
     in_user_neighbourhood = accessed_by_user.assigned_to_postcode?(address&.postcode)
     services_user_neighbourhood = new_service_areas.present?
 
-    return if new_service_areas.empty? && in_user_neighbourhood
-    return if address.blank? && services_user_neighbourhood
+    return if in_user_neighbourhood || services_user_neighbourhood
 
-    unless in_user_neighbourhood || services_user_neighbourhood
-      errors.add :service_areas, 'Partners must have an address or a service area inside your neighbourhood'
-      throw :abort
-    end
+    errors.add :service_areas, 'Partners must have an address or a service area inside your neighbourhood'
+    throw :abort
   end
 
   def must_have_address_or_service_area

--- a/test/controllers/admin/partners_controller_test.rb
+++ b/test/controllers/admin/partners_controller_test.rb
@@ -209,4 +209,33 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
 
     assert_template :setup
   end
+
+  test 'neighbourhood_admin: cannot remove service area from partner with no address' do
+    sign_in @neighbourhood_admin
+
+    partner_with_no_address = create(:bare_partner, name: 'test partner')
+    partner_with_no_address.service_areas.create(
+      neighbourhood: @neighbourhood
+    )
+    partner_with_no_address.address = nil
+    partner_with_no_address.save!
+
+    edit_params = {
+      partner: {
+        service_areas_attributes: {
+          '0':
+          {
+            id: partner_with_no_address.service_areas[0].id,
+            neighbourhood_id: @neighbourhood.id,
+            _destroy: '1'
+          }
+        }
+      }
+    }
+
+    patch admin_partner_url(partner_with_no_address), params: edit_params
+
+    assert_response :redirect
+    assert_equal 'Partners must have an address or a service area inside your neighbourhood', flash[:danger]
+  end
 end


### PR DESCRIPTION
Fixes #2124

## Description

A neighbourhood admin is now prevented from removing all service areas they admin for from their partners, unless a partner's address is within their neighbourhood.

## Some implementation notes

This was really tricky - you can't validate an association in the same way as the rest of the record so it has to be assessed after everything else is validated. Obviously this is not perfect because the service areas have to be evaluated in conjunction with the address, so users are not going to be able to see all validation warnings at once. 

Also I had to re-render the edit page instead of just returning it with errors in the normal way because if I did not, everything (the record, the database, and the params) was out of sync when I rendered the page and all sorts of nasty unexpected things were happening.