### PR TITLE
improve error messages

### DIFF
--- a/app/javascript/controllers/user_partners_controller.js
+++ b/app/javascript/controllers/user_partners_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
 
 	connect() {
 		const confirmRemove =
-			"Removing this partner will remove this user from your view and you will no longer be able to access them.\n\nIf you want to keep the user in your view but still remove this partner from them, you'll need to make them an admin for another partner before removing them from this one.\n\nAre you sure you want to remove it?";
+			"Removing this partner will remove this user from your view and you will no longer be able to access them.\n\nIf you want to keep the user in your view but still remove this partner from them, you'll need to make them an admin for another partner before removing this one.\n\nAre you sure you want to remove it?";
 		const denyRemove =
 			"You can only remove partners that you manage from a user.";
 

--- a/app/javascript/controllers/user_partners_controller.js
+++ b/app/javascript/controllers/user_partners_controller.js
@@ -4,6 +4,11 @@ export default class extends Controller {
 	static values = { permittedPartners: [String] };
 
 	connect() {
+		const confirmRemove =
+			"Removing this partner will remove this user from your view and you will no longer be able to access them.\n\nIf you want to keep the user in your view but still remove this partner from them, you'll need to make them an admin for another partner before removing them from this one.\n\nAre you sure you want to remove it?";
+		const denyRemove =
+			"You can only remove partners that you manage from a user.";
+
 		const getSelectValues = (select) => {
 			return [...(select && select.options)].reduce((accumulator, option) => {
 				if (option.selected) {
@@ -26,19 +31,13 @@ export default class extends Controller {
 				selectedPermittedValues.length <= 1 &&
 				permittedValues.includes(Number(event.params.args.data.id))
 			) {
-				if (
-					!confirm(
-						"Removing this partner will remove this user from your neighbourhood.\n\n Are you sure you want to remove it? \n\n  If you want to keep the user in the neighbourhood but still remove this partner from them, you'll need to make them an admin for another partner in your neighbourhood."
-					)
-				) {
+				if (!confirm(confirmRemove)) {
 					event.preventDefault();
 				}
 			}
 
 			if (!permittedValues.includes(Number(event.params.args.data.id))) {
-				alert(
-					"You can only remove partners in your neighbourhood from a user."
-				);
+				alert(denyRemove);
 				event.preventDefault();
 			}
 		});


### PR DESCRIPTION
Fixes #2175 

## Description

Honestly I cannot believe that this just works! We managed to already design a controller for this that simply compares a list of permitted 'removable' users with the user being removed by the user, which very helpfully evaluates correctly who will disappear from your sight upon removal regardless of whether you are a partnership, neighbourhood, or partner admin. Wonderful!

So, to address the needs of this ticket, I went down a teeny rabbit hole to change the error message wording to reflect the role of each user, but on reflection decided it would be good to keep this very loosely coupled and made much more sense from a users' perspective to use generic language rather than couching the whole thing in current PlaceCal terminology, so I just rewrote it to work with any admin.