### PR TITLE
make place requirements clearer on partner forms

### DIFF
--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -37,9 +37,7 @@
     <br>
     <hr>
     <h2>Place</h2>
-    <p>
-    Partners need to be connected to <b>atleast one place</b>, this can either be the address of the building they opperate from or the area they deliver services too. If this is more than one place you can add multiple service areas.
-    </p>
+    <p>Partners need to be associated with at least one place. This can be a fixed address if they usually operate from one location, or a service area which can be a Ward or District. Keep this information as specific as possible – limited to where this partner actually runs events rather than the geographical spread of the people they are trying to reach.</p>
     <div id='address'>
       <div class="row">
         <div class="col-md-6">

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -36,11 +36,15 @@
     </div>
     <br>
     <hr>
-    <h2>Address</h2>
+    <h2>Place</h2>
+    <p>
+    Partners need to be connected to <b>atleast one place</b>, this can either be the address of the building they opperate from or the area they deliver services too. If this is more than one place you can add multiple service areas.
+    </p>
     <div id='address'>
       <div class="row">
         <div class="col-md-6">
          
+    <h3>Address</h3>
             <%= render 'address_fields',
 		       form: f,
 		       partner: @partner %>
@@ -59,52 +63,54 @@
           <% end %>
         </div>
         <div class="col-md-6">
-          <%= f.input :url, class: "form-control", label: 'Website address', placeholder: 'https://your-website.org' %>
-          <div class="form-group url optional facebook_link form-group-invalid">
-            <%= f.label :facebook_link %>
-            <div class="input-group">
-              <div class="input-group-prepend">
-                <div class="input-group-text">https://facebook.com/</div>
-              </div>
-              <%= f.input_field :facebook_link, class: "form-control", placeholder: 'FacebookPageName' %>
-              <%= f.error :facebook_link, class: 'invalid-feedback' %>
+          <h3>Service Areas</h3>
+          <p>If this partner delivers services outside the above address, such as a phone support line or outreach service, select them here.</p>
+          <div class="sites_neighbourhoods">
+            <%= f.simple_fields_for :service_areas do |neighbourhood| %>
+              <%= render 'service_area_fields', :f => neighbourhood %>
+            <% end %>
+            <div class="links">
+              <%= link_to_add_association 'Add Service Area', f, :service_areas, class: "btn btn-primary btn-sm" %>
             </div>
-          </div>
-          <div class="form-group url optional twitter_handle form-group-invalid">
-            <%= f.label :twitter_handle %>
-            <div class="input-group">
-              <div class="input-group-prepend">
-                <div class="input-group-text">@</div>
-              </div>
-              <%= f.input_field :twitter_handle, class: "form-control", placeholder: 'TwitterAccount' %>
-              <%= f.error :twitter_handle, class: 'invalid-feedback' %>
-            </div>
-          </div>
-          <div class="form-group url optional twitter_handle form-group-invalid">
-            <%= f.label :instagram_handle %>
-            <div class="input-group">
-              <div class="input-group-prepend">
-                <div class="input-group-text">@</div>
-              </div>
-              <%= f.input_field :instagram_handle, class: "form-control", placeholder: 'InstagramAccount' %>
-              <%= f.error :instagram_handle, class: 'invalid-feedback' %>
-            </div>
+            <br>
           </div>
         </div>
       </div>
     </div>
     <hr>
-    <h2>Service Areas</h2>
-    <p>If this partner delivers services outside the above address, such as a phone support line or outreach service, select them here.</p>
-    <div class="sites_neighbourhoods">
-      <%= f.simple_fields_for :service_areas do |neighbourhood| %>
-        <%= render 'service_area_fields', :f => neighbourhood %>
-      <% end %>
-      <div class="links">
-        <%= link_to_add_association 'Add Service Area', f, :service_areas, class: "btn btn-primary btn-sm" %>
+    <h2>Online</h2>
+      <%= f.input :url, class: "form-control", label: 'Website address', placeholder: 'https://your-website.org' %>
+      <div class="form-group url optional facebook_link form-group-invalid">
+        <%= f.label :facebook_link %>
+        <div class="input-group">
+          <div class="input-group-prepend">
+            <div class="input-group-text">https://facebook.com/</div>
+          </div>
+          <%= f.input_field :facebook_link, class: "form-control", placeholder: 'FacebookPageName' %>
+          <%= f.error :facebook_link, class: 'invalid-feedback' %>
+        </div>
       </div>
-      <br>
-    </div>
+      <div class="form-group url optional twitter_handle form-group-invalid">
+        <%= f.label :twitter_handle %>
+        <div class="input-group">
+          <div class="input-group-prepend">
+            <div class="input-group-text">@</div>
+          </div>
+          <%= f.input_field :twitter_handle, class: "form-control", placeholder: 'TwitterAccount' %>
+          <%= f.error :twitter_handle, class: 'invalid-feedback' %>
+        </div>
+      </div>
+      <div class="form-group url optional twitter_handle form-group-invalid">
+        <%= f.label :instagram_handle %>
+        <div class="input-group">
+          <div class="input-group-prepend">
+            <div class="input-group-text">@</div>
+          </div>
+          <%= f.input_field :instagram_handle, class: "form-control", placeholder: 'InstagramAccount' %>
+          <%= f.error :instagram_handle, class: 'invalid-feedback' %>
+        </div>
+      </div>
+        
     <br>
     <hr>
     <h2>Contact Information</h2>

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -55,7 +55,7 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', text: 'Website address'
     assert_select 'label', text: 'Twitter handle'
 
-    assert_select 'h2', text: 'Address'
+    assert_select 'h3', text: 'Address'
     assert_select 'label', text: 'Street address *'
     assert_select 'label', text: 'Street address 2'
     assert_select 'label', text: 'Street address 3'


### PR DESCRIPTION
fixes #2310 


I've moved the place based parts of the form together and added text explaining that one is required. Updated with honor's description for people using the admin UI. Hopefully this makes it a bit clearer.


![image](https://github.com/geeksforsocialchange/PlaceCal/assets/6824891/382ef5a5-321e-442c-8f49-a7c54817b5fa)


