### PR TITLE
Update calendar policy to allow neighbourhood admins to see all calendars attached to their partners

### DIFF
--- a/test/factories/calendar.rb
+++ b/test/factories/calendar.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     end
 
     factory :calendar_for_outlook, class: 'Calendar' do
-      name { 'Eventbrite Calendar 1' }
+      name { 'Outlook Calendar 1' }
       # VCR.use_cassette(:outlook_events) do
       source { 'https://outlook.office365.com/owa/calendar/8a1f38963ce347bab8cfe0d0d8c5ff16@thebiglifegroup.com/5c9fc0f3292e4f0a9af20e18aa6f17739803245039959967240/calendar.ics' }
     end

--- a/test/policies/calendar_policy_test.rb
+++ b/test/policies/calendar_policy_test.rb
@@ -3,13 +3,55 @@
 require 'test_helper'
 
 class CalendarPolicyTest < ActiveSupport::TestCase
-  def test_scope; end
+  setup do
+    @partner_admin = create(:partner_admin)
+    @partner_in_neighbourhood = @partner_admin.partners.first
 
-  def test_show; end
+    @other_partner_admin = create(:partner_admin)
+    @partner_servicing_neighbourhood = @other_partner_admin.partners.first
+    @partner_servicing_neighbourhood.address.neighbourhood = create(:neighbourhood)
+    @partner_servicing_neighbourhood.service_areas.create! neighbourhood: create(:ashton_neighbourhood)
+    @partner_servicing_neighbourhood.save!
 
-  def test_create; end
+    @neighbourhood_admin = create(:neighbourhood_admin)
+    @neighbourhood_admin.neighbourhoods = [@partner_in_neighbourhood.address.neighbourhood]
+    @neighbourhood_admin.neighbourhoods << @partner_servicing_neighbourhood.service_areas.first.neighbourhood
 
-  def test_update; end
+    @partner_outside_neighbourhood = create(:partner)
+    @partner_outside_neighbourhood.address.neighbourhood = create(:neighbourhood)
+    @partner_outside_neighbourhood.save!
 
-  def test_destroy; end
+    @root = create(:root)
+
+    VCR.use_cassette(:import_test_calendar) do
+      @neighbourhood_cal = create(:calendar)
+      @partner_in_neighbourhood.calendars = [@neighbourhood_cal]
+    end
+    VCR.use_cassette(:calendar_for_outlook) do
+      @outside_neighbourhood_cal = create(:calendar_for_outlook)
+      @partner_outside_neighbourhood.calendars = [@outside_neighbourhood_cal]
+    end
+    VCR.use_cassette(:eventbrite_events) do
+      @servicing_neighbourhood_cal = create(:calendar_for_eventbrite)
+      @partner_servicing_neighbourhood.calendars = [@servicing_neighbourhood_cal]
+    end
+  end
+
+  def test_scope
+    # root can access everything
+    assert_equal(
+      permitted_records(@root, Calendar).sort,
+      [@neighbourhood_cal, @outside_neighbourhood_cal, @servicing_neighbourhood_cal].sort
+    )
+    # neighbourhood admin can see calendars for partners with service areas and addresses in neighbourhood
+    assert_equal(
+      permitted_records(@neighbourhood_admin, Calendar).sort,
+      [@neighbourhood_cal, @servicing_neighbourhood_cal].sort
+    )
+    # partner admin can only see calendars for partners they admin for
+    assert_equal(permitted_records(@partner_admin, Calendar), [@neighbourhood_cal])
+    assert_equal(
+      permitted_records(@other_partner_admin, Calendar), [@servicing_neighbourhood_cal]
+    )
+  end
 end

--- a/test/policies/partner_policy_test.rb
+++ b/test/policies/partner_policy_test.rb
@@ -14,6 +14,8 @@ class PartnerPolicyTest < ActiveSupport::TestCase
     @correct_ward_admin = create(:citizen)
     @wrong_ward_admin = create(:citizen)
 
+    @correct_service_area_admin = create(:neighbourhood_admin)
+
     @correct_district_admin = create(:citizen)
     @wrong_district_admin = create(:citizen)
 
@@ -26,6 +28,8 @@ class PartnerPolicyTest < ActiveSupport::TestCase
     # ---------------------------------------------------------------------------
 
     @partner = @correct_partner_admin.partners.first
+    @partner.service_areas.create! neighbourhood: @correct_service_area_admin.neighbourhoods.first
+
     @correct_ward_admin.neighbourhoods << @partner.address.neighbourhood
     @correct_district_admin.neighbourhoods << @partner.address.neighbourhood.district
 
@@ -53,6 +57,7 @@ class PartnerPolicyTest < ActiveSupport::TestCase
     assert allows_access(@root, Partner, :index)
     assert allows_access(@correct_partner_admin, Partner, :index)
     assert allows_access(@correct_ward_admin, Partner, :index)
+    assert allows_access(@correct_service_area_admin, Partner, :index)
     assert allows_access(@correct_district_admin, Partner, :index)
 
     # assert allows_access(@multi_admin, Partner, :index)


### PR DESCRIPTION
Fixes #2132 

## Description

Admins could create a calendar and then lose it because it was assigned to a partner whose service address is in their neighbourhood but whose address is not!

This updates the calendar policy to make the list of visible calendars include those which are attached to a partner whose service area is in an admins neighbourhood.

Also it adds some tests.