### PR TITLE
Queue new calendars for immediate import

### DIFF
--- a/app/controllers/admin/calendars_controller.rb
+++ b/app/controllers/admin/calendars_controller.rb
@@ -42,7 +42,11 @@ module Admin
       authorize @calendar
 
       if @calendar.save
-        flash[:success] = 'Successfully created new calendar'
+        if @calendar.queue_for_import! true, DateTime.now
+          flash[:success] = 'New calendar created and queued for importing. Please check back in a few minutes.'
+        else
+          flash[:danger] = 'Successfully created new calendar but there was a problem importing events.'
+        end
         redirect_to edit_admin_calendar_path(@calendar)
       else
         flash.now[:danger] = 'Calendar did not save'

--- a/app/controllers/admin/calendars_controller.rb
+++ b/app/controllers/admin/calendars_controller.rb
@@ -42,12 +42,8 @@ module Admin
       authorize @calendar
 
       if @calendar.save
-        if @calendar.queue_for_import! true, DateTime.now
-          flash[:success] = 'New calendar created and queued for importing. Please check back in a few minutes.'
-        else
-          flash[:danger] = 'Successfully created new calendar but there was a problem importing events.'
-        end
         redirect_to edit_admin_calendar_path(@calendar)
+        flash[:success] = 'New calendar created and queued for importing. Please check back in a few minutes.'
       else
         flash.now[:danger] = 'Calendar did not save'
         render 'new', status: :unprocessable_entity
@@ -56,7 +52,7 @@ module Admin
 
     def update
       if @calendar.update(calendar_params)
-        flash[:success] = 'Calendar successfully updated'
+        flash[:success] = 'Calendar successfully updated and queued for importing.'
         redirect_to edit_admin_calendar_path(@calendar)
       else
         flash.now[:danger] = 'Calendar did not save'

--- a/app/controllers/admin/calendars_controller.rb
+++ b/app/controllers/admin/calendars_controller.rb
@@ -52,7 +52,7 @@ module Admin
 
     def update
       if @calendar.update(calendar_params)
-        flash[:success] = 'Calendar successfully updated and queued for importing.'
+        flash[:success] = 'Calendar successfully updated'
         redirect_to edit_admin_calendar_path(@calendar)
       else
         flash.now[:danger] = 'Calendar did not save'

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -24,7 +24,7 @@ class Calendar < ApplicationRecord
 
   before_save :update_notice_count
 
-  after_save :automatically_queue_calendar
+  after_create :automatically_queue_calendar
 
   # Output the calendar's name when it's requested as a string
   alias_attribute :to_s, :name
@@ -120,7 +120,7 @@ class Calendar < ApplicationRecord
   end
 
   def automatically_queue_calendar
-    queue_for_import! true, DateTime.now
+    queue_for_import! false, DateTime.now
   end
 
   #

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -24,6 +24,8 @@ class Calendar < ApplicationRecord
 
   before_save :update_notice_count
 
+  after_save :automatically_queue_calendar
+
   # Output the calendar's name when it's requested as a string
   alias_attribute :to_s, :name
 
@@ -115,6 +117,10 @@ class Calendar < ApplicationRecord
   # internal model function
   def update_notice_count
     self.notice_count = (notices || []).count if notices_changed?
+  end
+
+  def automatically_queue_calendar
+    queue_for_import! true, DateTime.now
   end
 
   #

--- a/test/models/calendar_state_test.rb
+++ b/test/models/calendar_state_test.rb
@@ -103,7 +103,8 @@ class CalendarStateTest < ActiveSupport::TestCase
   # error'd
   test 'can be tested for' do
     VCR.use_cassette(:import_test_calendar) do
-      calendar = create(:calendar, calendar_state: :error)
+      calendar = create(:calendar)
+      calendar.calendar_state = :error
       assert_predicate calendar.calendar_state, :error?
     end
   end


### PR DESCRIPTION
Fixes #2304 

## Description

After a bit of digging it seemed like the easiest solution here was to improve the notification shown in the header and to also immediately import a calendar's events on creation. That means that the user doesn't get to specify the date to import from on their first import (it will just default to now) but they can change that at any point after the import, and changing it to a date in the future will remove any events that have already been imported if they didn't want current events showing for any reason. We could add a field in the form to let them control when the import begins from on their first import, but that just felt like another thing for users to have to think about at the create stage when most of them probably don't really care about this, so I think this would be better as a new feature if it comes up again.