### PR TITLE
add support section to sidebar in admin ui

### DIFF
--- a/app/views/layouts/admin/_admin_navigation.html.erb
+++ b/app/views/layouts/admin/_admin_navigation.html.erb
@@ -18,7 +18,7 @@
       <span>Get support</span>
     </h6>
     <%= admin_nav_link('Handbook', 'https://handbook.placecal.org/', 'book')%>
-    <%= admin_nav_link('Email us', 'mailto:support@placecal.org', 'envelope')%>
+    <li class="nav-item"><span class="nav-link"><i class="fa fa-envelope feather"></i>support@placecal.org</span></li>
     <%= admin_nav_link('Discord', 'http://discord.gfsc.studio/', 'comment')%>
     <%= admin_nav_link('Report a bug', 'https://github.com/geeksforsocialchange/PlaceCal/issues/new?assignees=&labels=&template=bug_report.md', 'bug')%>
 

--- a/app/views/layouts/admin/_admin_navigation.html.erb
+++ b/app/views/layouts/admin/_admin_navigation.html.erb
@@ -20,7 +20,7 @@
     <%= admin_nav_link('Handbook', 'https://handbook.placecal.org/', 'book')%>
     <%= admin_nav_link('Discord', 'http://discord.gfsc.studio/', 'comment')%>
     <%= admin_nav_link('Report a bug', 'https://github.com/geeksforsocialchange/PlaceCal/issues/new?assignees=&labels=&template=bug_report.md', 'bug')%>
-    <li class="nav-item"><span class="nav-link"><i class="fa fa-envelope feather"></i>support@placecal.org</span></li>
+    <li class="nav-item"><span class="nav-link"><i class="fa fa-envelope feather"></i> support@placecal.org</span></li>
 
   <% if policy(Collection).index? || policy(Supporter).index? %>
     <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">

--- a/app/views/layouts/admin/_admin_navigation.html.erb
+++ b/app/views/layouts/admin/_admin_navigation.html.erb
@@ -14,6 +14,14 @@
     <%= admin_nav_link('Tags', admin_tags_path, 'tags') if policy(Tag).index? %>
   <% end -%>
 
+    <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+      <span>Get support</span>
+    </h6>
+    <%= admin_nav_link('Handbook', 'https://handbook.placecal.org/', 'book')%>
+    <%= admin_nav_link('Email us', 'mailto:support@placecal.org', 'envelope')%>
+    <%= admin_nav_link('Discord', 'http://discord.gfsc.studio/', 'comment')%>
+    <%= admin_nav_link('Report a bug', 'https://github.com/geeksforsocialchange/PlaceCal/issues/new?assignees=&labels=&template=bug_report.md', 'bug')%>
+
   <% if policy(Collection).index? || policy(Supporter).index? %>
     <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
       <span>In development</span>
@@ -25,13 +33,10 @@
   <% end %>
 </ul>
 
-<br><br><br>
+<br><br>
 
 <p class="small text-info ml-3">
-<i class="fa fa-bug"></i> <%= link_to "Report a bug", "https://github.com/geeksforsocialchange/PlaceCal/issues/new?assignees=&labels=&template=bug_report.md" %>
-
-
 <% build = ENV['GIT_REV'] ? ENV['GIT_REV'][0,7] : 'development' %>
-<br><i class="fa fa-git"></i> Build: <tt><%= link_to build, "https://github.com/geeksforsocialchange/PlaceCal/commit/#{build}" %></tt>
+<i class="fa fa-git"></i> Build: <tt><%= link_to build, "https://github.com/geeksforsocialchange/PlaceCal/commit/#{build}" %></tt>
 
 </p>

--- a/app/views/layouts/admin/_admin_navigation.html.erb
+++ b/app/views/layouts/admin/_admin_navigation.html.erb
@@ -18,9 +18,9 @@
       <span>Get support</span>
     </h6>
     <%= admin_nav_link('Handbook', 'https://handbook.placecal.org/', 'book')%>
-    <li class="nav-item"><span class="nav-link"><i class="fa fa-envelope feather"></i>support@placecal.org</span></li>
     <%= admin_nav_link('Discord', 'http://discord.gfsc.studio/', 'comment')%>
     <%= admin_nav_link('Report a bug', 'https://github.com/geeksforsocialchange/PlaceCal/issues/new?assignees=&labels=&template=bug_report.md', 'bug')%>
+    <li class="nav-item"><span class="nav-link"><i class="fa fa-envelope feather"></i>support@placecal.org</span></li>
 
   <% if policy(Collection).index? || policy(Supporter).index? %>
     <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">


### PR DESCRIPTION
fixes #2146 

Added all the suggested links into the sidebar and moved the report a bug link in there too, I wrote the AC as appearing for admins but I included roots in this too as there seemed no harm in it and being familiar with what other users will see will make it easier to advice / support people.

![2024-04-12-11:07:01-screenshot](https://github.com/geeksforsocialchange/PlaceCal/assets/6824891/51459e41-99e7-4c2b-bfcb-5260f06fd666)
