### PR TITLE
Fix the tag editing capabilities of everyone on a partner

### DIFF
--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -6,6 +6,7 @@ module Admin
     before_action :set_partner, only: %i[show edit update destroy]
     before_action :set_tags, only: %i[new create edit]
     before_action :set_neighbourhoods, only: %i[new edit]
+    before_action :set_partner_tags_controller, only: %i[new edit]
 
     def index
       @partners = policy_scope(Partner).order({ updated_at: :desc }, :name).includes(:address)
@@ -124,6 +125,15 @@ module Admin
     end
 
     private
+
+    def set_partner_tags_controller
+      @partner_tags_controller =
+        if current_user.root? || (@partner.present? && current_user.admin_for_partner?(@partner.id))
+          'select2'
+        else
+          'partner-tags'
+        end
+    end
 
     def set_neighbourhoods
       if current_user.root? || (@partner.present? && current_user.admin_for_partner?(@partner.id))

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -17,11 +17,18 @@ module PartnersHelper
       end
   end
 
-  def options_for_partner_tags
-    policy_scope(Tag)
-      .select(:name, :type, :id)
-      .order(:name)
-      .map { |r| [r.name_with_type, r.id] }
+  def options_for_partner_tags(partner = nil)
+    options = policy_scope(Tag)
+              .select(:name, :type, :id)
+              .order(:name)
+              .map { |r| [r.name_with_type, r.id] }
+    return options unless partner
+
+    (options + partner&.tags&.map { |r| [r.name_with_type, r.id] }).uniq
+  end
+
+  def permitted_options_for_partner_tags
+    policy_scope(Tag).pluck(:id)
   end
 
   def partner_service_area_text(partner)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -18,3 +18,6 @@ application.register("select2", Select2Controller);
 
 import UserPartnersController from "./user_partners_controller.js";
 application.register("user-partners", UserPartnersController);
+
+import PartnerTagsController from "./partner_tags_controller.js";
+application.register("partner-tags", PartnerTagsController);

--- a/app/javascript/controllers/partner_tags_controller.js
+++ b/app/javascript/controllers/partner_tags_controller.js
@@ -29,7 +29,7 @@ export default class extends Controller {
 			) {
 				if (
 					!confirm(
-						"Removing this tag will remove this user from your partnership and you will no longer be able to access them.\n\n Are you sure you want to remove it?"
+						"Removing this tag will remove this partner from your partnership and you will no longer be able to access them, or any users that are partner admins for this partner, if they are not partner admins for anyone else in your partnership.\n\n Are you sure you want to remove it?"
 					)
 				) {
 					event.preventDefault();
@@ -38,7 +38,7 @@ export default class extends Controller {
 
 			if (!permittedValues.includes(Number(event.params.args.data.id))) {
 				alert(
-					"You can only remove partnership tags for partnerships you manage from a user."
+					"You can only remove partnership tags for partnerships that you manage."
 				);
 				event.preventDefault();
 			}

--- a/app/javascript/controllers/partner_tags_controller.js
+++ b/app/javascript/controllers/partner_tags_controller.js
@@ -1,0 +1,53 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+	static values = { permittedTags: [String] };
+
+	connect() {
+		const getSelectValues = (select) => {
+			return [...(select && select.options)].reduce((accumulator, option) => {
+				if (option.selected) {
+					return [...accumulator, Number(option.value || option.text)];
+				}
+				return accumulator;
+			}, []);
+		};
+
+		$(this.element).select2();
+
+		$(this.element).on("select2:unselecting", (event) => {
+			const selectedValues = getSelectValues(this.element);
+			const permittedValues = this.permittedTagsValue;
+
+			const selectedPermittedValues = permittedValues.filter((x) =>
+				selectedValues.includes(x)
+			);
+
+			if (
+				selectedPermittedValues.length <= 1 &&
+				permittedValues.includes(Number(event.params.args.data.id))
+			) {
+				if (
+					!confirm(
+						"Removing this tag will remove this user from your partnership and you will no longer be able to access them.\n\n Are you sure you want to remove it?"
+					)
+				) {
+					event.preventDefault();
+				}
+			}
+
+			if (!permittedValues.includes(Number(event.params.args.data.id))) {
+				alert(
+					"You can only remove partnership tags for partnerships you manage from a user."
+				);
+				event.preventDefault();
+			}
+		});
+
+		$(this.element).select2("close");
+	}
+
+	disconnect() {
+		$(this.element).select2("destroy");
+	}
+}

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -113,8 +113,11 @@
     <p>Partners may have up to 3 category tags.</p>
     <%= f.association :tags,
         label: false,
-        collection: options_for_partner_tags,
-        input_html: { class: 'form-check', data: { controller: "select2" } } %>
+        collection: options_for_partner_tags(@partner),
+        input_html: { class: 'form-check', data: { 
+          controller: @partner_tags_controller,
+          "partner-tags-permitted-tags-value": permitted_options_for_partner_tags 
+        } } %>
     <hr>
     <br>
     <div class="row">

--- a/test/helpers/partners_helper_test.rb
+++ b/test/helpers/partners_helper_test.rb
@@ -4,12 +4,33 @@ require 'test_helper'
 
 class PartnersHelperTest < ActionView::TestCase
   setup do
-    @partner = FactoryBot.create(:partner)
+    @root = create(:root)
+    @partner = create(:partner)
     @hoods = [
-      FactoryBot.create(:neighbourhood, name: 'alpha'),
-      FactoryBot.create(:neighbourhood, name: 'beta'),
-      FactoryBot.create(:neighbourhood, name: 'cappa')
+      create(:neighbourhood, name: 'alpha'),
+      create(:neighbourhood, name: 'beta'),
+      create(:neighbourhood, name: 'cappa')
     ]
+
+    @partnership_admin = create(:neighbourhood_admin)
+
+    @partner_in_neighbourhood = create(:partner)
+    @partner_in_neighbourhood.address.neighbourhood = @partnership_admin.neighbourhoods.first
+    @partner_in_neighbourhood.save!
+
+    @partner_servicing_neighbourhood = create(:partner)
+    @partner_servicing_neighbourhood.service_area_neighbourhoods << @partnership_admin.neighbourhoods.first
+    @partner_servicing_neighbourhood.save!
+
+    @partnership_tag = create(:partnership)
+    @other_partnership_tag = create(:partnership)
+    @other_partnership_tag_belonging_to_partner = create(:partnership)
+    @category_tag = create(:category)
+    @system_tag = create(:system_tag)
+    @facility_tag = create(:tag)
+
+    @partnership_admin.tags << @partnership_tag
+    @partner_in_neighbourhood.tags << @other_partnership_tag_belonging_to_partner
   end
 
   # testing partner_service_area_text
@@ -39,5 +60,45 @@ class PartnersHelperTest < ActionView::TestCase
     output = partner_service_area_text(@partner)
 
     assert_equal('alpha, beta and cappa', output)
+  end
+
+  test 'root user - options_for_partner_tags with no partner returns all allowed partners' do
+    def policy_scope(_scope)
+      Pundit.policy_scope!(@root, Tag)
+    end
+
+    expected = Tag.order(:name).select(:name, :type, :id).map { |r| [r.name_with_type, r.id] }
+
+    assert_equal(expected, options_for_partner_tags)
+  end
+
+  test 'root user - options_for_partner_tags with partner returns all allowed partners' do
+    def policy_scope(_scope)
+      Pundit.policy_scope!(@root, Tag)
+    end
+
+    expected = Tag.order(:name).select(:name, :type, :id).map { |r| [r.name_with_type, r.id] }
+
+    assert_equal(expected, options_for_partner_tags(@partner))
+  end
+
+  test 'partnership admin user - options_for_partner_tags with no partner returns neighbourhood partners' do
+    def policy_scope(_scope)
+      Pundit.policy_scope!(@partnership_admin, Tag)
+    end
+
+    expected = [@partnership_tag, @category_tag, @system_tag, @facility_tag].map { |r| [r.name_with_type, r.id] }
+
+    assert_equal(expected.sort, options_for_partner_tags.sort)
+  end
+
+  test 'partnership admin user - options_for_partner_tags with partner returns neighbourhood partners' do
+    def policy_scope(_scope)
+      Pundit.policy_scope!(@partnership_admin, Tag)
+    end
+
+    expected = [@partnership_tag, @other_partnership_tag_belonging_to_partner, @category_tag, @system_tag, @facility_tag].map { |r| [r.name_with_type, r.id] }
+
+    assert_equal(expected.sort, options_for_partner_tags(@partner_in_neighbourhood).sort)
   end
 end


### PR DESCRIPTION
fixes #2174

## Description

- ensures root users can still add/remove any tag
- ensures partner admins can still add any category or facility tag and remove any partnership tags
- allows partnership admins to edit tags without accidentally removing tags they can't see in the process
- prevents partnership admins from removing partnership tags that don't belong to them
- warns partnership admins if tag removal is likely to boot a partner out of their scope

## Implementation notes

I've used a bespoke select2 style controller for this again, like we did for controlling the partners that users admin for. This is mainly so there is instant and obvious feedback, and because we don't actually need to make these moves impossible at a database level, we just want to ensure admin users are fully aware of how certain actions will impact their reach. 

I've added tests for the new methods in the helper but not for the JS logic for the same reasons mentioned in the related PR.

(related PR [here](https://github.com/geeksforsocialchange/PlaceCal/pull/2120))