### PR TITLE
Staging mailer asset host configuration

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -75,6 +75,12 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
+  asset_url = routes.default_url_options[:protocol]
+  asset_url += "://#{routes.default_url_options[:host]}"
+  asset_url += ":#{routes.default_url_options[:port]}" if routes.default_url_options[:port].present?
+
+  config.action_mailer.asset_host = asset_url
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Closes #2133 

In staging environment initializer, set the URL the mailer will use to generate asset links from the base application URL.