### PR TITLE
Updated rollbar gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,7 +375,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.6)
-    rollbar (3.3.0)
+    rollbar (3.5.2)
     rubocop (1.62.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)


### PR DESCRIPTION
Closes #2367

Bit of a rabbit hole this one: when visiting unknown routes like `/foofoofoo` or `/styleguide/styleguide/event` the server would 500 with no backtrace (probably because there was an error in the error handler). 

Turns out the rollbar gem (v3.3.0) likely had a bug in it that is fixed in the latest version (v3.5.2)