### PR TITLE
Fix of admin show calendar page with notices

### DIFF
--- a/app/views/admin/calendars/show.html.erb
+++ b/app/views/admin/calendars/show.html.erb
@@ -37,17 +37,13 @@
     <h2>Important Notices</h2>
     <% if @calendar.notices.present? %>
       <p>The following events could not be imported due to invalid data: </p>
-      <ul class="pl-3">
+      <ul id="calendar-notices" class="pl-3">
         <% @calendar.notices.each do |notice| %>
-          <li>
-            <%= content_tag :strong, notice["event"]["dtstart"].to_date.strftime('%e %b %Y') %>.
-            <%= content_tag :em, notice["event"]["summary"] %>.
-            <%= notice["errors"].join(", ")%>
-          </li>
+          <li><%= notice %></li>
         <% end %>
       </ul>
     <% else %>
-      No notices to show
+      <p>No notices to show</p>
     <% end %>
   </div>
 </div>

--- a/test/controllers/admin/calendars_controller_test.rb
+++ b/test/controllers/admin/calendars_controller_test.rb
@@ -147,4 +147,28 @@ class Admin::CalendarControllerTest < ActionDispatch::IntegrationTest
 
     assert_select 'ul#calendar-notices li', count: 3
   end
+
+  test 'reporting calendar notices on admin show page' do
+    calendar = VCR.use_cassette(:calendar_for_outlook) do
+      create(:calendar,
+             source: 'https://outlook.office365.com/owa/calendar/8a1f38963ce347bab8cfe0d0d8c5ff16@thebiglifegroup.com/5c9fc0f3292e4f0a9af20e18aa6f17739803245039959967240/calendar.ics',
+             partner: @partner,
+             place: @partner)
+    end
+
+    calendar.calendar_state = 'idle'
+    calendar.notices = [
+      'Notice 1',
+      'Notice 2',
+      'Notice 3'
+    ]
+    calendar.save!
+
+    sign_in @root
+
+    get admin_calendar_path(calendar)
+    assert_predicate response, :successful?
+
+    assert_select 'ul#calendar-notices li', count: 3
+  end
 end


### PR DESCRIPTION
Closes #2328 

When a calendar has notices and an admin visits the "show calendar" page, those notices are displayed like how they show on the "edit calendar" page.