### PR TITLE
fix: missing sites from partners @sites

### DIFF
--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -59,10 +59,10 @@ module PartnersHelper
   def site_links
     return unless @sites
 
-    @sites.order(:name)
-          .map { |site| link_to site.name, site.domain }
-          .join(', ')
-          .html_safe
+    @sites
+      .map { |site| link_to site.name, site.domain }
+      .join(', ')
+      .html_safe
   end
 
   def partner_has_unmappable_postcode?(partner)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -159,13 +159,14 @@ class Site < ApplicationRecord
     # @param [Partner]
     # @return [ActiveRecord::Relation<Site>]
     def sites_that_contain_partner(partner)
-      neighbourhood_ids = partner.owned_neighbourhood_ids
-      tag_ids = partner.partner_tags.pluck(:tag_id)
-
-      Site.left_outer_joins(:sites_tag, :sites_neighbourhoods)
-          .group(:id)
-          .where('neighbourhood_id in (?) or tag_id in (?)',
-                 neighbourhood_ids, tag_ids)
+      sites = Site.all.order(:name)
+      site_partners = []
+      sites.each do |site|
+        partner_ids = Partner.for_site(site).pluck(:id)
+        site_partners.push({ site: site, partner_ids: partner_ids })
+      end
+      site_partners.select { |sp| sp[:partner_ids].include? partner.id }
+                   .map { |sp| sp[:site] }
     end
   end
 end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -30,18 +30,18 @@ class SitePartnerTest < ActiveSupport::TestCase
     service_area_site = FactoryBot.create(:site, name: 'service area site')
     service_area_site.neighbourhoods << service_area_neighbourhood
 
-    tag = FactoryBot.create(:tag)
+    tag = FactoryBot.create(:partnership)
     tag_site = FactoryBot.create(:site, name: 'tag site')
     tag_site.tags << tag
+    tag_site.neighbourhoods << address_neighbourhood
 
     partner = FactoryBot.create(:partner)
     partner.address.neighbourhood = address_neighbourhood
     partner.service_area_neighbourhoods << service_area_neighbourhood
     partner.tags << tag
+    partner.save
 
-    service_area_site
-
-    found = Site.sites_that_contain_partner(partner).order(:id)
+    found = Site.sites_that_contain_partner(partner)
 
     assert_equal found, [address_site, service_area_site, tag_site]
   end


### PR DESCRIPTION
fixes #2151 

We were checking the partners neighborhood ids against the sites neighborhood ids but this failed when the site had a neighborhood that encompassed other smaller neighborhoods. From the partner we would have needed to expand all the way to the root neighborhood and check if any sites existed.

It feels like there's probably some more efficient way of doing this,  we bounce back and forth between the sites and partners rebuilding the entire world just to scope it back down again. So open to an obvious answer I'm missing but also didn't want to start down a  rabbithole.