### PR TITLE
1712 restrict tags to roots

### DIFF
--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -33,18 +33,6 @@ class TagPolicy < ApplicationPolicy
     fields.push(partner_ids: [], user_ids: [])
   end
 
-  def disabled_fields
-    if user.root?
-      %i[]
-    elsif user.tag_admin? && user.tags.include?(@record)
-      %i[system_tag users user_ids]
-    elsif user.tag_admin? || user.partner_admin?
-      %i[name slug description users user_ids system_tag]
-    else # Should never be hit, but it's useful as a guard
-      %i[name slug description users partner_ids user_ids system_tag]
-    end
-  end
-
   class Scope < Scope
     def resolve
       Tag.users_tags(user)

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -1,5 +1,3 @@
-<%- disabled_fields = policy(@tag).disabled_fields %>
-
 <% if !@tag.new_record? %>
 <p>A tag of type <em><%= @tag.class %></em>.</p>
 <% end %>
@@ -19,17 +17,15 @@
   <%= render_component "error", object: @tag %>
 
   <%= f.input :name, class: 'form-control',
-              disabled: disabled_fields.include?(:name) || @tag.system_tag %>
+              disabled: @tag.system_tag %>
 
   <%= f.input :slug, class: 'form-control',
-              disabled: disabled_fields.include?(:slug) || @tag.system_tag %>
+              disabled:  @tag.system_tag %>
 
-  <%= f.input :description, class: 'form-control',
-              disabled: disabled_fields.include?(:description) %>
+  <%= f.input :description, class: 'form-control' %>
 
   <% if current_user.root? -%>
     <%= f.input :system_tag, class: 'form-control',
-      disabled: disabled_fields.include?(:system_tag),
       hint: 'This tag is read only and should not be edited' %>
   <% end -%>
 
@@ -48,26 +44,14 @@
 
   <h2>Tagged Partners</h2>
   <p>Apply this tag to the given partners</p>
-  <% if disabled_fields.include?(:partner_ids) %>
-    <%# # Create a dummy field, because f.assoc disappears %>
-    <%= f.input :partners, collection: options_for_partners,
-        input_html: { class: 'form-control', data: { controller: "select2" } }, disabled: true %>
-  <% else %>
-    <%= f.association :partners, collection: options_for_partners,
+  <%= f.association :partners, collection: options_for_partners,
         input_html: { class: 'form-control', data: { controller: "select2" } } %>
-  <% end %>
 
   <% if show_assigned_user_field_for(f) %>
     <h2>Assigned Users</h2>
     <p>Grant permission to assign this tag</p>
-    <% if disabled_fields.include?(:user_ids) %>
-      <%# # Create a dummy field, because f.assoc disappears %>
-      <%= f.association :users,
-        input_html: { class: 'form-control', data: { controller: "select2" } }, disabled: true %>
-    <% else %>
-      <%= f.association :users, collection: options_for_users,
+    <%= f.association :users, collection: options_for_users,
         input_html: { class: 'form-control', data: { controller: "select2" } } %>
-    <% end %>
   <% end %>
 
   <span>

--- a/test/controllers/admin/tags_controller_test.rb
+++ b/test/controllers/admin/tags_controller_test.rb
@@ -30,12 +30,12 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
   #   Show every Tag for roots
   #   Redirect everyone else to admin_root_url
 
-  it_allows_access_to_index_for(%i[root tag_admin partner_admin]) do
+  it_allows_access_to_index_for(%i[root]) do
     get admin_tags_url
     assert_response :success
   end
 
-  it_denies_access_to_index_for(%i[citizen]) do
+  it_denies_access_to_index_for(%i[citizen tag_admin partner_admin]) do
     get admin_tags_url
     assert_redirected_to admin_root_url
   end
@@ -77,12 +77,12 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
   #   Allow tag admins to update partner_ids of public tags, and root-assigned tags
   #   Everyone else, redirect to admin_root_url
 
-  it_allows_access_to_edit_for(%i[root partner_admin tag_admin]) do
+  it_allows_access_to_edit_for(%i[root]) do
     get edit_admin_tag_url(@unassigned_root_tag)
     assert_response :success
   end
 
-  it_denies_access_to_edit_for(%i[citizen]) do
+  it_denies_access_to_edit_for(%i[citizen partner_admin tag_admin]) do
     get edit_admin_tag_url(@unassigned_root_tag)
     assert_redirected_to admin_root_url
   end
@@ -95,21 +95,6 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [@partner.id], @category_tag.reload.partner_ids
   end
 
-  # partner admins can add and remove partners they admin for without removing those they don't
-  it_allows_access_to_update_for(%i[partner_admin]) do
-    patch admin_tag_url(@category_tag),
-          params:  { tag: { partner_ids: [@partner.id] }, id: 'activism' }
-
-    assert_redirected_to admin_tags_url
-    assert_equal [@partner.id, @unassigned_partner.id].sort, @category_tag.reload.partner_ids.sort
-
-    patch admin_tag_url(@category_tag),
-          params:  { tag: { partner_ids: [] }, id: 'activism' }
-
-    assert_redirected_to admin_tags_url
-    assert_equal [@unassigned_partner.id].sort, @category_tag.reload.partner_ids.sort
-  end
-
   # partner admins cannot update partners they do not admin for
   it_allows_access_to_update_for(%i[partner_admin_with_no_partners]) do
     patch admin_tag_url(@category_tag),
@@ -119,7 +104,7 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [@unassigned_partner.id], @category_tag.reload.partner_ids
   end
 
-  it_denies_access_to_update_for(%i[citizen]) do
+  it_denies_access_to_update_for(%i[citizen partner_admin tag_admin]) do
     patch admin_tag_url(@category_tag),
           params:  { tag: { partner_ids: [@partner.id] }, id: 'activism' }
 

--- a/test/integration/admin/tags_integration_test.rb
+++ b/test/integration/admin/tags_integration_test.rb
@@ -44,17 +44,6 @@ class Admin::TagsTest < ActionDispatch::IntegrationTest
     assert_content 'A new tag name'
   end
 
-  test 'citizen users cannot modify tag' do
-    @citizen.tags << @tag
-    @citizen.tags << @system_tag
-
-    log_in_with @citizen.email
-
-    visit edit_admin_tag_url(@system_tag)
-
-    assert_content 'This tag is a system tag meaning that it cannot be edited by non-root admins.'
-  end
-
   test 'root users can make a tag a system tag' do
     log_in_with @root.email
 

--- a/test/policies/tag_policy_test.rb
+++ b/test/policies/tag_policy_test.rb
@@ -18,12 +18,12 @@ class TagPolicyTest < ActiveSupport::TestCase
     @non_root.tags << @normal_tag
 
     assert allows_access(@root, @normal_tag, :update)
-    assert allows_access(@non_root, @normal_tag, :update)
+    assert denies_access(@non_root, @normal_tag, :update)
 
-    assert allows_access(@partner_admin, @normal_tag, :update)
+    assert denies_access(@partner_admin, @normal_tag, :update)
     assert denies_access(@partner_admin, @system_tag, :update)
 
-    assert allows_access(@tag_admin, @normal_tag, :update)
+    assert denies_access(@tag_admin, @normal_tag, :update)
     assert denies_access(@tag_admin, @system_tag, :update)
 
     assert allows_access(@root, @system_tag, :update)
@@ -42,13 +42,5 @@ class TagPolicyTest < ActiveSupport::TestCase
     fields = policy.permitted_attributes
 
     assert_not fields.include?(:type), 'Expecting type field to NOT be allowed for sub-model'
-  end
-
-  test 'permitted_attributes for partner_admins are just partner_ids' do
-    policy = TagPolicy.new(@partner_admin, Tag.new)
-    fields = policy.permitted_attributes
-
-    assert_includes fields, { partner_ids: [] }
-    assert_equal(1, fields.length)
   end
 end


### PR DESCRIPTION
fixes #1712 

- Only roots see the admin ui https://admin.placecal.org/tags*
- Only roots can create and delete Tags
- Only roots can edit tag related properties (name, slug, description, type)
- Partnership Admins should be able to add their partnership tag to partners (via partner edit page)
- Only roots can add partnership tags to users