### PR TITLE
Hide untagged partner admins from partnership admins

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -130,7 +130,6 @@ class UserPolicy < ApplicationPolicy
 
       else
         user_neighbourhood_ids = user.owned_neighbourhood_ids
-
         scope
           .left_joins(partners: %i[address service_areas])
           .where(

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -130,6 +130,7 @@ class UserPolicy < ApplicationPolicy
 
       else
         user_neighbourhood_ids = user.owned_neighbourhood_ids
+
         scope
           .left_joins(partners: %i[address service_areas])
           .where(

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserPolicyTest < ActiveSupport::TestCase
+  setup do
+    @citizen = create(:citizen)
+    @root = create(:root)
+    @partner_admin_in_partnership = create(:partner_admin)
+    @partner_admin_in_neighbourhood = create(:partner_admin)
+    @partner_admin = create(:partner_admin)
+    @neighbourhood_admin = create(:neighbourhood_admin)
+    @partnership_tag = create(:partnership)
+
+    @partnership_admin = create(:neighbourhood_admin)
+    @partnership_admin.tags << @partnership_tag
+
+    @partner_admin_in_partnership.partners.first.tags << @partnership_tag
+    @partner_admin_in_partnership.partners.first.service_areas.create(
+      neighbourhood:  @partnership_admin.neighbourhoods.first
+    )
+    @partner_admin_in_partnership.save!
+
+    @partner_admin_in_neighbourhood.partners.first.address.neighbourhood = @neighbourhood_admin.neighbourhoods.first
+    @partner_admin_in_neighbourhood.partners.first.save!
+  end
+
+  def test_scope
+    assert_empty(permitted_records(@citizen, User))
+    assert_equal(permitted_records(@root, User), User.all)
+    assert_equal(permitted_records(@partnership_admin, User), [@partner_admin_in_partnership])
+    assert_equal(permitted_records(@neighbourhood_admin, User), [@partner_admin_in_neighbourhood])
+  end
+end


### PR DESCRIPTION
Fixes #2169 

## Description

- Shows partnership admins only users that are partner admins for partners within their scope
- Adds some user policy tests to assert the scope is behaving as it should