### PR TITLE
Prevent events from linking up to the wrong partner

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,7 @@ Rails/ActionOrder:
 Metrics/ClassLength:
   Exclude:
     - "test/**/*.rb"
+    - "app/models/partner.rb"
 
 
 

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -74,7 +74,7 @@ class CalendarImporter::EventResolver
 
   def event_strategy(partner, address: nil)
     if data.has_location?
-      partner = Partner.fuzzy_find_by_location(event_location_components)
+      partner = Partner.find_from_event(event_location_components, data.postcode)
       address = partner&.address || Address.build_from_components(event_location_components, data.postcode)
     elsif partner.present?
       raise Problem, WARNING2_MSG
@@ -84,7 +84,7 @@ class CalendarImporter::EventResolver
 
   def event_override_strategy(partner, address: nil)
     if data.has_location?
-      partner = Partner.fuzzy_find_by_location(event_location_components)
+      partner = Partner.find_from_event(event_location_components, data.postcode)
       address = partner&.address || Address.build_from_components(event_location_components, data.postcode)
       raise Problem, INFO1_MSG if partner.nil? && address.nil?
     elsif partner.present?

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -72,65 +72,27 @@ class CalendarImporter::EventResolver
     data.partner_id = calendar.partner_id
   end
 
-  def event_strategy(place, address: nil)
+  def event_strategy(partner, address: nil)
     if data.has_location?
-      # place = 'attempt to match location'
-      # address = 'calendar.place.address || location'
-
-      # try to find the place
-      place = Partner.fuzzy_find_by_location(event_location_components)
-
-      # try to use that address
-      address = place&.address
-
-      # if no place, try to find an address
-      # (This only executes if there is no place given)
-      address ||= Address.search(data.location, event_location_components, data.postcode)
-
-      # if we have an address, try to use the place that address points to
-      # (Only runs if the fuzzy find and calendar.place are both nil)
-      place ||= address&.partners&.first
-
-      # NOTE: What happens if address has zero partners and the earlier assignments fail?
-      #       'place' is nil in this instance
-      # NOTE: Address.search can also return Nil if there are no event_location_components, or
-      #       if the address failed to save
-      # Both of these will cause the event to fail validation with "No place or address could be created/found (etc)"
-
-    elsif place.present?
+      partner = Partner.fuzzy_find_by_location(event_location_components)
+      address = partner&.address || Address.build_from_components(event_location_components, data.postcode)
+    elsif partner.present?
       raise Problem, WARNING2_MSG
-    end # no location
-    # No longer an error if place is not present -- see #1198
-    # Passthrough here
-
-    [place, address]
+    end
+    [partner, address]
   end
 
-  def event_override_strategy(place, address: nil)
+  def event_override_strategy(partner, address: nil)
     if data.has_location?
-      # place = 'attempt to match location'
-      # address = 'calendar.place.address || location'
-      place = Partner.fuzzy_find_by_location(event_location_components)
-      address = place&.address
-      address ||= Address.search(data.location, event_location_components, data.postcode)
-
-      raise Problem, INFO1_MSG if place.nil? && address.nil?
-
-      # NOTE: Either one of 'place' or 'address' is unset here but not both
-      # NOTE: place is possibly unset here - fuzzy_find_by_location can be nil
-      # NOTE: address is possibly unset here - place might be nil or Address.search can return nil
-      #       In either case we will just drop this event on the floor
-    elsif place.present? # no location
-      address = place.address
-    # place = 'calendar.place'
-    # address = 'calendar.place.address'
-    # place = calendar.place
-
-    else # no place, no location
+      partner = Partner.fuzzy_find_by_location(event_location_components)
+      address = partner&.address || Address.build_from_components(event_location_components, data.postcode)
+      raise Problem, INFO1_MSG if partner.nil? && address.nil?
+    elsif partner.present?
+      address = partner.address
+    else
       raise Problem, WARNING1_MSG
     end
-
-    [place, address]
+    [partner, address]
   end
 
   def place_strategy(_place, _address: nil)

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -105,34 +105,6 @@ class Address < ApplicationRecord
   end
 
   class << self
-    # location - The raw location field
-    # components - Array containing parts of an event's location field, excluding the postcode.
-    def search(_location, components, postcode)
-      return nil if components.empty?
-
-      # try by street name string match
-      address = Address.find_by('lower(street_address) IN (?)', components.map(&:downcase))
-      return address if address
-
-      ukpc = UKPostcode.parse(postcode.to_s)
-
-      if ukpc.full_valid?
-        address = Address.find_by(postcode: ukpc.to_s)
-        return address if address
-      end
-
-      begin
-        # now just create one
-        Address.build_from_components(components, postcode)
-      rescue ActiveRecord::RecordNotFound
-        # This 'solution' makes it so if an address is provided to us that
-        # does not map cleanly on to our neighbourhood table then we simply
-        # consider that a failed look up. In practice we should do more to
-        # normalize data both coming from Postcodes.io and our UK government
-        # ward dataset
-      end
-    end
-
     def build_from_components(components, postcode)
       return if components.blank?
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -372,8 +372,13 @@ class Partner < ApplicationRecord
     end
   end
 
-  def self.fuzzy_find_by_location(components)
-    Partner.find_by('lower(name) IN (?)', components.map(&:downcase))
+  def self.find_from_event(components, postcode)
+    return Partner.left_joins(:address)
+                  .find_by(
+                    'lower(name) IN (:components) AND lower(addresses.postcode) = (:postcode)',
+                    components: components.map(&:downcase),
+                    postcode: postcode.downcase
+                  )
   end
 
   def self.neighbourhood_names_for_site(current_site, badge_zoom_level)

--- a/test/jobs/calendar_importer/event_resolver_strategy_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_strategy_test.rb
@@ -91,6 +91,8 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
     #     use location from data
     #       (not from calendar)
     @event_data.location = @address_partner.name
+    @event_data.postcode = @address_partner.address.postcode
+
     calendar = create_calendar_with(strategy: 'event', place: @other_address_partner)
 
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
@@ -113,13 +115,15 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
     #       (not from calendar)
 
     @event_data.location = @address_partner.name
+    @event_data.postcode = @address_partner.address.postcode
+
     calendar = create_calendar_with(strategy: 'event_override', place: @other_address_partner) # <--- different strategy
 
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
-    place, address = resolver.event_override_strategy(calendar.place)
+    partner, address = resolver.event_override_strategy(calendar.place)
 
     # these come from the event data
-    assert_equal place, @address_partner
+    assert_equal partner, @address_partner
   end
 
   def test_place_strategy_works
@@ -133,6 +137,7 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
     #     event place = calendar place
 
     @event_data.location = @address_partner.name
+
     calendar = create_calendar_with(strategy: 'place', place: @other_address_partner)
 
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)

--- a/test/jobs/calendar_importer/events_import_test.rb
+++ b/test/jobs/calendar_importer/events_import_test.rb
@@ -14,13 +14,7 @@ class EventsImportTest < ActiveSupport::TestCase
 
       # Identify partner by partner.name == event_location.street_address
       # (Automatically created address will not match event location.)
-      partner1 = create(:partner, name: 'Z-aRtS')
-
-      # Identify partner by partner.address.street_address == event_location.street_address
-      # (Other automatically created fields will not match event location.)
-      partner2 = create(:partner)
-      partner2.address.street_address = 'MartIn HarriS cEntre for Music and Drama'
-      partner2.address.save!
+      partner = create(:partner, name: 'Z-aRtS')
 
       from_date = Date.new(2018, 11, 20)
       force_import = false
@@ -39,8 +33,7 @@ class EventsImportTest < ActiveSupport::TestCase
       # assert_equal 3, Address.count
 
       # Were the correct number of events found at each partner location?
-      assert_equal 2, Event.where(place: partner1).count
-      assert_equal 1, Event.where(place: partner2).count
+      assert_equal 2, Event.where(place: partner).count
     end
   end
 

--- a/test/jobs/calendar_importer/events_import_test.rb
+++ b/test/jobs/calendar_importer/events_import_test.rb
@@ -15,15 +15,15 @@ class EventsImportTest < ActiveSupport::TestCase
       # Identify partner by partner.name == event_location.street_address
       # (Automatically created address will not match event location.)
       partner = create(:partner, name: 'Z-aRtS')
+      partner.address.postcode = 'M15 5ZA'
+      partner.save!
 
       from_date = Date.new(2018, 11, 20)
       force_import = false
       CalendarImporter::CalendarImporterTask.new(calendar, from_date, force_import).run
 
-      # pp Event.all
-      # pp Address.all
-
       # Did all events import?
+
       assert_equal 11, Event.count
 
       # Each partner created above will automatically create one address.

--- a/test/support/geocoder.rb
+++ b/test/support/geocoder.rb
@@ -43,6 +43,52 @@ Geocoder::Lookup::Test.add_stub(
 )
 
 Geocoder::Lookup::Test.add_stub(
+  'M15 5ZA', [
+    { 'postcode' => 'M15 5ZA',
+      'quality' => 1,
+      'eastings' => 383_348,
+      'northings' => 396_672,
+      'country' => 'England',
+      'nhs_ha' => 'North West',
+      'longitude' => -2.252301,
+      'latitude' => 53.466521,
+      'european_electoral_region' => 'North West',
+      'primary_care_trust' => 'Manchester Teaching',
+      'region' => 'North West',
+      'lsoa' => 'Manchester 019D',
+      'msoa' => 'Manchester 019',
+      'incode' => '5ZA',
+      'outcode' => 'M15',
+      'parliamentary_constituency' => 'Manchester Central',
+      'parliamentary_constituency_2024' => 'Manchester Rusholme',
+      'admin_district' => 'Manchester',
+      'parish' => 'Manchester, unparished area',
+      'admin_county' => nil,
+      'date_of_introduction' => '199706',
+      'admin_ward' => 'Hulme',
+      'ced' => nil,
+      'ccg' => 'NHS Greater Manchester',
+      'nuts' => 'Manchester',
+      'pfa' => 'Greater Manchester',
+      'codes' =>
+        { 'admin_district' => 'E08000003',
+          'admin_county' => 'E99999999',
+          'admin_ward' => 'E05011368',
+          'parish' => 'E43000157',
+          'parliamentary_constituency' => 'E14000807',
+          'parliamentary_constituency_2024' => 'E14001353',
+          'ccg' => 'E38000217',
+          'ccg_id' => '14L',
+          'ced' => 'E99999999',
+          'nuts' => 'TLD33',
+          'lsoa' => 'E01005214',
+          'msoa' => 'E02001063',
+          'lau2' => 'E08000003',
+          'pfa' => 'E23000005' } }
+  ]
+)
+
+Geocoder::Lookup::Test.add_stub(
   'OL6 8BH', [
     { 'postcode' => 'OL6 8BH',
       'quality' => 1,


### PR DESCRIPTION
Fixes #2348 

## Description

The event resolver has two strategies that can link up an event to a partner that is different to the partner they belong to.

These strategies previously tried to:
A) match with a partner by checking if the name and postcode in the event matched any partners in our DB

if this was unsuccessful they then tried to:
B) match with a partner by checking if the address matched any partners' addresses in our DB

if this was unsuccessful they then tried to:
C) create a new address from the event

Route B was broken - it would return true if just the first line of the address matched. 

I've decided to simply remove this option because I think it's poorly thought out - in our system it could be possible for multiple partners to exist at the same address and this only returns one. However partner names are unique, so if the address contains a matching partner name & postcode then we can be certain we are associating it with the intended partner.

I've also tidied up the code a little bit to remove some of the noise.