### PR TITLE
Add controllers to create action to prevent controller breaking if validation fails

### DIFF
--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -6,7 +6,7 @@ module Admin
     before_action :set_partner, only: %i[show edit update destroy clear_address]
     before_action :set_tags, only: %i[new create edit]
     before_action :set_neighbourhoods, only: %i[new edit]
-    before_action :set_partner_tags_controller, only: %i[new edit update]
+    before_action :set_partner_tags_controller, only: %i[new create edit update]
 
     def index
       @partners = policy_scope(Partner).order({ updated_at: :desc }, :name).includes(:address)


### PR DESCRIPTION
Fixes #2229


## Description

This js controller also needed to be used on create, which is the action used following a validation fail on new. Works now!