### PR TITLE
Hiding partners from the GraphQL API that are set to `hidden`

### DIFF
--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -33,7 +33,6 @@ module Types
           description: 'The address where this event will take place'
 
     field :organizer, PartnerType,
-          method: :partner,
           description: 'The organising partner of this event'
 
     field :publisherUrl, String,
@@ -53,6 +52,13 @@ module Types
 
     def onlineEventUrlType
       object&.online_address&.link_type
+    end
+
+    def organizer
+      partner = object&.partner
+      return if partner.blank? || partner.hidden
+
+      partner
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -22,15 +22,15 @@ module Types
     end
 
     def partner(id:)
-      Partner.find(id)
+      Partner.visible.find(id)
     end
 
     def partner_connection(**_args)
-      Partner.all
+      Partner.visible.all
     end
 
     def partners_by_tag(tag_id:)
-      Partner.with_tags(tag_id).order(:name)
+      Partner.visible.with_tags(tag_id).order(:name)
     end
   end
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -157,12 +157,17 @@ class Partner < ApplicationRecord
     return none if site_neighbourhood_ids.empty?
 
     query
+      .visible
       .left_joins(:address, :service_areas)
       .where(
-        'NOT hidden AND (service_areas.neighbourhood_id in (:neighbourhood_ids) OR addresses.neighbourhood_id in (:neighbourhood_ids))',
+        '(service_areas.neighbourhood_id in (:neighbourhood_ids) OR addresses.neighbourhood_id in (:neighbourhood_ids))',
         neighbourhood_ids: site_neighbourhood_ids
       )
       .distinct
+  }
+
+  scope :visible, lambda {
+    where(hidden: false)
   }
 
   scope :for_site_with_tag, lambda { |site, tag|


### PR DESCRIPTION
Closes #2220 

## Considerations
Can a partner be viewed through an event even if not visible?