### PR TITLE
ensure correct select2 js controller is invoked on a new partner with a failed validation

### DIFF
--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -6,7 +6,7 @@ module Admin
     before_action :set_partner, only: %i[show edit update destroy clear_address]
     before_action :set_tags, only: %i[new create edit]
     before_action :set_neighbourhoods, only: %i[new edit]
-    before_action :set_partner_tags_controller, only: %i[new edit update]
+    before_action :set_partner_tags_controller, only: %i[create new edit update]
 
     def index
       @partners = policy_scope(Partner).order({ updated_at: :desc }, :name).includes(:address)


### PR DESCRIPTION
fixes #2224 
fixes #2229 

Another controller hook miss for the select2 stimulus controller. 