### PR TITLE
Fix/revert datatables removal

### DIFF
--- a/app/javascript/src/datatable.js
+++ b/app/javascript/src/datatable.js
@@ -4,15 +4,6 @@ require("datatables.net-bs4")(window, $);
 // if you press the browser back button
 let dataTable = "";
 
-document.addEventListener("turbo:before-cache", function () {
-	if (dataTable !== null) {
-		$("#datatable").DataTable({
-			destroy: true,
-		});
-		dataTable = null;
-	}
-});
-
 document.addEventListener("turbo:load", function () {
 	try {
 		dataTable = $("#datatable").DataTable({

--- a/app/javascript/src/datatable.js
+++ b/app/javascript/src/datatable.js
@@ -4,6 +4,13 @@ require("datatables.net-bs4")(window, $);
 // if you press the browser back button
 let dataTable = "";
 
+document.addEventListener("turbo:before-cache", function () {
+	if (dataTable !== null && dataTable !== "") {
+		dataTable.destroy();
+		dataTable = null;
+	}
+});
+
 document.addEventListener("turbo:load", function () {
 	try {
 		dataTable = $("#datatable").DataTable({


### PR DESCRIPTION
This code is not working so I am putting it back the way it was before, with one more check to assert the variable is not `== ""` before calling destroy on it. This will hopefully prevent system tests from breaking quite so much!