### PR TITLE
reduce instance homepage boiler plate text

### DIFF
--- a/app/views/sites/default.html.erb
+++ b/app/views/sites/default.html.erb
@@ -11,8 +11,7 @@
 
 <section class="region region__mission">
   <div class="c c--narrow">
-    <h2 class="serif">PlaceCal is working to make <%= @site.place_name %> a better connected neighbourhood.</h2>
-    <p>We're working with <%= link_to 'local organisations', partners_path %> and <%= link_to 'places', places_path %> to create a great calendar of everything that's on in <%= @site.place_name %>.</p>
+    <p>We're working with <%= link_to 'local organisations', partners_path %> to create a great calendar of everything that's on in <%= @site.place_name %>.</p>
     <%= link_to "See what's on", events_path, class: "btn btn--lg btn--alt btn--mt" %>
   </div>
 </section>

--- a/test/integration/sites_integration_test.rb
+++ b/test/integration/sites_integration_test.rb
@@ -30,7 +30,6 @@ class SitesIntegrationTest < ActionDispatch::IntegrationTest
     get 'http://hulme.lvh.me'
     assert_select 'h1',
                   'PlaceCal is a community events calendar where you can find everything near you, all in one place.'
-    assert_select 'h2', "PlaceCal is working to make #{@site.place_name} a better connected neighbourhood."
     assert_select 'p', @site.description
     assert_select 'strong', @site_admin.full_name
     assert_select 'strong', @site_admin.phone


### PR DESCRIPTION
fixes #2384

I think the reason it looks like so much text is because previously the large hero text was such poor contrast it was getting ignored. I've just pulled the hard-coded boilerplate below the hero text and removed the reference to places that duplicates local orgs.