### PR TITLE
 partnership_admin create partners permissions

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -99,6 +99,8 @@ class Partner < ApplicationRecord
 
   validate :three_or_less_category_tags
 
+  validate :partnership_admins_must_add_tag, on: %i[create]
+
   attr_accessor :accessed_by_user
 
   mount_uploader :image, ImageUploader
@@ -439,5 +441,17 @@ class Partner < ApplicationRecord
     return if categories.count < 4
 
     errors.add :base, 'Partner.tags can contain a maximum of 3 Category tags'
+  end
+
+  def partnership_admins_must_add_tag
+    return unless accessed_by_user.partnership_admin?
+
+    if tags.any?
+      accessed_by_user.tags.each do |t|
+        return true if tags.include? t
+      end
+    end
+
+    errors.add :base, 'This partner must be a part of your partnership'
   end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -444,6 +444,7 @@ class Partner < ApplicationRecord
   end
 
   def partnership_admins_must_add_tag
+    return if accessed_by_user.nil? # HACK: to stop factory breaking tests
     return unless accessed_by_user.partnership_admin?
 
     if tags.any?

--- a/test/models/partner_test.rb
+++ b/test/models/partner_test.rb
@@ -410,4 +410,17 @@ class PartnerTest < ActiveSupport::TestCase
     partner.address.postcode = 'M15 5DD'
     partner.update! name: 'A new partner name'
   end
+
+  test 'partnership_admin cannot create a partner that is not part of their partnership' do
+    pa = create(:partnership_admin)
+    assert_raises(ActiveRecord::RecordInvalid, 'This partner must be a part of your partnership') do
+      create(:partner, :accessed_by_user => pa)
+    end
+  end
+
+  test 'partnership_admin can create a partner that is part of their partnership' do
+    pa = create(:partnership_admin)
+    partner = create(:partner, :accessed_by_user => pa, :tags => [pa.tags.first])
+    assert_predicate partner, :valid?
+  end
 end


### PR DESCRIPTION
fixes #2171

Added a validation to partner model that check if user is a `partnership_admin` and prevents them creating partners outside their partnership. The other AC are already in place based on the work we did on `neighbourhood_admin` permissions.