### PR TITLE
seperate out tag inputs on partners

### DIFF
--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -71,8 +71,6 @@ module Admin
 
       mutated_params = permitted_attributes(@partner)
 
-      before = @partner.hidden
-
       @partner.accessed_by_user = current_user
 
       # prevent someone trying to add the same service_area twice by mistake and causing a crash
@@ -86,9 +84,6 @@ module Admin
       hidden_in_this_edit = mutated_params[:hidden] == '1' && !@partner.hidden
 
       mutated_params[:hidden_blame_id] = current_user.id  if hidden_in_this_edit
-      Rails.logger.debug '0' * 80
-      Rails.logger.debug mutated_params
-      Rails.logger.debug '0' * 80
 
       if @partner.update(mutated_params)
         # have to redirect on associated service area errors or form breaks

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -27,8 +27,15 @@ module PartnersHelper
     (options + partner&.tags&.map { |r| [r.name_with_type, r.id] }).uniq
   end
 
+  def options_for_partner_partnerships
+    options = policy_scope(Partnership)
+              .select(:name, :type, :id)
+              .order(:name)
+              .map { |r| [r.name, r.id] }
+  end
+
   def permitted_options_for_partner_tags
-    policy_scope(Tag).pluck(:id)
+    policy_scope(Partnership).pluck(:id)
   end
 
   def partner_service_area_text(partner)

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -17,16 +17,6 @@ module PartnersHelper
       end
   end
 
-  def options_for_partner_tags(partner = nil)
-    options = policy_scope(Tag)
-              .select(:name, :type, :id)
-              .order(:name)
-              .map { |r| [r.name_with_type, r.id] }
-    return options unless partner
-
-    (options + partner&.tags&.map { |r| [r.name_with_type, r.id] }).uniq
-  end
-
   def options_for_partner_partnerships
     options = policy_scope(Partnership)
               .select(:name, :type, :id)

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class Partnership < Tag
+  scope :users_partnerships, lambda { |user|
+                               return Partnership.all if user.role == 'root' && !user.partnership_admin?
+
+                               user.partnerships
+                             }
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -29,6 +29,8 @@ class Tag < ApplicationRecord
             }
   validate :check_editable_fields
 
+  # TECHDEBT
+  # we should look to work this out of the system as we now cover this with a scope on Partnership
   scope :users_tags, lambda { |user|
                        return Tag.all if user.role == 'root' && !user.partnership_admin?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
 
   has_many :tags_users, dependent: :destroy
   has_many :tags, through: :tags_users
+  has_many :partnerships, through: :tags_users, source: :tag, class_name: 'Partnership'
 
   validates :email,
             presence: true,

--- a/app/policies/partner_policy.rb
+++ b/app/policies/partner_policy.rb
@@ -54,12 +54,13 @@ class PartnerPolicy < ApplicationPolicy
              { calendars_attributes: %i[id name source strategy place_id partner_id _destroy],
                address_attributes: %i[id street_address street_address2 street_address3 city postcode],
                service_areas_attributes: %i[id neighbourhood_id _destroy],
-               tag_ids: [] }]
+               tag_ids: [], category_ids: [], facility_ids: []  }]
 
     attrs << :slug if user.root?
     attrs << :hidden if user.root? || user.neighbourhood_admin? || user.partnership_admin?
     attrs << :hidden_reason if user.root? || user.neighbourhood_admin? || user.partnership_admin?
     attrs << :hidden_blame_id  if user.root? || user.neighbourhood_admin? || user.partnership_admin?
+    attrs << { partnership_ids: [] }  if user.root? || user.partnership_admin?
     attrs
   end
 

--- a/app/policies/partnership_policy.rb
+++ b/app/policies/partnership_policy.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class PartnershipPolicy < TagPolicy
+  class Scope < Scope
+    def resolve
+      Partnership.users_partnerships(user)
+    end
+  end
 end

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -153,7 +153,6 @@
     <%= f.association :facilities,
         label: "Facilities",
         hint:"What infrastructure does this partner provide.",
-        collection: options_for_partner_partnerships(),
         collection: Facility.all,
         input_html: { class: 'form-check', data: { 
           controller: 'select2',

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -140,12 +140,28 @@
     <h2>Tags</h2>
     <p>What partnerships, categories and facilities does this partner have or belong to?</p>
     <p>Partners may have up to 3 category tags.</p>
-    <%= f.association :tags,
-        label: false,
-        collection: options_for_partner_tags(@partner),
+    <% if  current_user.partnership_admin? || current_user.root? %>
+      <%= f.association :partnerships,
+          label: "Partnerships",
+          collection: options_for_partner_partnerships(),
+          input_html: { class: 'form-check', data: { 
+            controller: 'partner-tags',
+            "partner-tags-permitted-tags-value": permitted_options_for_partner_tags 
+          } } %>
+      <hr>
+    <% end %>
+    <%= f.association :facilities,
+        label: "Facilities",
+        collection: Facility.all,
         input_html: { class: 'form-check', data: { 
-          controller: @partner_tags_controller,
-          "partner-tags-permitted-tags-value": permitted_options_for_partner_tags 
+          controller: 'select2',
+        } } %>
+    <hr>
+    <%= f.association :categories,
+        label: "Categories",
+        collection: Category.all,
+        input_html: { class: 'form-check', data: { 
+          controller: 'select2',
         } } %>
     <hr>
     <% unless @partner.new_record? %>

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -138,11 +138,11 @@
     </div>
     <hr>
     <h2>Tags</h2>
-    <p>What partnerships, categories and facilities does this partner have or belong to?</p>
-    <p>Partners may have up to 3 category tags.</p>
+    <p>What other associations does this partner have apart from place.</p>
     <% if  current_user.partnership_admin? || current_user.root? %>
       <%= f.association :partnerships,
           label: "Partnerships",
+          hint:"Which communities of interest should this partner appear on",
           collection: options_for_partner_partnerships(),
           input_html: { class: 'form-check', data: { 
             controller: 'partner-tags',
@@ -152,6 +152,8 @@
     <% end %>
     <%= f.association :facilities,
         label: "Facilities",
+        hint:"What infrastructure does this partner provide.",
+        collection: options_for_partner_partnerships(),
         collection: Facility.all,
         input_html: { class: 'form-check', data: { 
           controller: 'select2',
@@ -159,6 +161,7 @@
     <hr>
     <%= f.association :categories,
         label: "Categories",
+        hint:"Partners may have up to 3 category tags, the public will be able to filter by these",
         collection: Category.all,
         input_html: { class: 'form-check', data: { 
           controller: 'select2',

--- a/test/helpers/partners_helper_test.rb
+++ b/test/helpers/partners_helper_test.rb
@@ -62,43 +62,43 @@ class PartnersHelperTest < ActionView::TestCase
     assert_equal('alpha, beta and cappa', output)
   end
 
-  test 'root user - options_for_partner_tags with no partner returns all allowed partners' do
+  test 'root user - options_for_partner_partnerships with no partner returns all allowed partners' do
     def policy_scope(_scope)
-      Pundit.policy_scope!(@root, Tag)
+      Pundit.policy_scope!(@root, Partnership)
     end
 
-    expected = Tag.order(:name).select(:name, :type, :id).map { |r| [r.name_with_type, r.id] }
+    expected = Partnership.order(:name).select(:name, :type, :id).map { |r| [r.name, r.id] }
 
-    assert_equal(expected, options_for_partner_tags)
+    assert_equal(expected, options_for_partner_partnerships)
   end
 
-  test 'root user - options_for_partner_tags with partner returns all allowed partners' do
+  test 'root user - options_for_partner_partnerships with partner returns all allowed partners' do
     def policy_scope(_scope)
-      Pundit.policy_scope!(@root, Tag)
+      Pundit.policy_scope!(@root, Partnership)
     end
 
-    expected = Tag.order(:name).select(:name, :type, :id).map { |r| [r.name_with_type, r.id] }
+    expected = Partnership.order(:name).select(:name, :type, :id).map { |r| [r.name, r.id] }
 
-    assert_equal(expected, options_for_partner_tags(@partner))
+    assert_equal(expected, options_for_partner_partnerships)
   end
 
-  test 'partnership admin user - options_for_partner_tags with no partner returns neighbourhood partners' do
+  test 'partnership admin user - options_for_partner_partnerships with no partner returns neighbourhood partners' do
     def policy_scope(_scope)
-      Pundit.policy_scope!(@partnership_admin, Tag)
+      Pundit.policy_scope!(@partnership_admin, Partnership)
     end
 
-    expected = [@partnership_tag, @category_tag, @system_tag, @facility_tag].map { |r| [r.name_with_type, r.id] }
+    expected = [@partnership_tag].map { |r| [r.name, r.id] }
 
-    assert_equal(expected.sort, options_for_partner_tags.sort)
+    assert_equal(expected.sort, options_for_partner_partnerships.sort)
   end
 
-  test 'partnership admin user - options_for_partner_tags with partner returns neighbourhood partners' do
+  test 'partnership admin user - options_for_partner_partnerships with partner returns neighbourhood partners' do
     def policy_scope(_scope)
-      Pundit.policy_scope!(@partnership_admin, Tag)
+      Pundit.policy_scope!(@partnership_admin, Partnership)
     end
 
-    expected = [@partnership_tag, @other_partnership_tag_belonging_to_partner, @category_tag, @system_tag, @facility_tag].map { |r| [r.name_with_type, r.id] }
+    expected = [@partnership_tag].map { |r| [r.name, r.id] }
 
-    assert_equal(expected.sort, options_for_partner_tags(@partner_in_neighbourhood).sort)
+    assert_equal(expected.sort, options_for_partner_partnerships.sort)
   end
 end

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -16,8 +16,6 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     @neighbourhood_admin = create(:citizen)
     @neighbourhood_admin.neighbourhoods = [@partner.address.neighbourhood]
 
-    @tag = create(:tag, type: 'Category')
-
     host! 'admin.lvh.me'
   end
 
@@ -93,20 +91,6 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_select 'a#destroy-partner', 'Delete Partner'
-  end
-
-  test 'Partner has owned tag preselected' do
-    @neighbourhood_region_admin.tags << @tag
-
-    sign_in @neighbourhood_region_admin
-
-    get new_admin_partner_path(@partner)
-    assert_response :success
-
-    tag_options = assert_select 'div.partner_tags option', count: 1, text: @tag.name_with_type
-
-    tag = tag_options.first
-    assert tag.attributes.key?('selected')
   end
 
   test 'Partner create form gives feedback on bad image selection' do

--- a/test/system/admin/partner_test.rb
+++ b/test/system/admin/partner_test.rb
@@ -11,7 +11,9 @@ class AdminPartnerTest < ApplicationSystemTestCase
     create_default_site
     @root_user = create :root, email: 'root@lvh.me'
     @partner = create :ashton_partner
-    @tag = create :tag
+    @partnership = create :partnership
+    @category = create :category
+    @facility = create :tag
     @neighbourhood_one = neighbourhoods[1].to_s.tr('w', 'W')
     @neighbourhood_two = neighbourhoods[2].to_s.tr('w', 'W')
 
@@ -40,9 +42,18 @@ class AdminPartnerTest < ApplicationSystemTestCase
     assert_select2_single @neighbourhood_one, service_areas[0]
     assert_select2_single @neighbourhood_two, service_areas[1]
 
-    tags = select2_node 'partner_tags'
-    select2 @tag.name, xpath: tags.path
-    assert_select2_multiple [@tag.name_with_type], tags
+    partnerships = select2_node 'partner_partnerships'
+    select2 @partnership.name, xpath: partnerships.path
+    assert_select2_multiple [@partnership.name], partnerships
+
+    categories = select2_node 'partner_categories'
+    select2 @category.name, xpath: categories.path
+    assert_select2_multiple [@category.name], categories
+
+    facilities = select2_node 'partner_facilities'
+    select2 @facility.name, xpath: facilities.path
+    assert_select2_multiple [@facility.name], facilities
+
     click_button 'Save Partner'
 
     click_link 'Partners'
@@ -50,9 +61,19 @@ class AdminPartnerTest < ApplicationSystemTestCase
 
     click_link @partner.name
 
-    tags = select2_node 'partner_tags'
+    partnerships = select2_node 'partner_partnerships'
     find_element_and_retry_if_not_found do
-      assert_select2_multiple [@tag.name_with_type], tags
+      assert_select2_multiple [@partnership.name], partnerships
+    end
+
+    categories = select2_node 'partner_categories'
+    find_element_and_retry_if_not_found do
+      assert_select2_multiple [@category.name], categories
+    end
+
+    facilities = select2_node 'partner_facilities'
+    find_element_and_retry_if_not_found do
+      assert_select2_multiple [@facility.name], facilities
     end
 
     service_areas = all_cocoon_select2_nodes 'sites_neighbourhoods'
@@ -106,13 +127,13 @@ class AdminPartnerTest < ApplicationSystemTestCase
     await_datatables
 
     click_link @partner.name
-    find :css, '.partner_tags', wait: 100
+    find :css, '.partner_partnerships', wait: 100
 
     # very specific bug in the view template here: if opening times has malformed data
     #   it will cause problems for the javascript that runs the partner tags selector
     #   (in the browser). so we verify the select2 code has worked by seeing if it has
     #   correctly done its thing to the tag selector
-    assert_selector '.partner_tags ul.select2-selection__rendered'
+    assert_selector '.partner_partnerships ul.select2-selection__rendered'
   end
 
   test 'adding dupplicate service_areas to an existing partner does not crash' do


### PR DESCRIPTION
fixes #2333

-  there is an input for category tags
- category input has validation for max 3 selected
- there is an input for partnerships
- partnership input has JS validation that warns a user about removing a tag from a partner
- there is an input for facility tags

## notes

I have left as much of the `tag` associations in place so that we didn't need to restructure much of placecal, the forms add to the respective STI options and that's picked up by the tags. I did a small amount of tidying of the helper function file pointed tests in it's direction but I stopped short of ripping out the partnership scoping on the tag model, that should probably done after all the other entities have been shifted over. I think in the future I would avoid STI as it has created a lot of tight coupling between things that aren't really related.

I expect people will have opinions on the exact wording of the helper text in the UI but I tried to put something sensible in as a jumping off point.


![image](https://github.com/geeksforsocialchange/PlaceCal/assets/6824891/9676dc20-413c-4c4a-9a07-d0fa899c9b28)

