### PR TITLE
Update the way partner moderation works to remove the sharing of emails

### DIFF
--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -64,9 +64,6 @@ module Admin
     def edit
       authorize @partner
       @sites = Site.sites_that_contain_partner(@partner)
-      return unless @partner.hidden
-
-      @mod_email = User.find(@partner.hidden_blame_id).email
     end
 
     def update

--- a/app/mailers/moderation_mailer.rb
+++ b/app/mailers/moderation_mailer.rb
@@ -3,7 +3,6 @@
 class ModerationMailer < ApplicationMailer
   def hidden_message(user, partner)
     @reason = partner.hidden_reason_html
-    @mod_email = User.find(partner.hidden_blame_id).email
     @partner_name = partner.name
     @user = user
 
@@ -13,7 +12,7 @@ class ModerationMailer < ApplicationMailer
   def hidden_staff_alert(partner)
     @partner = partner
     @reason = partner.hidden_reason_html
-    @mod_email = User.find(partner.hidden_blame_id).email
+    @moderator = User.find(partner.hidden_blame_id)
 
     mail(to: 'support@placecal.org', subject: 'A partner has been hidden from PlaceCal')
   end

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -10,7 +10,7 @@
             <%= @partner.hidden_reason_html.to_s.html_safe %>
           </div>
           <hr>
-          <p class="mb-0">Once you have fixed this issue get in touch with <a href="mailto:<%= @mod_email %>" class="alert-link"><%= @mod_email %></a> so they can make you public again. If you feel this was in error, or that this action is unreasonable, you can raise a support ticket with PlaceCal here: <a href="mailto:support@placecal.org" class="alert-link">support@placecal.org</a>.</p>
+          <p>Once you have fixed this issue get in touch with <a href="mailto:support@placecal.org">support@placecal.org</a> so that we can make you public again. If you feel this was in error, or that this action is unreasonable, you can raise a support ticket with PlaceCal here: <a href="mailto:support@placecal.org">support@placecal.org</a>.</p>
         </div>
       <% end  %>
     <% end  %>
@@ -139,7 +139,7 @@
         <div class="alert alert-light border" role="alert">
           <h2 class="alert-heading">Moderation</h2>
           <p>Hiding a partner is a last resort, and will remove them from all PlaceCal sites, not just yours. This is appropriate if a partner suddenly starts publishing things like spam or hate speech. In such cases, hiding a partner is the right action and we appreciate your help in keeping PlaceCal a safe place to be.</p>
-          <p>Hiding a partner does not delete them. It will notify both the partner and the PlaceCal team, using the information you fill out. The partner will receive your email address in order to discuss or arrange reinstatement.</p>
+          <p>Hiding a partner does not delete them. It will notify both the partner and the PlaceCal team, using the information you fill out.</p>
           <p>Please use the space below to explain the reason for hiding the partner and steps needed to re-instate them.</p>
           <%= f.input :hidden, class: "form-control" %>
           <%= f.input :hidden_reason, label: "Explanation for hiding",  class: "form-control" , input_html: { rows: 7 } %>

--- a/app/views/moderation_mailer/hidden_message.html.erb
+++ b/app/views/moderation_mailer/hidden_message.html.erb
@@ -4,8 +4,8 @@
 
 <p><%= greeting_text(@user) %>,</p>
 
-<p>Your partner (<%= @partner_name %>) has been hidden from PlaceCal for the following reasons.</p>
+<p>Your partner (<%= @partner.name %>, id: <%= @partner.id %>) has been hidden from PlaceCal for the following reasons:</p>
 
 <%= @reason.to_s.html_safe %>
 
-<p>Once you have fixed this issue get in touch with <a href="mailto:<%= @mod_email %>"><%= @mod_email %></a> so they can make you public again. If you feel this was in error, or that this action is unreasonable, you can raise a support ticket with PlaceCal here: <a href="mailto:support@placecal.org">support@placecal.org</a>.</p>
+<p>Once you have fixed this issue get in touch with <a href="mailto:support@placecal.org">support@placecal.org</a> so that we can make you public again. If you feel this was in error, or that this action is unreasonable, you can raise a support ticket with PlaceCal here: <a href="mailto:support@placecal.org">support@placecal.org</a>.</p>

--- a/app/views/moderation_mailer/hidden_staff_alert.html.erb
+++ b/app/views/moderation_mailer/hidden_staff_alert.html.erb
@@ -2,11 +2,13 @@
   <%= image_tag(image_url("logo.png"), height: '75') %>
 </div>
 
-<p>Copy of reason sent to Partners users,</p>
+<p>A partner (<%= @partner.name %>, id: <%= @partner.id %>) has been hidden by an admin user (<%= @moderator.email %>, id: <%= @moderator.id %>). Below is a copy of the email sent to that partner's admins, with the reason given for taking this action.</p>
 
-<p>Your partner (<%= @partner.name %>, id: <%= @partner.id %> ) has been hidden from PlaceCal for the following reasons.</p>
+<p>---------------------------</p>
+
+<p>Your partner (<%= @partner.name %>, id: <%= @partner.id %>) has been hidden from PlaceCal for the following reasons:</p>
 
 <%= @reason.to_s.html_safe %>
 
-<p>Once you have fixed this issue get in touch with <a href="mailto:<%= @mod_email %>"><%= @mod_email %></a> so they can make you public again. If you feel this was in error, or that this action is unreasonable, you can raise a support ticket with PlaceCal here: <a href="mailto:support@placecal.org">support@placecal.org</a>.</p>
+<p>Once you have fixed this issue get in touch with <a href="mailto:support@placecal.org">support@placecal.org</a> so that we can make you public again. If you feel this was in error, or that this action is unreasonable, you can raise a support ticket with PlaceCal here: <a href="mailto:support@placecal.org">support@placecal.org</a>.</p>
 


### PR DESCRIPTION
## Description

- Small edits to the email & UI info that is shown to partner admins if their partner is hidden to remove the details of the user who moderated them. Now they will have to email support@placecal.org to settle any problems that arise.
- Change to the email sent to support@placecal.org as a notification that this action has been taken to include the information about who took the action.