### PR TITLE
restrict partnership_admin access to calendars by neighbourhood AND partnership tag

### DIFF
--- a/app/controllers/admin/calendars_controller.rb
+++ b/app/controllers/admin/calendars_controller.rb
@@ -32,6 +32,7 @@ module Admin
     end
 
     def edit
+      authorize @calendar
       @versions = @calendar.recent_activity
       @partner = @calendar.partner
     end

--- a/app/policies/calendar_policy.rb
+++ b/app/policies/calendar_policy.rb
@@ -14,15 +14,12 @@ class CalendarPolicy < ApplicationPolicy
   end
 
   def edit?
-    index?
+    update?
   end
 
   def update?
     return true if user.root?
-    return true if user.partner_admin? && user.partner_ids.include?(record.partner_id)
-
-    # return true if user.neighbourhood_admin? && user.neighbourhoods.include?(record.address.neighbourhood)
-    index?
+    return true if scope.map(&:id).include? record.id
   end
 
   def import?
@@ -42,16 +39,32 @@ class CalendarPolicy < ApplicationPolicy
       return scope.all if user.root?
       return scope.none if !user.partner_admin? && !user.neighbourhood_admin?
 
-      neighbourhood_calendars =
-        Calendar.left_joins(partner: %i[address service_areas])
-                .where(
-                  '(addresses.neighbourhood_id in (:neighbourhood_ids) OR '\
-                  'service_areas.neighbourhood_id in (:neighbourhood_ids) OR '\
-                  'calendars.partner_id IN (:partner_ids))',
-                  neighbourhood_ids: user.owned_neighbourhood_ids,
-                  partner_ids: user.partner_ids
-                )
-                .distinct
+      if user.partnership_admin?
+        user_partnership_tag_ids = user.tags.map(&:id)
+        partnership_calendars =
+          Calendar.left_joins(partner: %i[address service_areas partnerships])
+                  .where(
+                    'calendars.partner_id IN (:partner_ids) OR
+                      ( partner_tags.tag_id IN (:tags) AND
+                       (addresses.neighbourhood_id in (:neighbourhood_ids) OR
+                      service_areas.neighbourhood_id in (:neighbourhood_ids)))',
+                    neighbourhood_ids: user.owned_neighbourhood_ids,
+                    partner_ids: user.partner_ids,
+                    tags: user_partnership_tag_ids
+                  )
+                  .distinct
+      else
+        neighbourhood_calendars =
+          Calendar.left_joins(partner: %i[address service_areas])
+                  .where(
+                    '(addresses.neighbourhood_id in (:neighbourhood_ids) OR '\
+                    'service_areas.neighbourhood_id in (:neighbourhood_ids) OR '\
+                    'calendars.partner_id IN (:partner_ids))',
+                    neighbourhood_ids: user.owned_neighbourhood_ids,
+                    partner_ids: user.partner_ids
+                  )
+                  .distinct
+      end
     end
   end
 end

--- a/app/policies/calendar_policy.rb
+++ b/app/policies/calendar_policy.rb
@@ -37,7 +37,7 @@ class CalendarPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       return scope.all if user.root?
-      return scope.none if !user.partner_admin? && !user.neighbourhood_admin?
+      return scope.none if !user.partner_admin? && !user.neighbourhood_admin? && !user.partnership_admin?
 
       if user.partnership_admin?
         user_partnership_tag_ids = user.tags.map(&:id)

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -23,7 +23,10 @@ FactoryBot.define do
     end
 
     factory(:partnership_admin) do
-      after(:create) { |user| user.tags = [create(:tag, type: 'Partnership')] }
+      after(:create) do |user|
+        user.tags = [create(:tag, type: 'Partnership')]
+        user.neighbourhoods = [create(:neighbourhood)]
+      end
     end
 
     factory(:neighbourhood_admin) do

--- a/test/policies/calendar_policy_test.rb
+++ b/test/policies/calendar_policy_test.rb
@@ -17,6 +17,11 @@ class CalendarPolicyTest < ActiveSupport::TestCase
     @neighbourhood_admin.neighbourhoods = [@partner_in_neighbourhood.address.neighbourhood]
     @neighbourhood_admin.neighbourhoods << @partner_servicing_neighbourhood.service_areas.first.neighbourhood
 
+    @partnership_admin = create(:partnership_admin)
+    @partnership_admin.neighbourhoods = [@partner_in_neighbourhood.address.neighbourhood]
+    @partnership_admin.neighbourhoods << @partner_servicing_neighbourhood.service_areas.first.neighbourhood
+    @partner_servicing_neighbourhood.tags = @partnership_admin.tags
+
     @partner_outside_neighbourhood = create(:partner)
     @partner_outside_neighbourhood.address.neighbourhood = create(:neighbourhood)
     @partner_outside_neighbourhood.save!
@@ -46,6 +51,16 @@ class CalendarPolicyTest < ActiveSupport::TestCase
     # neighbourhood admin can see calendars for partners with service areas and addresses in neighbourhood
     assert_equal(
       permitted_records(@neighbourhood_admin, Calendar).sort,
+      [@neighbourhood_cal, @servicing_neighbourhood_cal].sort
+    )
+    # partnership admin can see calendars for partners with service areas and addresses in neighbourhood
+    # if they have a corresponding partnership tag
+    assert_equal(
+      permitted_records(@partnership_admin, Calendar).sort,
+      [@servicing_neighbourhood_cal].sort
+    )
+    assert_not_equal(
+      permitted_records(@partnership_admin, Calendar).sort,
       [@neighbourhood_cal, @servicing_neighbourhood_cal].sort
     )
     # partner admin can only see calendars for partners they admin for


### PR DESCRIPTION
fixes #2170 

- adjust scope to account for tags
- adjust edit policy to prevent partnership_admins accessing calendars directly via URL