### PR TITLE
Add partner admins into scope

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -114,29 +114,35 @@ class UserPolicy < ApplicationPolicy
 
       elsif user.partnership_admin?
         user_neighbourhood_ids = user.owned_neighbourhood_ids
+        user_partner_ids = user.partners.map(&:id)
         user_partnership_tag_ids = user.tags.map(&:id)
 
         scope
           .left_joins(partners: %i[address service_areas partner_tags])
           .where(
-            'partner_tags.tag_id IN (:tags) AND
+            '(partner_tags.tag_id IN (:tags) AND
               (
                 addresses.neighbourhood_id IN (:ids) OR
                 service_areas.neighbourhood_id IN (:ids)
-              )',
+              )
+            ) OR partners.id IN (:partner_ids)',
             ids: user_neighbourhood_ids,
-            tags: user_partnership_tag_ids
+            tags: user_partnership_tag_ids,
+            partner_ids: user_partner_ids
           ).distinct
 
       else
         user_neighbourhood_ids = user.owned_neighbourhood_ids
+        user_partner_ids = user.partners.map(&:id)
 
         scope
           .left_joins(partners: %i[address service_areas])
           .where(
             'addresses.neighbourhood_id IN (:ids) OR
-            service_areas.neighbourhood_id IN (:ids)',
-            ids: user_neighbourhood_ids
+            service_areas.neighbourhood_id IN (:ids) OR
+            partners.id IN (:partner_ids)',
+            ids: user_neighbourhood_ids,
+            partner_ids: user_partner_ids
           ).distinct
       end
     end

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -30,5 +30,6 @@ class UserPolicyTest < ActiveSupport::TestCase
     assert_equal(permitted_records(@root, User), User.all)
     assert_equal(permitted_records(@partnership_admin, User), [@partner_admin_in_partnership])
     assert_equal(permitted_records(@neighbourhood_admin, User), [@partner_admin_in_neighbourhood])
+    assert_equal(permitted_records(@partner_admin, User), [@partner_admin])
   end
 end


### PR DESCRIPTION
Fixes #2169 
Fixes #2212

## Description

Adds in a missing part of the puzzle - allowing partner admins to also see all the users that admin for their partners, and in a way that works in conjunction with other admin types, so for example, if you're a neighbourhood admin for manchester and also a partner admin for a gardening group based in Liverpool, you can see every user that admins for a partner based in manchester as well as every user that admins for your gardening group.