### PR TITLE
Prevent user creation without partners

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class UsersController < Admin::ApplicationController
     before_action :set_user, only: %i[edit update destroy]
     before_action :set_user_partners_controller, only: %i[new edit create]
-    before_action :validate_neighbourhood_relation, only: %i[create]
+    before_action :validate_partner_relation, only: %i[create]
 
     def profile
       authorize current_user, :profile?
@@ -136,10 +136,10 @@ module Admin
       end
     end
 
-    def validate_neighbourhood_relation
-      # we only allow the neighbourhood_admin to assign Partners from their own Neighbourhood so any ids here are proof of a relationship
+    def validate_partner_relation
+      # we only allow admins to assign partners they can see so any ids here are proof of a relationship
       return if current_user.root?
-      return unless current_user.neighbourhood_admin? && params[:user][:partner_ids].reject { |id| id == '' }.empty?
+      return unless params[:user][:partner_ids].reject { |id| id == '' }.empty?
 
       # we're about to refresh the page so save the users input
       @user = User.new(permitted_attributes(User))

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -17,7 +17,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def index?
-    user.root? || PartnerPolicy::Scope.new(user, Partner).resolve&.to_a&.any?
+    user.root? || can_see_any_partners?
   end
 
   def create?
@@ -146,5 +146,11 @@ class UserPolicy < ApplicationPolicy
           ).distinct
       end
     end
+  end
+
+  private
+
+  def can_see_any_partners?
+    PartnerPolicy::Scope.new(user, Partner).resolve&.to_a&.any?
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -17,7 +17,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def index?
-    user.root? || user.neighbourhood_admin? || user.partnership_admin?
+    user.root? || PartnerPolicy::Scope.new(user, Partner).resolve&.to_a&.any?
   end
 
   def create?

--- a/test/integration/admin/user_integration_test.rb
+++ b/test/integration/admin/user_integration_test.rb
@@ -109,8 +109,17 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'h3', 'Role'
   end
 
+  test "Neighbourhood admins with no partners in their neighbourhood cannot create users" do
+    sign_in @neighbourhood_admin
+    get new_admin_user_path(@citizen)
+    assert_response :redirect
+  end
+
   test "Create form has correct fields for neighbourhood admin" do
     sign_in @neighbourhood_admin
+    @partner.address.neighbourhood = @neighbourhood
+    @partner.save!
+
     get new_admin_user_path(@citizen)
     assert_response :success
 
@@ -147,6 +156,9 @@ class AdminUserIntegrationTest < ActionDispatch::IntegrationTest
 
   test "Edit form has correct fields for neighbourhood admin" do
     sign_in @neighbourhood_admin
+    @partner.address.neighbourhood = @neighbourhood
+    @partner.save!
+
     get edit_admin_user_path(@citizen)
     assert_response :success
 


### PR DESCRIPTION
Fixes #2227

## Description

This changes the user policy so that only admin users with partners can create users. In our current system the relationship between one user and another hinges entirely on the partners they can see, so if you can't see any partners, you can't see any users, and should not be able to create them.

I've also updated the user create form so that any admin user other than a root who can create a user is now forced to attach a partner to them in the process - this will prevent partner admins from being able to create rogue users, and simplifies the logic here.