### PR TITLE
Address fields are not required on the partner form

### DIFF
--- a/app/views/admin/partners/_address_fields.html.erb
+++ b/app/views/admin/partners/_address_fields.html.erb
@@ -8,7 +8,9 @@
 
   <%= address_form.input :street_address,
       class: "form-control address_1 address_field",
-      label: 'Street address' %>
+      label: 'Street address',
+      required: false
+    %>
 
   <%= address_form.input :street_address2,
       class: "form-control address_2 address_field",
@@ -22,7 +24,9 @@
       class: "form-control city address_field" %>
 
   <%= address_form.input :postcode,
-      class: "form-control postcode address_field" %>
+      class: "form-control postcode address_field",
+      required: false
+  %>
 
   <% if partner.can_clear_address?(current_user) %>
   <div data-partner-address-target="addressInfoArea">

--- a/test/integration/admin/partner_integration_test.rb
+++ b/test/integration/admin/partner_integration_test.rb
@@ -54,11 +54,11 @@ class PartnerIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'label', text: 'Twitter handle'
 
     assert_select 'h3', text: 'Address'
-    assert_select 'label', text: 'Street address *'
+    assert_select 'label', text: 'Street address'
     assert_select 'label', text: 'Street address 2'
     assert_select 'label', text: 'Street address 3'
     assert_select 'label', text: 'City'
-    assert_select 'label', text: 'Postcode *'
+    assert_select 'label', text: 'Postcode'
 
     assert_select 'h2', text: 'Contact Information'
     assert_select 'h3', text: 'Public Contact'


### PR DESCRIPTION
fixes #2310 

- text approved from previous pr  #2317 
- removed required status from 1st line of address and postcode field

## Notes

If someone misses out both these fields when adding the address, and they have a service area, it fails silently (refreshing the page but no warning). An unlikely event but it does not allow the creation of a malformed address.

There is a related issue #2364 that is outside the scope of the PR