### PR TITLE
All neighbourhoods on partners are shown, editing these is limited for neighbourhood admins

### DIFF
--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -6,7 +6,6 @@ module Admin
     before_action :set_partner, only: %i[show edit update destroy]
     before_action :set_tags, only: %i[new create edit]
     before_action :set_neighbourhoods, only: %i[new edit]
-    before_action :set_service_area_map_ids, only: %i[new edit]
 
     def index
       @partners = policy_scope(Partner).order({ updated_at: :desc }, :name).includes(:address)
@@ -54,7 +53,6 @@ module Admin
           format.html do
             flash.now[:danger] = 'Partner was not saved.'
             set_neighbourhoods
-            set_service_area_map_ids
             render :new, status: :unprocessable_entity
           end
           format.json { render json: @partner.errors, status: :unprocessable_entity }
@@ -89,7 +87,6 @@ module Admin
       else
         flash.now[:danger] = 'Partner was not saved.'
         set_neighbourhoods
-        set_service_area_map_ids
         render :edit, status: :unprocessable_entity
       end
     end
@@ -124,25 +121,15 @@ module Admin
 
     private
 
-    def set_service_area_map_ids
-      # maps neighbourhood ID to service_area ID
-      @service_area_id_map = if @partner
-                               @partner
-                                 .service_areas.select(:id, :neighbourhood_id)
-                                 .map { |sa| { sa.neighbourhood_id => sa.id } }
-                                 .reduce({}, :merge)
-                             else
-                               {}
-                             end
-    end
-
     def set_neighbourhoods
-      if @partner.present? && current_user.neighbourhood_admin_for_partner?(@partner.id)
+      if current_user.root?
+        @all_neighbourhoods = Neighbourhood.order(:name)
+      elsif @partner.present? && current_user.neighbourhood_admin_for_partner?(@partner.id)
         ids = @partner.owned_neighbourhood_ids | current_user.owned_neighbourhood_ids
         @all_neighbourhoods = Neighbourhood.where(id: ids)
-      elsif current_user.admin_for_partner?(@partner.id) || current_user.root?
-        # if user can see partner because they own them or are root let them set any neighbourhood
-        @all_neighbourhoods = Neighbourhood.order(:name)
+      else
+        ids = current_user.owned_neighbourhood_ids
+        @all_neighbourhoods = Neighbourhood.where(id: ids)
       end
     end
 

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -137,13 +137,13 @@ module Admin
     end
 
     def set_neighbourhoods
-      # if user owns partner let them set any neighbourhood
-      if @partner.present? && current_user.admin_for_partner?(@partner.id)
+      if @partner.present? && current_user.neighbourhood_admin_for_partner?(@partner.id)
+        ids = @partner.owned_neighbourhood_ids | current_user.owned_neighbourhood_ids
+        @all_neighbourhoods = Neighbourhood.where(id: ids)
+      elsif current_user.admin_for_partner?(@partner.id) || current_user.root?
+        # if user can see partner because they own them or are root let them set any neighbourhood
         @all_neighbourhoods = Neighbourhood.order(:name)
-        return
       end
-
-      @all_neighbourhoods = policy_scope(Neighbourhood).order(:name)
     end
 
     def user_not_authorized

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -122,7 +122,7 @@ module Admin
     private
 
     def set_neighbourhoods
-      if current_user.root?
+      if current_user.root? || (@partner.present? && current_user.admin_for_partner?(@partner.id))
         @all_neighbourhoods = Neighbourhood.order(:name)
       elsif @partner.present? && current_user.neighbourhood_admin_for_partner?(@partner.id)
         ids = @partner.owned_neighbourhood_ids | current_user.owned_neighbourhood_ids

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,7 +80,8 @@ class User < ApplicationRecord
   end
 
   def neighbourhood_admin_for_partner?(partner_id)
-    neighbourhood_admin? &&
+    partner_id.present? &&
+      neighbourhood_admin? &&
       (
         owned_neighbourhood_ids & (
           Partner.find_by(id: partner_id).owned_neighbourhood_ids
@@ -92,6 +93,16 @@ class User < ApplicationRecord
     root? || (
       neighbourhood_admin? &&
       owned_neighbourhood_ids.include?(neighbourhood_id)
+    )
+  end
+
+  def can_edit_partners_neighbourhood_by_id?(neighbourhood_id, partner_id = nil)
+    root? || (
+      neighbourhood_admin? &&
+      owned_neighbourhood_ids.include?(neighbourhood_id)
+    ) || (
+      partner_admin? &&
+      partners.pluck(:id).include?(partner_id)
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,10 +100,7 @@ class User < ApplicationRecord
     root? || (
       neighbourhood_admin? &&
       owned_neighbourhood_ids.include?(neighbourhood_id)
-    ) || (
-      partner_admin? &&
-      partners.pluck(:id).include?(partner_id)
-    )
+    ) || admin_for_partner?(partner_id)
   end
 
   def neighbourhood_admin?

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -1,157 +1,129 @@
 <div class="form">
   <%= simple_form_for @partner do |f| %>
-
-  <%= render_component "error", object: @partner %>
-
-  <h2>Basic Information</h2>
-
-  <%= f.input :name, class: "form-control" %>
-  <%= f.input :slug, class: "form-control" if policy(@partner).permitted_attributes.include? :slug %>
-
-  <%= f.input :summary, class: "form-control", label: 'Summary', input_html: { maxlength: 200, rows: 2 }, as: 'text' %>
-
-  <%= f.input :description, class: "form-control", label: 'Description', input_html: { rows: 7 } %>
-
-  <%= f.input :accessibility_info, class: "form-control", label: 'Accessibility Information', input_html: { rows: 7 } %>
-
-  <div class="row">
-    <div class="col-md-6" data-controller="image-preview">
-      <%= f.input :image,
-          hint: image_uploader_hint(@partner.image),
-          as: :file,
-          input_html: { data: { action: "change->image-preview#file"} }
-          %>
-      <% if @partner.image.url  %>
-      <%= image_tag @partner.image.url,  width: '125', class: 'brand_image', data: { image_preview_target: "img"}  %>
-      <% else  %>
-      <%= image_tag "", style: 'display:none;', width: '125', class: 'brand_image', data: { image_preview_target: "img"} %>
-      <% end  %>
+    <%= render_component "error", object: @partner %>
+    <h2>Basic Information</h2>
+    <%= f.input :name, class: "form-control" %>
+    <%= f.input :slug, class: "form-control" if policy(@partner).permitted_attributes.include? :slug %>
+    <%= f.input :summary, class: "form-control", label: 'Summary', input_html: { maxlength: 200, rows: 2 }, as: 'text' %>
+    <%= f.input :description, class: "form-control", label: 'Description', input_html: { rows: 7 } %>
+    <%= f.input :accessibility_info, class: "form-control", label: 'Accessibility Information', input_html: { rows: 7 } %>
+    <div class="row">
+      <div class="col-md-6" data-controller="image-preview">
+        <%= f.input :image,
+            hint: image_uploader_hint(@partner.image),
+            as: :file,
+            input_html: { data: { action: "change->image-preview#file"} }
+            %>
+        <% if @partner.image.url  %>
+        <%= image_tag @partner.image.url,  width: '125', class: 'brand_image', data: { image_preview_target: "img"}  %>
+        <% else  %>
+        <%= image_tag "", style: 'display:none;', width: '125', class: 'brand_image', data: { image_preview_target: "img"} %>
+        <% end  %>
+      </div>
     </div>
-
-  </div>
-
-  <br>
-  <hr>
-
-  <h2>Address</h2>
-
-  <div id='address'>
+    <br>
+    <hr>
+    <h2>Address</h2>
+    <div id='address'>
+      <div class="row">
+        <div class="col-md-6">
+          <%= f.fields_for :address, @partner.address || Address.new do |a| %>
+            <%= render 'address_fields', f: a %>
+          <% end %>
+          <% if @partner&.address&.neighbourhood&.legacy_neighbourhood? %>
+            <p>
+              The address for this partner is assigned to an out of date neighbourhood.
+              You do not need to take any action but if you wish to reassign this to an
+              up to date neighbourhood please contact support at <a href="mailto:support@placecal.org">support@placecal.org</a>.
+            </p>
+          <% end %>
+          <% if partner_has_unmappable_postcode?(@partner) %>
+            <p>
+              The Postcode you were trying to lookup has not been added to our system yet. Please contact us for further assistance.
+            </p>
+          <% end %>
+        </div>
+        <div class="col-md-6">
+          <%= f.input :url, class: "form-control", label: 'Website address', placeholder: 'https://your-website.org' %>
+          <div class="form-group url optional facebook_link form-group-invalid">
+            <%= f.label :facebook_link %>
+            <div class="input-group">
+              <div class="input-group-prepend">
+                <div class="input-group-text">https://facebook.com/</div>
+              </div>
+              <%= f.input_field :facebook_link, class: "form-control", placeholder: 'FacebookPageName' %>
+              <%= f.error :facebook_link, class: 'invalid-feedback' %>
+            </div>
+          </div>
+          <div class="form-group url optional twitter_handle form-group-invalid">
+            <%= f.label :twitter_handle %>
+            <div class="input-group">
+              <div class="input-group-prepend">
+                <div class="input-group-text">@</div>
+              </div>
+              <%= f.input_field :twitter_handle, class: "form-control", placeholder: 'TwitterAccount' %>
+              <%= f.error :twitter_handle, class: 'invalid-feedback' %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <hr>
+    <h2>Service Areas</h2>
+    <p>If this partner delivers services outside the above address, such as a phone support line or outreach service, select them here.</p>
+    <div class="sites_neighbourhoods">
+      <%= f.simple_fields_for :service_areas do |neighbourhood| %>
+        <%= render 'service_area_fields', :f => neighbourhood %>
+      <% end %>
+      <div class="links">
+        <%= link_to_add_association 'Add Service Area', f, :service_areas, class: "btn btn-primary btn-sm" %>
+      </div>
+      <br>
+    </div>
+    <br>
+    <hr>
+    <h2>Contact Information</h2>
     <div class="row">
       <div class="col-md-6">
-        <%= f.fields_for :address, @partner.address || Address.new do |a| %>
-        <%= render 'address_fields', f: a %>
-        <% end %>
-
-  <% if @partner&.address&.neighbourhood&.legacy_neighbourhood? %>
-  <p>
-    The address for this partner is assigned to an out of date neighbourhood.
-    You do not need to take any action but if you wish to reassign this to an
-    up to date neighbourhood please contact support at <a href="mailto:support@placecal.org">support@placecal.org</a>.
-  </p>
-  <% end %>
-	<% if partner_has_unmappable_postcode?(@partner) %>
-	<p>
-	  The Postcode you were trying to lookup has not been added to our system yet. Please contact us for further assistance.
-	</p>
-	<% end %>
+        <h3>Public Contact</h3>
+        <p>This is the information that will be shown to the public.</p>
+        <%= f.input :public_name, class: "form-control" %>
+        <%= f.input :public_email, class: "form-control" %>
+        <%= f.input :public_phone, class: "form-control" %>
       </div>
       <div class="col-md-6">
-        <%= f.input :url, class: "form-control", label: 'Website address', placeholder: 'https://your-website.org' %>
-
-        <div class="form-group url optional facebook_link form-group-invalid">
-          <%= f.label :facebook_link %>
-          <div class="input-group">
-            <div class="input-group-prepend">
-              <div class="input-group-text">https://facebook.com/</div>
-            </div>
-            <%= f.input_field :facebook_link, class: "form-control", placeholder: 'FacebookPageName' %>
-            <%= f.error :facebook_link, class: 'invalid-feedback' %>
-          </div>
-        </div>
-
-        <div class="form-group url optional twitter_handle form-group-invalid">
-          <%= f.label :twitter_handle %>
-          <div class="input-group">
-            <div class="input-group-prepend">
-              <div class="input-group-text">@</div>
-            </div>
-            <%= f.input_field :twitter_handle, class: "form-control", placeholder: 'TwitterAccount' %>
-            <%= f.error :twitter_handle, class: 'invalid-feedback' %>
-          </div>
-        </div>
+        <h3>Partnership Contact</h3>
+        <p><em>If different from public contact:</em> The contact person for PlaceCal.</p>
+        <%= f.input :partner_name, class: "form-control" %>
+        <%= f.input :partner_email, class: "form-control" %>
+        <%= f.input :partner_phone, class: "form-control" %>
       </div>
     </div>
-  </div>
-
-  <hr>
-
-  <h2>Service Areas</h2>
-
-  <p>If this partner delivers services outside the above address, such as a phone support line or outreach service, select them here.</p>
-
-  <div class="sites_neighbourhoods">
-    <%= f.simple_fields_for :service_areas do |neighbourhood| %>
-    <%= render 'service_area_fields', :f => neighbourhood %>
-    <% end %>
-    <div class="links">
-      <%= link_to_add_association 'Add Service Area', f, :service_areas, class: "btn btn-primary btn-sm" %>
+    <hr>
+    <div class="row">
+      <div class="col-lg-8 col-md-12">
+        <h2>Opening times</h2>
+        <%= render 'opening_times', f: f %>
+      </div>
     </div>
-    <br></br>
-  </div>
-
-  <br>
-
-  <hr>
-  <h2>Contact Information</h2>
-
-  <div class="row">
-    <div class="col-md-6">
-      <h3>Public Contact</h3>
-      <p>This is the information that will be shown to the public.</p>
-      <%= f.input :public_name, class: "form-control" %>
-      <%= f.input :public_email, class: "form-control" %>
-      <%= f.input :public_phone, class: "form-control" %>
+    <hr>
+    <h2>Tags</h2>
+    <p>What partnerships, categories and facilities does this partner have or belong to?</p>
+    <p>Partners may have up to 3 category tags.</p>
+    <%= f.association :tags,
+        label: false,
+        collection: options_for_partner_tags,
+        input_html: { class: 'form-check', data: { controller: "select2" } } %>
+    <hr>
+    <br>
+    <div class="row">
+      <div class="col-sm-12">
+        <%= f.submit "Save Partner", class: "btn btn-primary btn-lg" %><br><br><br>
+        <% if policy(@partner).destroy? && !@partner.new_record? %>
+          <%= link_to "Delete Partner", @partner, method: :delete, class: "btn btn-danger btn-sm", id: 'destroy-partner'  %>
+        <% end %>
+      </div>
     </div>
-    <div class="col-md-6">
-      <h3>Partnership Contact</h3>
-      <p><em>If different from public contact:</em> The contact person for PlaceCal.</p>
-      <%= f.input :partner_name, class: "form-control" %>
-      <%= f.input :partner_email, class: "form-control" %>
-      <%= f.input :partner_phone, class: "form-control" %>
-    </div>
-  </div>
-  <hr>
-  <div class="row">
-    <div class="col-lg-8 col-md-12">
-      <h2>Opening times</h2>
-      <%= render 'opening_times', f: f %>
-    </div>
-  </div>
-  <hr>
-  <h2>Tags</h2>
-
-  <p>What partnerships, categories and facilities does this partner have or belong to?</p>
-  <p>Partners may have up to 3 category tags.</p>
-
-  <%= f.association :tags,
-      label: false,
-      collection: options_for_partner_tags,
-      input_html: { class: 'form-check', data: { controller: "select2" } } %>
-
-  <hr>
-  <br>
-  <div class="row">
-    <div class="col-sm-12">
-      <%= f.submit "Save Partner", class: "btn btn-primary btn-lg" %><br><br><br>
-
-      <% if policy(@partner).destroy? && !@partner.new_record? %>
-      <%= link_to "Delete Partner", @partner, method: :delete, class: "btn btn-danger btn-sm", id: 'destroy-partner'  %>
-      <% end %>
-    </div>
-  </div>
-  <%# End form tag %>
   <% end %>
 </div>
-
 <div id="map-pin-div" data-url="<%= image_path('icons/map/map-marker.png') %>"></div>
-

--- a/app/views/admin/partners/_service_area_fields.html.erb
+++ b/app/views/admin/partners/_service_area_fields.html.erb
@@ -1,15 +1,22 @@
 <fieldset class="input-group nested-fields p-0">
     <%# The style width setting here is applied to dynamically created elements, we do not know why. %>
     <%# TODO: Fix the dynamic styling so that width does not get applied, so we can remove this smell %>
+    
     <%= f.input :neighbourhood_id,
                 collection: options_for_service_area_neighbourhoods(@partner),
-                include_blank: false,
+                include_blank: true,
                 value_method: ->(obj) { obj[:id] },
                 label_method: ->(obj) { obj[:name] },
-                input_html: { class: 'form-control', data: { controller: "select2" } , style: "width: 599.8px;" },
+                input_html: { 
+                    class: 'form-control', 
+                    data: { controller: "select2" },
+                    disabled: f.object.neighbourhood_id && !current_user.can_edit_partners_neighbourhood_by_id?(f.object.neighbourhood_id, @partner.id),
+                },
                 label: '', label_html: { hidden: true } %>
 
-    <div class="input-group-append p-0">
-        <%= link_to_remove_association 'Remove', f, class: "pl-2 pt-1 text-danger" %>
-    </div>
+    <%- if !f.object.neighbourhood_id || current_user.can_edit_partners_neighbourhood_by_id?(f.object.neighbourhood_id, @partner.id)%>
+        <div class="input-group-append p-0">
+            <%= link_to_remove_association 'Remove', f, class: "pl-2 pt-1 text-danger" %>
+        </div>
+    <% end %>
 </fieldset>

--- a/test/controllers/admin/partner_edit_site_test.rb
+++ b/test/controllers/admin/partner_edit_site_test.rb
@@ -64,26 +64,26 @@ class PartnerEditSiteTest < ActionDispatch::IntegrationTest
 
     get edit_admin_partner_url(@partner)
 
-    assert_select '#partner_service_areas_attributes_0_neighbourhood_id option', count: 10
+    assert_select '#partner_service_areas_attributes_0_neighbourhood_id option', count: 11
   end
 
-  # partner owner can see all neighbourhoods
-  test 'partner owner can see all neighbourhoods' do
+  # partner admin can see all neighbourhoods
+  test 'partner admin can see all neighbourhoods' do
     @partner.service_area_neighbourhoods << @neighbourhood
     @partner.save!
 
     given_lots_of_neighbourhoods_exist
 
-    other_user = create(:user)
-    assert_not other_user.neighbourhood_admin?
+    partner_admin = create(:user)
+    assert_not partner_admin.neighbourhood_admin?
 
-    other_user.partners << @partner # owns this
+    partner_admin.partners << @partner # owns this
 
-    sign_in other_user
+    sign_in partner_admin
     get edit_admin_partner_url(@partner)
 
     # has same number as root
-    assert_select '#partner_service_areas_attributes_0_neighbourhood_id option', count: 10
+    assert_select '#partner_service_areas_attributes_0_neighbourhood_id option', count: 11
   end
 
   # user can only see neighbourhoods they admin
@@ -118,7 +118,7 @@ class PartnerEditSiteTest < ActionDispatch::IntegrationTest
     get edit_admin_partner_url(@partner)
 
     # can only see the neighbourhoods the user owns
-    assert_select '#partner_service_areas_attributes_0_neighbourhood_id option', count: 5
+    assert_select '#partner_service_areas_attributes_0_neighbourhood_id option', count: 6
   end
 
   def given_lots_of_neighbourhoods_exist

--- a/test/controllers/admin/partners_controller_test.rb
+++ b/test/controllers/admin/partners_controller_test.rb
@@ -9,13 +9,15 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
 
     @address = create(:address)
     @neighbourhood = @address.neighbourhood
+    @other_partner_neighbourhood = create(:moss_side_neighbourhood)
+    @other_neighbourhood_admin_neighbourhood = create(:ashton_neighbourhood)
 
     @neighbourhood_admin = create(:user)
     @neighbourhood_admin.neighbourhoods << @neighbourhood
+    @neighbourhood_admin.neighbourhoods << @other_neighbourhood_admin_neighbourhood
 
     @partner = create(:partner, address_id: @address.id)
-    @partner.service_areas = [create(:moss_side_neighbourhood)]
-    @partner.save!
+    @partner.service_areas.build neighbourhood: @other_partner_neighbourhood
 
     @partner_admin = create(:user)
     @partner_admin.partners << @partner
@@ -214,10 +216,13 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
 
   test 'neighbourhood_admin : can see all of a partners service areas' do
     sign_in @neighbourhood_admin
+    get edit_admin_partner_url(@partner)
+    all_neighbourhoods = [
+      @neighbourhood,
+      @other_partner_neighbourhood,
+      @other_neighbourhood_admin_neighbourhood
+    ]
 
-    get edit_admin_partners_url(@partner)
-    assert_response :success
-    # assert_select 'a', 'Edit'
-    assert_select '#select2-partner_service_areas_attributes_0_neighbourhood_id-container', 'Govan'
+    assert_equal all_neighbourhoods.sort, @controller.view_assigns['all_neighbourhoods'].sort
   end
 end

--- a/test/controllers/admin/partners_controller_test.rb
+++ b/test/controllers/admin/partners_controller_test.rb
@@ -14,6 +14,8 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
     @neighbourhood_admin.neighbourhoods << @neighbourhood
 
     @partner = create(:partner, address_id: @address.id)
+    @partner.service_areas = [create(:moss_side_neighbourhood)]
+    @partner.save!
 
     @partner_admin = create(:user)
     @partner_admin.partners << @partner
@@ -208,5 +210,14 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
     post setup_admin_partners_url, params: params
 
     assert_template :setup
+  end
+
+  test 'neighbourhood_admin : can see all of a partners service areas' do
+    sign_in @neighbourhood_admin
+
+    get edit_admin_partners_url(@partner)
+    assert_response :success
+    # assert_select 'a', 'Edit'
+    assert_select '#select2-partner_service_areas_attributes_0_neighbourhood_id-container', 'Govan'
   end
 end

--- a/test/controllers/admin/partners_controller_test.rb
+++ b/test/controllers/admin/partners_controller_test.rb
@@ -8,16 +8,17 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
     @citizen = create(:user)
 
     @address = create(:address)
-    @neighbourhood = @address.neighbourhood
-    @other_partner_neighbourhood = create(:moss_side_neighbourhood)
+    @neighbourhood_admin_neighbourhood = @address.neighbourhood
+    @partner_neighbourhood = create(:moss_side_neighbourhood)
     @other_neighbourhood_admin_neighbourhood = create(:ashton_neighbourhood)
 
     @neighbourhood_admin = create(:user)
-    @neighbourhood_admin.neighbourhoods << @neighbourhood
+    @neighbourhood_admin.neighbourhoods << @neighbourhood_admin_neighbourhood
     @neighbourhood_admin.neighbourhoods << @other_neighbourhood_admin_neighbourhood
 
     @partner = create(:partner, address_id: @address.id)
-    @partner.service_areas.build neighbourhood: @other_partner_neighbourhood
+    @partner.service_areas.build(neighbourhood: @partner_neighbourhood)
+    @partner.save!
 
     @partner_admin = create(:user)
     @partner_admin.partners << @partner
@@ -113,7 +114,6 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
   #   Everyone else, redirect to admin_partners_url
 
   it_allows_access_to_edit_for(%i[root neighbourhood_admin partner_admin]) do
-    assert_equal @partner.address.neighbourhood_id, @neighbourhood_admin.neighbourhood_ids.last
     get edit_admin_partner_url(@partner)
     assert_response :success
   end
@@ -218,8 +218,8 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
     sign_in @neighbourhood_admin
     get edit_admin_partner_url(@partner)
     all_neighbourhoods = [
-      @neighbourhood,
-      @other_partner_neighbourhood,
+      @partner_neighbourhood,
+      @neighbourhood_admin_neighbourhood,
       @other_neighbourhood_admin_neighbourhood
     ]
 

--- a/test/integration/admin/user_integration_test.rb
+++ b/test/integration/admin/user_integration_test.rb
@@ -302,7 +302,6 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
 
   test 'a neighbourhood_admin can create a user with a partner' do
     sign_in @neighbourhood_admin
-    puts "this si the partner id ~ #{@partner.id}"
 
     new_user_params = {
       email: 'user@example.com',

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -123,6 +123,33 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [error_message], @user.errors[:tags]
   end
 
+  test 'can_edit_partners_neighbourhood_by_id?' do
+    root = create(:root)
+    ashton_neighbourhood = create(:ashton_neighbourhood)
+    other_neighbourhood = create(:moss_side_neighbourhood)
+    neighbourhood_admin = create(:neighbourhood_admin)
+    neighbourhood_admin.neighbourhoods << ashton_neighbourhood
+    partner_admin = create(:partner_admin)
+    partner = partner_admin.partners.first
+
+    # root can attach/remove any neighbourhood
+    assert(root.can_edit_partners_neighbourhood_by_id?(1))
+    assert(root.can_edit_partners_neighbourhood_by_id?(ashton_neighbourhood.id, partner.id))
+
+    # partner admin can attach/remove any neighbourhood
+    assert(partner_admin.can_edit_partners_neighbourhood_by_id?(other_neighbourhood.id, partner.id))
+
+    # neighbourhood admin can attach/remove neighbourhood it owns
+    assert(neighbourhood_admin.can_edit_partners_neighbourhood_by_id?(ashton_neighbourhood.id, partner.id))
+
+    # neighbourhood admin can't attach/remove neighbourhood it doesn't own
+    assert_not(neighbourhood_admin.can_edit_partners_neighbourhood_by_id?(other_neighbourhood.id, partner.id))
+
+    # neighbourhood & partner admin can attach/remove any neighbourhood
+    neighbourhood_admin.partners << partner
+    assert(neighbourhood_admin.can_edit_partners_neighbourhood_by_id?(other_neighbourhood.id, partner.id))
+  end
+
   test 'Faciltiy tag cannot be assigned to User' do
     error_message = 'Can only be of type Partnership'
     @user.tags << Facility.first


### PR DESCRIPTION
Fixes #2123 

## Description

What a bug! Neighbourhood admins used to see an incorrect list of service areas for partners - it would replace actual neighbourhoods with neighbourhoods owned only by the admin.

They can now see all of the neighbourhoods, but they cannot remove or modify neighbourhoods they do not admin for. They CAN add neighbourhoods they do not admin for, but only ones that are already owned by the partner, ie: no change. This does cause the validation to fail, preventing a partner save, but they can refresh the page and everything is fine. I will raise a separate ticket to fix this in a future iteration as it is annoying but does not actually break anything, and the likelihood that admins are going to be trying to add the same service area multiple times is really slim.

Partner admins and root users can still see and modify every service area.

This logic required a change to the input, but since the actual logic is handled in a new user method and the controller, testing is just based on these methods.

I've also done a tiny bit of refactoring on a form whose layout was hurting my eyes, and removed an unused method from the partners controller.
 