### PR TITLE
Only show tagged partners to partnership admins

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -17,8 +17,7 @@ module UsersHelper
   def user_has_no_rights?(user)
     return false if user.root?
     return false if user.editor?
-
-    return false if user.tag_admin?
+    return false if user.partnership_admin?
     return false if user.neighbourhood_admin?
     return false if user.partner_admin?
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -30,7 +30,7 @@ class Tag < ApplicationRecord
   validate :check_editable_fields
 
   scope :users_tags, lambda { |user|
-                       return Tag.all if user.role == 'root' && !user.tag_admin?
+                       return Tag.all if user.role == 'root' && !user.partnership_admin?
 
                        partnership_tags = Tag.where(type: 'Partnership', id: user.tags_users.distinct.pluck(:tag_id)).pluck(:id)
                        other_tags = Tag.where("type != 'Partnership'").pluck(:id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,8 +120,8 @@ class User < ApplicationRecord
     partners.any?
   end
 
-  def tag_admin?
-    tags.any?
+  def partnership_admin?
+    tags.any? { |tag| tag[:type] == 'Partnership' }
   end
 
   def admin_roles
@@ -131,7 +131,7 @@ class User < ApplicationRecord
     types << 'editor' if editor?
     types << 'neighbourhood_admin' if neighbourhood_admin?
     types << 'partner_admin' if partner_admin?
-    types << 'partnership_admin' if tag_admin?
+    types << 'partnership_admin' if partnership_admin?
     types << 'site_admin' if site_admin?
 
     types.join(', ')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,14 +79,16 @@ class User < ApplicationRecord
     partners.pluck(:id).include? partner_id
   end
 
+  def partnership_admin_for_partner?(partner_id)
+    partner_id.present? &&
+      partner_in_neighbourhood_scope?(partner_id) &&
+      partner_in_partnership_scope?(partner_id)
+  end
+
   def neighbourhood_admin_for_partner?(partner_id)
     partner_id.present? &&
-      neighbourhood_admin? &&
-      (
-        owned_neighbourhood_ids & (
-          Partner.find_by(id: partner_id).owned_neighbourhood_ids
-        )
-      ).any?
+      !partnership_admin? &&
+      partner_in_neighbourhood_scope?(partner_id)
   end
 
   def only_neighbourhood_admin_for_partner?(partner_id)
@@ -154,6 +156,23 @@ class User < ApplicationRecord
   end
 
   protected
+
+  def partner_in_neighbourhood_scope?(partner_id)
+    neighbourhood_admin? &&
+      (
+        owned_neighbourhood_ids & (
+          Partner.find_by(id: partner_id).owned_neighbourhood_ids
+        )
+      ).any?
+  end
+
+  def partner_in_partnership_scope?(partner_id)
+    partnership_admin? &&
+      (
+        tags.map(&:id) &
+        Partner.find_by(id: partner_id).partnerships.map(&:id)
+      ).any?
+  end
 
   def validate_tags_are_partnerships
     return true if tags.all?(Partnership)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -41,7 +41,7 @@ class UserPolicy < ApplicationPolicy
       (user.neighbourhood_admin? &&
       !record.root? &&
       !record.neighbourhood_admin? &&
-      !record.tag_admin? &&
+      !record.partnership_admin? &&
       record.partner_admin? &&
       all_user_partners_in_admin_neighbourhood?(record, user))
   end

--- a/app/views/admin/users/profile.html.erb
+++ b/app/views/admin/users/profile.html.erb
@@ -70,7 +70,7 @@
   </div>
   <div class="row">
     <div class="col-md-6">
-      <% if current_user.tag_admin? %>
+      <% if current_user.partnership_admin? %>
         <h3>Your assigned tags</h3>
         <p>Please note these tags will be pre-selected when creating a new partner<p>
         <ul>

--- a/test/controllers/admin/tags_controller_test.rb
+++ b/test/controllers/admin/tags_controller_test.rb
@@ -12,7 +12,7 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
     @unassigned_root_tag = create(:tag)
     @category_tag = create(:tag, type: 'Category', name: 'Activism', partner_ids: [@unassigned_partner.id])
 
-    @tag_admin = create(:tag_admin)
+    @partnership_admin = create(:partnership_admin)
     @partner_admin_with_no_partners = create(:partner_admin) do |user|
       user.partners = []
       user.save!
@@ -35,7 +35,7 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  it_denies_access_to_index_for(%i[citizen tag_admin partner_admin]) do
+  it_denies_access_to_index_for(%i[citizen partnership_admin partner_admin]) do
     get admin_tags_url
     assert_redirected_to admin_root_url
   end
@@ -50,7 +50,7 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  it_denies_access_to_new_for(%i[tag_admin partner_admin citizen]) do
+  it_denies_access_to_new_for(%i[partnership_admin partner_admin citizen]) do
     get new_admin_tag_url
     assert_redirected_to admin_root_url
   end
@@ -62,7 +62,7 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  it_denies_access_to_create_for(%i[tag_admin partner_admin citizen]) do
+  it_denies_access_to_create_for(%i[partnership_admin partner_admin citizen]) do
     assert_no_difference('Tag.count') do
       post admin_tags_url,
            params: { tag: attributes_for(:tag) }
@@ -82,7 +82,7 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  it_denies_access_to_edit_for(%i[citizen partner_admin tag_admin]) do
+  it_denies_access_to_edit_for(%i[citizen partner_admin partnership_admin]) do
     get edit_admin_tag_url(@unassigned_root_tag)
     assert_redirected_to admin_root_url
   end
@@ -104,7 +104,7 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [@unassigned_partner.id], @category_tag.reload.partner_ids
   end
 
-  it_denies_access_to_update_for(%i[citizen partner_admin tag_admin]) do
+  it_denies_access_to_update_for(%i[citizen partner_admin partnership_admin]) do
     patch admin_tag_url(@category_tag),
           params:  { tag: { partner_ids: [@partner.id] }, id: 'activism' }
 
@@ -124,7 +124,7 @@ class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_tags_url
   end
 
-  it_denies_access_to_destroy_for(%i[tag_admin partner_admin citizen]) do
+  it_denies_access_to_destroy_for(%i[partnership_admin partner_admin citizen]) do
     assert_no_difference('Tag.count') do
       delete admin_tag_url(@unassigned_root_tag)
     end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -22,8 +22,8 @@ FactoryBot.define do
       role { 'editor' }
     end
 
-    factory(:tag_admin) do
-      after(:create) { |user| user.tags = [create(:tag)] }
+    factory(:partnership_admin) do
+      after(:create) { |user| user.tags = [create(:tag, type: 'Partnership')] }
     end
 
     factory(:neighbourhood_admin) do

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -15,7 +15,7 @@ class TagTest < ActiveSupport::TestCase
     @partnership_tag.users << @user
     @partnership_tag.save!
     @user.reload
-    assert_predicate @user, :tag_admin?
+    assert_predicate @user, :partnership_admin?
   end
 
   test 'updates partners tags when saved' do
@@ -41,7 +41,7 @@ class TagTest < ActiveSupport::TestCase
     assert_equal Tag.users_tags(root_user), Tag.all
   end
 
-  test 'a root user who is a tag_admin can access their own Partnership tag but not others' do
+  test 'a root user who is a partnership_admin can access their own Partnership tag but not others' do
     root_user = create :root
     @partnership_tag.users << root_user
     @partnership_tag.save!
@@ -52,7 +52,7 @@ class TagTest < ActiveSupport::TestCase
     end
   end
 
-  test 'a root user who is a tag_admin can access Facility tags' do
+  test 'a root user who is a partnership_admin can access Facility tags' do
     root_user = create :root
     @partnership_tag.users << root_user
     @partnership_tag.save
@@ -64,7 +64,7 @@ class TagTest < ActiveSupport::TestCase
     end
   end
 
-  test 'a root user who is a tag_admin can access Category tags' do
+  test 'a root user who is a partnership_admin can access Category tags' do
     root_user = create :root
     @partnership_tag.users << root_user
     @partnership_tag.save
@@ -76,7 +76,7 @@ class TagTest < ActiveSupport::TestCase
     end
   end
 
-  test 'a tag_admin can access their own Partnership tag but not others' do
+  test 'a partnership_admin can access their own Partnership tag but not others' do
     @partnership_tag.users << @user
     @partnership_tag.save
 
@@ -85,7 +85,7 @@ class TagTest < ActiveSupport::TestCase
     end
   end
 
-  test 'a tag_admin can access Facility tags' do
+  test 'a partnership_admin can access Facility tags' do
     @partnership_tag.users << @user
     @partnership_tag.save
 
@@ -96,7 +96,7 @@ class TagTest < ActiveSupport::TestCase
     end
   end
 
-  test 'a tag_admin can access Category tags' do
+  test 'a partnership_admin can access Category tags' do
     @partnership_tag.users << @user
     @partnership_tag.save
 
@@ -107,7 +107,7 @@ class TagTest < ActiveSupport::TestCase
     end
   end
 
-  test 'a non tag_admin cannot access any Partnership tags' do
+  test 'a non partnership_admin cannot access any Partnership tags' do
     assert_equal(0, Tag.users_tags(@user).where(type: 'Partnership').count)
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,6 +7,12 @@ class UserTest < ActiveSupport::TestCase
     create_typed_tags
     @user = create(:user)
     @neighbourhood_region_admin = create(:neighbourhood_region_admin)
+
+    @partnership_tag = create(:partnership)
+    @partnership_admin = create(:neighbourhood_region_admin)
+
+    @partnership_admin.tags << @partnership_tag
+    @partnership_admin.save
   end
 
   test 'owned neighbourhoods returns all descendants' do
@@ -53,6 +59,34 @@ class UserTest < ActiveSupport::TestCase
     assert @neighbourhood_region_admin.neighbourhood_admin_for_partner?(partner_in_neighbourhood.id)
     assert @neighbourhood_region_admin.neighbourhood_admin_for_partner?(partner_with_service_area_in_neighbourhood.id)
     assert_not @neighbourhood_region_admin.neighbourhood_admin_for_partner?(partner_outside_neighbourhood.id)
+  end
+
+  test 'is partnership admin for partner when neighbourhood admin for partners neighbourhood or service area and partnership admin for partners tag' do
+    partner_in_neighbourhood_and_partnership = create(:partner)
+    partner_in_partnership_with_service_area_in_neighbourhood = create(:partner)
+    partner_in_neighbourhood_but_not_partnership = create(:partner)
+    partner_outside_neighbourhood_but_in_partnership = create(:moss_side_partner)
+
+    partner_in_neighbourhood_and_partnership.address.neighbourhood = @partnership_admin.neighbourhoods.first
+    partner_in_neighbourhood_and_partnership.tags << @partnership_tag
+    partner_in_neighbourhood_and_partnership.save!
+
+    partner_in_partnership_with_service_area_in_neighbourhood.service_areas.create(
+      neighbourhood: @partnership_admin.neighbourhoods.first
+    )
+    partner_in_partnership_with_service_area_in_neighbourhood.tags << @partnership_tag
+    partner_in_partnership_with_service_area_in_neighbourhood.save!
+
+    partner_outside_neighbourhood_but_in_partnership.tags << @partnership_tag
+    partner_outside_neighbourhood_but_in_partnership.save!
+
+    partner_in_neighbourhood_but_not_partnership.address.neighbourhood = @partnership_admin.neighbourhoods.first
+    partner_in_neighbourhood_but_not_partnership.save!
+
+    assert @partnership_admin.partnership_admin_for_partner?(partner_in_neighbourhood_and_partnership.id)
+    assert @partnership_admin.partnership_admin_for_partner?(partner_in_partnership_with_service_area_in_neighbourhood.id)
+    assert_not @partnership_admin.partnership_admin_for_partner?(partner_in_neighbourhood_but_not_partnership.id)
+    assert_not @partnership_admin.partnership_admin_for_partner?(partner_outside_neighbourhood_but_in_partnership.id)
   end
 
   test 'is the only possible neighbourhood admin for a partner when admin for partners neighbourhood or service area and partner has no other neighbourhoods' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -104,9 +104,9 @@ class UserTest < ActiveSupport::TestCase
     assert_predicate @user, :partner_admin?
 
     # Does this person manage at least one tag?
-    @user.tags << create(:tag)
+    @user.tags << create(:partnership)
     @user.save
-    assert_predicate @user, :tag_admin?
+    assert_predicate @user, :partnership_admin?
 
     # Is this person a root? If they are, they're also a secretary
     @user.update(role: :root)

--- a/test/policies/partner_policy_test.rb
+++ b/test/policies/partner_policy_test.rb
@@ -7,6 +7,7 @@ class PartnerPolicyTest < ActiveSupport::TestCase
     # Make some user accounts
     # -----------------------
     @citizen = create(:citizen)
+    @other_partner = create(:partner)
 
     @correct_partner_admin = create(:partner_admin)
     @wrong_partner_admin = create(:partner_admin)
@@ -21,7 +22,15 @@ class PartnerPolicyTest < ActiveSupport::TestCase
 
     @root = create(:root)
 
+    partnership_tag = create(:partnership)
+
+    @wrong_partner = @wrong_partner_admin.partners.first
     @partner = @correct_partner_admin.partners.first
+
+    @wrong_partner.address = create(:moss_side_address)
+    @wrong_partner.save
+
+    @partner.tags << partnership_tag
     @partner.service_areas.create! neighbourhood: @correct_service_area_admin.neighbourhoods.first
 
     @correct_ward_admin.neighbourhoods << @partner.address.neighbourhood
@@ -30,6 +39,10 @@ class PartnerPolicyTest < ActiveSupport::TestCase
     @only_ward_admin = create(:citizen)
     @only_ward_admin_partner = create(:partner)
     @only_ward_admin.neighbourhoods << @partner.address.neighbourhood
+
+    @partnership_admin = create(:citizen)
+    @partnership_admin.neighbourhoods << @partner.address.neighbourhood
+    @partnership_admin.tags << partnership_tag
   end
 
   #  Everyone except guess can view list
@@ -41,6 +54,8 @@ class PartnerPolicyTest < ActiveSupport::TestCase
     assert allows_access(@correct_ward_admin, Partner, :index)
     assert allows_access(@correct_service_area_admin, Partner, :index)
     assert allows_access(@correct_district_admin, Partner, :index)
+    assert allows_access(@correct_district_admin, Partner, :index)
+    assert allows_access(@partnership_admin, Partner, :index)
 
     # assert allows_access(@multi_admin, Partner, :index)
   end
@@ -67,6 +82,7 @@ class PartnerPolicyTest < ActiveSupport::TestCase
     assert allows_access(@root, @partner, :update)
     assert allows_access(@correct_partner_admin, @partner, :update)
     assert allows_access(@correct_ward_admin, @partner, :update)
+    assert allows_access(@partnership_admin, @partner, :update)
     # assert allows_access(@correct_district_admin, @partner, :update)
 
     # assert allows_access(@multi_admin, @partner, :update)
@@ -86,18 +102,18 @@ class PartnerPolicyTest < ActiveSupport::TestCase
 
   def test_scope
     # We sort these because for some reason permitted records sometimes returns results back in a different order here
-    # assert_equal(permitted_records(@root, Partner).sort_by(&:id),
-    #              [@partner, @partner_two, @ashton_partner])
-    # assert_equal(permitted_records(@correct_partner_admin, Partner).sort_by(&:id),
-    #              [@partner])
-    # assert_equal(permitted_records(@wrong_partner_admin, Partner).sort_by(&:id),
-    #              [@partner_two])
-    # assert_equal(permitted_records(@correct_ward_admin, Partner).sort_by(&:id),
-    #              [@partner, @partner_two])
+    assert_equal(permitted_records(@root, Partner).sort_by(&:id),
+                 [@partner, @only_ward_admin_partner, @other_partner, @wrong_partner].sort_by(&:id))
+    assert_equal(permitted_records(@correct_partner_admin, Partner).sort_by(&:id),
+                 [@partner])
+    assert_equal(permitted_records(@wrong_partner_admin, Partner).sort_by(&:id),
+                 [@wrong_partner])
+    assert_equal(permitted_records(@correct_ward_admin, Partner).sort_by(&:id),
+                 [@partner, @only_ward_admin_partner, @other_partner].sort_by(&:id))
     # assert_equal(permitted_records(@correct_district_admin, Partner).sort_by(&:id),
-    #              [@partner, @partner_two])
-    # assert_equal(permitted_records(@multi_admin, Partner).sort_by(&:id),
-    #              [@partner, @partner_two, @ashton_partner])
+    #              [@partner, @only_ward_admin_partner, @other_partner].sort_by(&:id))
+    assert_equal(permitted_records(@partnership_admin, Partner).sort_by(&:id),
+                 [@partner])
   end
 
   def test_create_with_partner_permissions
@@ -115,13 +131,12 @@ class PartnerPolicyTest < ActiveSupport::TestCase
 
   def test_update_with_partner_permissions
     user = create(:user)
-    partner = create(:partner)
 
     # denies user with no partners
-    assert denies_access(user, partner, :update)
+    assert denies_access(user, @other_partner, :update)
 
     # can update partners user has access to
-    user.partners << partner
-    assert allows_access(user, partner, :update)
+    user.partners << @other_partner
+    assert allows_access(user, @other_partner, :update)
   end
 end

--- a/test/policies/tag_policy_test.rb
+++ b/test/policies/tag_policy_test.rb
@@ -8,25 +8,20 @@ class TagPolicyTest < ActiveSupport::TestCase
     @non_root = create(:editor)
 
     @partner_admin = create(:partner_admin)
-    @tag_admin = create(:tag_admin)
+    @partnership_admin = create(:partnership_admin)
 
     @normal_tag = create(:tag)
     @system_tag = create(:tag, system_tag: true)
   end
 
   def test_update
-    @non_root.tags << @normal_tag
-
     assert allows_access(@root, @normal_tag, :update)
-    assert denies_access(@non_root, @normal_tag, :update)
+    assert allows_access(@root, @system_tag, :update)
 
     assert denies_access(@partner_admin, @normal_tag, :update)
     assert denies_access(@partner_admin, @system_tag, :update)
-
-    assert denies_access(@tag_admin, @normal_tag, :update)
-    assert denies_access(@tag_admin, @system_tag, :update)
-
-    assert allows_access(@root, @system_tag, :update)
+    assert denies_access(@partnership_admin, @normal_tag, :update)
+    assert denies_access(@partnership_admin, @system_tag, :update)
     assert denies_access(@non_root, @system_tag, :update)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,11 +49,6 @@ module ActiveSupport
 
     fixtures :neighbourhoods
 
-    # Usage:
-    #
-    # it_allows_access_to_action_for(%i[root tag_admin partner_admin place_admin citizen guest]) do
-    # end
-
     %i[index show new edit create update destroy].each do |action|
       define_singleton_method(:"it_allows_access_to_#{action}_for") do |users, &block|
         users.each do |user|


### PR DESCRIPTION
## Description

fixes #2168

This PR begins the work to reinstate partnership admins by making the only partners visible to them ones that have the tag that they own, and are in neighbourhoods within their scope. 

I began by defining a generic partnership admin as a tag admin who only owns partnership tags. Since it is technically impossible for a user to own any other type of tag, this is a bit belt and braces, but I thought it made it clearer what it meant to be a partnership admin. I then removed all references to tag admins and replaced them with references to the partnership admin.

I tweaked how we define a `neighbourhood_admin_for_partner` class method on the user to only return true for users without partnership tags, and added a `partnership_admin_for_partner` class method that will only return true for users who own a tag shared with that partner, and manage neighbourhoods that partner is in. I decided to take this approach so that we could leave the neighbourhood admin logic completely untouched, safe in the knowledge that all we were doing was removing anyone with a partnership_tag from this bracket.

I also added a new clause to the partner policy scope to replicate this logic, revived some broken tests we had for this, and added some new partnership admin tests to cover all of the above!