### PR TITLE
WIP: research splitting out tag imputs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,7 +54,7 @@ class ApplicationController < ActionController::Base
 
     if site
       events = events.for_site(site)
-      events = events.with_tags(site.tags) if site.tags.any?
+      events = events.with_tags(site.partnership) if site.partnership.any?
     end
 
     events = events.in_place(place) if place

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,16 +6,16 @@ class PagesController < ApplicationController
 
   def home
     @neighbourhoods = Site.published.select do |site|
-      site.tags.none? { |tag| tag.type == 'Partnership' }
+      site.partnership.none? { |tag| tag.type == 'Partnership' }
     end
   end
 
   def find_placecal
     @neighbourhoods = Site.published.select do |site|
-      site.tags.none? { |tag| tag.type == 'Partnership' }
+      site.partnership.none? { |tag| tag.type == 'Partnership' }
     end
     @partnerships = Site.published.select do |site|
-      site.tags.any? { |tag| tag.type == 'Partnership' }
+      site.partnership.any? { |tag| tag.type == 'Partnership' }
     end
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -60,7 +60,7 @@ class Article < ApplicationRecord
     # site has no tags or locations.
 
     site_neighbourhood_ids = site.owned_neighbourhoods.pluck(:id)
-    site_tag_ids = site.tags.pluck(:id)
+    site_tag_ids = site.partnership.pluck(:id)
 
     # if site has no tags or neighbourhoods then just return nothing to caller
     return none if site_neighbourhood_ids.empty? && site_tag_ids.empty?

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -143,7 +143,7 @@ class Partner < ApplicationRecord
     query = Partner
 
     # if site has tags show only partners WITH those tags
-    site_tag_ids = site.tags.map(&:id)
+    site_tag_ids = site.partnership.map(&:id)
     if site_tag_ids.any?
       query = query
               .left_joins(:partner_tags)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -22,7 +22,7 @@ class Site < ApplicationRecord
   has_many :neighbourhoods, through: :sites_neighbourhoods
 
   has_many :sites_tag, dependent: :destroy
-  has_many :tags, through: :sites_tag
+  has_many :partnership, through: :sites_tag, source: :tag, class_name: 'Partnership'
 
   has_and_belongs_to_many :supporters
 

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -35,7 +35,7 @@ class SitePolicy < ApplicationPolicy
             .push(sites_neighbourhoods_attributes: %i[_destroy id neighbourhood_id relation_type],
                   sites_neighbourhood_attributes: %i[_destroy id neighbourhood_id relation_type])
 
-    root_attrs = %i[slug url site_admin_id tags sites_neighbourhoods]
+    root_attrs = %i[slug url site_admin_id partnership sites_neighbourhoods]
                  .push(tag_ids: [])
 
     return root_attrs + attrs if user.root?

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -143,13 +143,13 @@
     <div class="row">
       <div class="col-md-6">
         <p class="font-weight-light">(If selected) Only show partners which are members of these Partnerships</p>
-        <% if policy(@site).permitted_attributes.include? :tags %>
-          <%= f.association :tags,
+        <% if policy(@site).permitted_attributes.include? :partnership %>
+          <%= f.association :partnership,
                             label: false,
                             collection: options_for_tags,
                             input_html: { class: 'form-check', data: { controller: "select2" } } %>
         <% else %>
-          <%= f.association :tags,
+          <%= f.association :partnership,
                             disabled: true,
                             label: false,
                             collection: options_for_tags,

--- a/test/integration/admin/sites_integration_test.rb
+++ b/test/integration/admin/sites_integration_test.rb
@@ -106,7 +106,7 @@ class AdminSitesIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'site tags show up and display their type' do
-    @site.tags << @partnership_tag
+    @site.partnership << @partnership_tag
     @site_admin.tags << @partnership_tag
 
     sign_in(@site_admin)

--- a/test/integration/event_site_integration_test.rb
+++ b/test/integration/event_site_integration_test.rb
@@ -76,7 +76,7 @@ class EventsBySiteTagTest < ActionDispatch::IntegrationTest
       name: 'Tag',
       slug: 'tag',
       description: 'A tag about a thing',
-      type: 'Facility'
+      type: 'Partnership'
     )
 
     tag_site = Site.create!(
@@ -86,7 +86,7 @@ class EventsBySiteTagTest < ActionDispatch::IntegrationTest
       url: 'https://a-site.lvh.me',
       is_published: true
     )
-    tag_site.tags << tag
+    tag_site.partnership << tag
     tag_site.neighbourhoods << neighbourhood
 
     address = Address.create!(

--- a/test/integration/partners_integration_test.rb
+++ b/test/integration/partners_integration_test.rb
@@ -44,8 +44,8 @@ class PartnersIntegrationTest < ActionDispatch::IntegrationTest
     end
     @tagged_site.neighbourhoods << @neighbourhood4
 
-    @tag = create(:tag)
-    @tagged_site.tags << @tag
+    @tag = create(:partnership)
+    @tagged_site.partnership << @tag
 
     @tagged_site_partners.each do |partner|
       partner.tags << @tag

--- a/test/integration/sites_integration_test.rb
+++ b/test/integration/sites_integration_test.rb
@@ -58,7 +58,7 @@ class SitesIntegrationTest < ActionDispatch::IntegrationTest
 
   test 'show computer access card when partners are tagged for it' do
     tag = create(:tag, name: 'computers')
-    @site.tags << tag
+    @site.partnership << tag
 
     partner = build(:partner)
     partner.service_area_neighbourhoods << @neighbourhood
@@ -76,7 +76,7 @@ class SitesIntegrationTest < ActionDispatch::IntegrationTest
 
   test 'show public wifi card when partners are tagged for it' do
     tag = create(:tag, name: 'wifi')
-    @site.tags << tag
+    @site.partnership << tag
 
     partner = build(:partner)
     partner.service_area_neighbourhoods << @neighbourhood

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -125,12 +125,12 @@ class ArticleTest < ActiveSupport::TestCase
     assert_equal 5, found.count
   end
 
-  test '::for_site returns articles with site tags applied' do
-    tag = create(:tag)
+  test '::for_site returns articles with site.partnership applied' do
+    tag = create(:partnership)
     author = create(:root)
 
     site = create(:site)
-    site.tags << tag
+    site.partnership << tag
     site.validate!
 
     3.times do |n|
@@ -166,8 +166,8 @@ class ArticleTest < ActiveSupport::TestCase
       )
     end
 
-    tag = create(:tag)
-    site.tags << tag
+    tag = create(:partnership)
+    site.partnership << tag
 
     5.times do |n|
       article = Article.create!(

--- a/test/models/partner_site_scope_test.rb
+++ b/test/models/partner_site_scope_test.rb
@@ -138,12 +138,12 @@ class PartnerSiteScopeTest < ActiveSupport::TestCase
 
   test 'only finds partners with tags if site has tags' do
     neighbourhood = geocodable_neighbourhood_one
-    tag = create(:tag)
-    other_tag = create(:tag)
+    tag = create(:partnership)
+    other_tag = create(:partnership)
 
     site.neighbourhoods << neighbourhood
-    site.tags << tag
-    site.tags << other_tag
+    site.partnership << tag
+    site.partnership << other_tag
 
     # NOTE: we assume the relations between partners and sites via address
     #   neighbourhoods works and is tested elsewhere

--- a/test/models/partner_site_with_tag_scope_test.rb
+++ b/test/models/partner_site_with_tag_scope_test.rb
@@ -47,13 +47,13 @@ class PartnerSiteWithTagScopeTest < ActiveSupport::TestCase
   end
 
   test 'finds partners with tag' do
-    tag = create(:tag)
-    other_tag = create(:tag)
+    tag = create(:partnership)
+    other_tag = create(:partnership)
 
     neighbourhood = geocodable_neighbourhood_one
     site.neighbourhoods << neighbourhood
-    site.tags << tag
-    site.tags << other_tag
+    site.partnership << tag
+    site.partnership << other_tag
 
     4.times do |n|
       partner = create(:partner, name: "Partner #{n}", address: address_one)

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -32,7 +32,7 @@ class SitePartnerTest < ActiveSupport::TestCase
 
     tag = FactoryBot.create(:partnership)
     tag_site = FactoryBot.create(:site, name: 'tag site')
-    tag_site.tags << tag
+    tag_site.partnership << tag
     tag_site.neighbourhoods << address_neighbourhood
 
     partner = FactoryBot.create(:partner)


### PR DESCRIPTION
research for #2066

OK I picked the simplest option to implement as a test run: sites only have partnerships.

 I've got it to a state where simply scoping the tags down from the full set to partnerships doesn't reduce the amount of failing tests (55 initially, down to about 15 now) but starts to introduce new one.  eg.
 
 ```ruby
  test 'show computer access card when partners are tagged for it' do
    tag = create(:tag, name: 'computers')
    @site.partnership << tag

    partner = build(:partner)
    partner.service_area_neighbourhoods << @neighbourhood
    partner.tags << tag
    partner.save!

    get 'http://hulme.lvh.me'

    assert_select '.help__computer_access'

    url = partner_path(partner)
    selector = ".help__computer_access a[href='#{url}']"
    assert_select selector
  end

  test 'show public wifi card when partners are tagged for it' do
    tag = create(:tag, name: 'wifi')
    @site.partnership << tag

    partner = build(:partner)
    partner.service_area_neighbourhoods << @neighbourhood
    partner.tags << tag
    partner.save!

    get 'http://hulme.lvh.me'
    assert_select '.help__free_public_wifi'

    url = partner_path(partner)
    selector = ".help__free_public_wifi a[href='#{url}']"
    assert_select selector
  end
```

[view code in context](https://github.com/geeksforsocialchange/PlaceCal/blob/4399ac0e5f48335dbb9f4b510d3524d8b1f2d082/test/integration/sites_integration_test.rb#L59-L92)

This is the point where we will start to need to reconsider the underlying implementation rather than just what is happening with the admin UI. For example it's not clear to me why a `Site` would be receiving facility tags.

Given that we have 3 other places to implement this and the Partners is the most complicated involving some custom validation based on the current UI I think this is the best place to stop and open up discussion for next steps.