### PR TITLE
Rake task that lists and removes duplicate events

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -186,6 +186,43 @@ namespace :db do
 
     $stdout.puts "Restoring DB dump file #{filename} to local dev DB. (May take a while.) ..."
     puts `dropdb placecal_dev && createdb placecal_dev && pg_restore -d placecal_dev #{filename}`
+
+    if $CHILD_STATUS.success?
+      $stdout.puts '... done.'
+    else
+      warn 'Failed to restore DB dump to local dev DB!'
+      warn 'Please manually check to see whether local DB dev still exists.'
+      exit
+    end
+  end
+
+  desc 'a better version of db:restore_local'
+  task restore_local_2: :environment do
+    # this does the same thing as the previous task but in a less hacky way by
+    #    utilising rails tasks and configurations.
+
+    filename = ENV.fetch(DB_DUMP_ENV_KEY, nil)
+    raise "Could not find #{filename} file!" unless File.exist? filename
+
+    $stdout.puts "Restoring DB dump file #{filename} to local dev DB. (May take a while.) ..."
+
+    db_config = Rails.configuration.database_configuration[Rails.env]
+
+    begin
+      Rake::Task['db:drop'].invoke
+
+    rescue ActiveRecord::ProtectedEnvironmentError
+      # https://github.com/rails/rails/issues/34041#issuecomment-426097998
+      puts "*** DB drop failed, you may have pending migrations ***\n\n"
+      raise
+    end
+
+    Rake::Task['db:create'].invoke
+
+    command = "pg_restore -h #{db_config['host']} -p #{db_config['port']} -d #{db_config['database']} -U #{db_config['username']} #{filename}"
+    puts "running: #{command}"
+    system command
+
     if $CHILD_STATUS.success?
       $stdout.puts '... done.'
     else
@@ -286,6 +323,40 @@ namespace :db do
     end
   end
 
+  desc 'scrubs events that have the same UID and dtstart, pass in `true` if you want those events deleted'
+  task :find_and_clean_duplicate_events, %i[destroy_arg] => :environment do |_t, args|
+    destroy = to_boolean(args[:destroy_arg])
+    if destroy
+      puts 'WARNING! you have selected DESTROY, this is not reversible'
+      sleep 5
+    end
+
+    bad_events = Event.group(:uid, :dtstart).count.keep_if { |_, count| count > 1 }
+    puts "Found #{bad_events.count} events with duplicate IDs"
+
+    bad_events.each do |fields, _|
+      uid, dtstart = fields
+
+      event_cluster = Event.where(uid: uid)
+
+      start_date = event_cluster.each_with_object({}) do |event, out|
+        out[event.dtstart] = out[event.dtstart].to_i + 1
+      end
+
+      bad_dates = start_date.keep_if { |_date, count| count > 1 }
+      next if bad_dates.empty?
+
+      bad_dates.each do |date, _count|
+        bad_event_cluster = event_cluster.where(dtstart: date).order(updated_at: :desc).offset(1)
+
+        puts "#{uid} has duplicate count: #{bad_event_cluster.count} for date #{date}"
+        puts "  #{bad_event_cluster.all.map(&:id).to_json}"
+
+        bad_event_cluster.destroy_all if destroy
+      end
+    end
+  end
+
   private
 
   def ensure_format(format)
@@ -334,5 +405,9 @@ namespace :db do
           ActiveRecord::Base.connection_config[:host],
           ActiveRecord::Base.connection_config[:database],
           ActiveRecord::Base.connection_config[:username]
+  end
+
+  def to_boolean(value)
+    (@boolean ||= ActiveModel::Type::Boolean.new).cast value
   end
 end


### PR DESCRIPTION
Closes #2287 

There was a long investigation in to how the event importer operates when dealing with duplicates but as far as can be figured out there is a discrepancy between how the Event model defines a duplicate and how the EventResolver defines a duplicate. The Event model validation also only runs on save and not update. 

I think it may have to do with some odd data we get from the remote source: like if a user moves an event around on their calendar. But this would require finding or recreating the conditions and stepping through the EventResolver.

In the interim this PR provides a rake task `rails db:find_and_clean_duplicate_events[]` which will list and remove duplicate events. When run with no arguments it only shows you something like
```
Found 5 events with duplicate IDs
37r53ov39h6m1n948thtpp61ro@google.com has duplicate count: 1 for date 2024-03-27 11:00:00 +0000
  [377603]
76ma3pl0c9mqgc6rcs5nmea55o@google.com has duplicate count: 2 for date 2022-10-18 00:00:00 +0100
  [317332,317333]
5nesefucdvre4pq56f4u2d18e4@google.com has duplicate count: 2 for date 2024-03-15 17:00:00 +0000
  [367369,368285]
3nmemfvb3mnclgsa8cqt2cdauo@google.com has duplicate count: 1 for date 2024-07-20 10:00:00 +0100
  [355460]
4ao2d36r8ngo5s04i4v7dhf7fv_R20210809T180000@google.com has duplicate count: 1 for date 2021-12-13 19:00:00 +0000
  [308662]
```

But when run like `rails db:find_and_clean_duplicate_events[true]` it also destroys the duplicates.

This rake task could be run every day or hour or something.

## A better database snapshot restore

Have also implemented `rails db:restore_local_2` that uses more railsy actions, so instead of calling `dropdb` directly it invokes `rails db:drop` and it also reads all its configuration arguments from the rails configuration object, rather than having them fixed in code.

I didn't want to unilaterally replace `db:restore_local` without first getting some feedback from other developers.

