### PR TITLE
Removing unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,8 @@ gem 'puma'
 gem 'rails'
 
 # Frontend
-gem 'coffee-rails'
-gem 'importmap-rails'
+# gem 'coffee-rails'
 gem 'jquery-rails'
-gem 'jquery-turbolinks'
 gem 'jsbundling-rails'
 gem 'sass-rails', '6.0.0'
 gem 'stimulus-rails'
@@ -51,7 +49,6 @@ gem 'simple_form'
 # Users, login, permissions
 gem 'devise'
 gem 'devise_invitable'
-gem 'omniauth-facebook'
 gem 'pundit'
 
 # Maps and geolocation
@@ -67,7 +64,6 @@ gem 'groupdate'
 
 # Markdown
 gem 'kramdown'
-gem 'rails_autolink'
 
 # Jobs
 gem 'delayed_job_active_record'
@@ -81,31 +77,25 @@ gem 'active_link_to'
 gem 'bootsnap', require: false
 gem 'enumerize'
 gem 'friendly_id'
-gem 'jbuilder'
 # gem 'listen' # needed?
 gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem 'net-smtp', require: false
 
-gem 'oj'
 gem 'paper_trail'
 gem 'rollbar'
 gem 'sendgrid-actionmailer'
 gem 'uk_postcode'
-gem 'virtus'
-gem 'whenever', require: false
 
 group :development, :test do
-  gem 'byebug', platform: :mri
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'timecop'
 end
 
 group :development do
-  gem 'awesome_print'
   gem 'better_errors'
-  gem 'binding_of_caller'
+  gem 'foreman'
   gem 'graphiql-rails'
   gem 'letter_opener'
   gem 'rails-erd'
@@ -118,7 +108,6 @@ group :development do
   gem 'rubocop-rake', require: false
   gem 'spring'
   # gem 'spring-watcher-listen'
-  gem 'foreman'
   gem 'web-console'
   gem 'yard'
 end
@@ -134,11 +123,8 @@ group :test do
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'
   gem 'vcr'
-  gem 'webmock'
+  gem 'webmock' # used by VCR
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-# Use Redis for Action Cable
-gem 'redis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,19 +73,12 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
-    awesome_print (1.9.2)
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.18)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindex (0.8.1)
-    binding_of_caller (1.0.0)
-      debug_inspector (>= 0.0.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     bootstrap (4.6.2)
@@ -93,7 +86,6 @@ GEM
       popper_js (>= 1.16.1, < 2)
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
-    byebug (11.1.3)
     capybara (3.37.1)
       addressable
       matrix
@@ -114,18 +106,8 @@ GEM
       ssrf_filter (~> 1.0)
     childprocess (4.1.0)
     choice (0.2.0)
-    chronic (0.10.2)
     cocoon (1.2.15)
     coderay (1.1.3)
-    coercible (1.0.0)
-      descendants_tracker (~> 0.0.1)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
@@ -135,14 +117,11 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.4)
-    debug_inspector (1.1.0)
     delayed_job (4.1.10)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)
       activerecord (>= 3.0, < 8.0)
       delayed_job (>= 3.0, < 5)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -169,29 +148,6 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.10.0)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
     ffi (1.15.5)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
@@ -211,7 +167,6 @@ GEM
     groupdate (6.1.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
-    hashie (5.0.0)
     htmlentities (4.3.4)
     http-accept (1.7.0)
     http-cookie (1.0.5)
@@ -227,23 +182,13 @@ GEM
       icalendar (~> 2.0)
       ice_cube (~> 0.16)
     ice_cube (0.16.4)
-    ice_nine (0.11.2)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    importmap-rails (1.1.0)
-      actionpack (>= 6.0.0)
-      railties (>= 6.0.0)
-    jbuilder (2.11.5)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     jquery-rails (4.5.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-turbolinks (2.1.0)
-      railties (>= 3.1.0)
-      turbolinks
     jsbundling-rails (1.0.2)
       railties (>= 6.0.0)
     json (2.7.1)
@@ -258,7 +203,6 @@ GEM
     json_matchers (0.11.1)
       json_schema
     json_schema (0.21.0)
-    jwt (2.4.1)
     kramdown (2.4.0)
       rexml
     language_server-protocol (3.17.0.3)
@@ -300,7 +244,6 @@ GEM
     msgpack (1.5.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    multipart-post (2.2.0)
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -317,22 +260,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
-    oauth2 (1.4.9)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
-      multi_xml (~> 0.5)
-      rack (>= 1.2, < 3)
-    oj (3.13.14)
-    omniauth (2.1.0)
-      hashie (>= 3.4.6)
-      rack (>= 2.2.3)
-      rack-protection
-    omniauth-facebook (9.0.0)
-      omniauth-oauth2 (~> 1.2)
-    omniauth-oauth2 (1.7.2)
-      oauth2 (~> 1.4)
-      omniauth (>= 1.9, < 3)
     orm_adapter (0.5.0)
     paper_trail (12.3.0)
       activerecord (>= 5.2)
@@ -354,8 +281,6 @@ GEM
     rack (2.2.6.4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-protection (2.2.0)
-      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (6.1.7)
@@ -387,8 +312,6 @@ GEM
       ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.4.4)
       loofah (~> 2.19, >= 2.19.1)
-    rails_autolink (1.1.6)
-      rails (> 3.1)
     railties (6.1.7)
       actionpack (= 6.1.7)
       activesupport (= 6.1.7)
@@ -401,7 +324,6 @@ GEM
       link_header (~> 0.0, >= 0.0.8)
     rdoc (6.4.0)
       psych (>= 4.0.0)
-    redis (4.6.0)
     regexp_parser (2.9.0)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -446,7 +368,6 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
-    ruby2_keywords (0.0.5)
     ruby_http_client (3.5.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
@@ -486,7 +407,6 @@ GEM
       railties (>= 6.0.0)
     stringio (3.0.2)
     thor (1.2.1)
-    thread_safe (0.3.6)
     tilt (2.0.11)
     timecop (0.9.5)
     timeout (0.4.1)
@@ -494,9 +414,6 @@ GEM
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uk_postcode (2.1.8)
@@ -509,10 +426,6 @@ GEM
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
-    virtus (2.0.0)
-      axiom-types (~> 0.1)
-      coercible (~> 1.0)
-      descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -529,8 +442,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.28)
@@ -545,16 +456,12 @@ DEPENDENCIES
   active_link_to
   ajax-datatables-rails
   ancestry
-  awesome_print
   better_errors
-  binding_of_caller
   bootsnap
   bootstrap
-  byebug
   capybara-select-2
   carrierwave
   cocoon
-  coffee-rails
   database_cleaner-active_record
   delayed_job_active_record
   devise
@@ -575,10 +482,7 @@ DEPENDENCIES
   icalendar
   icalendar-recurrence
   image_processing
-  importmap-rails
-  jbuilder
   jquery-rails
-  jquery-turbolinks
   jsbundling-rails
   json-ld
   json_matchers
@@ -592,8 +496,6 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  oj
-  omniauth-facebook
   paper_trail
   pg
   puma
@@ -602,9 +504,7 @@ DEPENDENCIES
   rails
   rails-controller-testing
   rails-erd
-  rails_autolink
   rdoc
-  redis
   rollbar
   rubocop (= 1.59.0)
   rubocop-graphql (= 1.5.0)
@@ -624,10 +524,8 @@ DEPENDENCIES
   uk_postcode
   vcr
   view_component
-  virtus
   web-console
   webmock
-  whenever
   yard
 
 RUBY VERSION

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,4 +54,6 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.assets.paths << Rails.root.join('app/javascript')
 end


### PR DESCRIPTION
Closes #2162 

Removed unused gems

## Important notes when merged in

I found running these commands where necessary to expunge the old gems / assets from being loaded (during tests):

```bash
rbenv gemset delete 3.1.2 gfsc-placecal # purge old/unused gems
bundle
rails assets:clobber # force clean assets
rails tmp:cache:clear # will remove coffee script remnants
```

## Important notes when deploying

The `rails tmp:cache:clear` may have to be run prior to deployment to staging / production.