### PR TITLE
Partners control event connections

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -372,6 +372,7 @@ Rails/SkipsModelValidations:
   Exclude:
     - 'lib/tasks/fixes/users.rake'
     - 'db/migrate/20240125175508_partner_hidden_attribute_set_value.rb'
+    - 'db/migrate/20240411200641_partner_can_be_assigned_events_set_value.rb'
 
 # Offense count: 22
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/app/components/event/_event.html.erb
+++ b/app/components/event/_event.html.erb
@@ -34,11 +34,11 @@
           Online
         </div>
       <% end %>
-      <% if place || first_address_line %>
+      <% if partner_at_location || first_address_line %>
         <div class="event__detail event__location">
           <span class="icon-font--place"></span>
-          <% if place %>
-            <%= link_to place, partner_path(place) %>
+          <% if partner_at_location %>
+            <%= link_to partner_at_location, partner_path(partner_at_location) %>
           <% elsif first_address_line %>
             <%= first_address_line %>
           <% end %>

--- a/app/components/event/event_component.rb
+++ b/app/components/event/event_component.rb
@@ -8,8 +8,7 @@ class EventComponent < MountainView::Presenter
   include ActionView::Helpers::DateHelper
 
   delegate :id, to: :event
-
-  delegate :place, to: :event
+  delegate :partner_at_location, to: :event
 
   def time
     if event.dtend

--- a/app/controllers/concerns/map_markers.rb
+++ b/app/controllers/concerns/map_markers.rb
@@ -19,7 +19,7 @@ module MapMarkers
     locations = locations.map do |loc|
       next loc unless loc.is_a?(Event)
 
-      loc.place || loc.address
+      loc.partner_at_location || loc.address
     end
 
     # Partners

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -52,8 +52,8 @@ class EventsController < ApplicationController
   # GET /events/1
   # GET /events/1.json
   def show
-    if @event.place
-      @map = get_map_markers([@event.place])
+    if @event.partner_at_location
+      @map = get_map_markers([@event.partner_at_location])
     elsif @event.address
       @map = get_map_markers([@event.address])
     end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -30,13 +30,6 @@ class PartnersController < ApplicationController
     @map = get_map_markers(@partners, true) if @partners.detect(&:address)
   end
 
-  # # GET /places
-  # # GET /places.json
-  # def places_index
-  #   @places = Partner.event_hosts.for_site(current_site).order(:name)
-  #   @map = get_map_markers(@places) if @places.detect(&:address)
-  # end
-
   # GET /partners/1
   # GET /partners/1.json
   def show

--- a/app/jobs/calendar_importer/calendar_importer_task.rb
+++ b/app/jobs/calendar_importer/calendar_importer_task.rb
@@ -67,7 +67,6 @@ class CalendarImporter::CalendarImporterTask
     parsed_event.determine_online_location
 
     parsed_event.determine_location_for_strategy
-    # next if parsed_event.is_address_missing?
 
     active_event_uids << parsed_event.uid
 

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -75,6 +75,7 @@ class CalendarImporter::EventResolver
   def event_strategy(partner, address: nil)
     if data.has_location?
       address = Address.build_from_components(event_location_components, data.postcode)
+      partner = nil
     elsif partner.present?
       raise Problem, WARNING2_MSG
     end
@@ -84,6 +85,7 @@ class CalendarImporter::EventResolver
   def event_override_strategy(partner, address: nil)
     if data.has_location?
       address = Address.build_from_components(event_location_components, data.postcode)
+      partner = nil
       raise Problem, INFO1_MSG if address.nil?
     elsif partner.present?
       address = partner.address

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -6,7 +6,6 @@ class CalendarImporter::EventResolver
   WARNING2_MSG = 'Could not determine where this event is. A default location is set but the importer is set '  \
                  'to ignore this. Add an address to the location field of the source calendar, or choose '      \
                  'another import strategy with a default location.'
-  INFO1_MSG = 'This location was not recognised by PlaceCal, woulfd you like to add it?'
 
   attr_reader :data, :uid, :notices, :calendar
 
@@ -86,7 +85,6 @@ class CalendarImporter::EventResolver
     if data.has_location?
       address = Address.build_from_components(event_location_components, data.postcode)
       partner = nil
-      raise Problem, INFO1_MSG if address.nil?
     elsif partner.present?
       address = partner.address
     else

--- a/app/jobs/calendar_importer/event_resolver.rb
+++ b/app/jobs/calendar_importer/event_resolver.rb
@@ -83,15 +83,20 @@ class CalendarImporter::EventResolver
 
   def event_override_strategy(partner, address: nil)
     if data.has_location?
-      address = Address.build_from_components(event_location_components, data.postcode)
-      raise Problem, INFO1_MSG if address.nil?
-
-      partner = nil
-    elsif partner.present?
-      address = partner.address
+      address = Address.build_from_components(
+        event_location_components,
+        data.postcode
+      )
+    end
+    if address.nil?
+      address = partner&.address
     else
+      partner = nil
+    end
+    if partner.nil? && address.nil?
       raise Problem, WARNING1_MSG
     end
+
     [partner, address]
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -139,13 +139,14 @@ class Event < ApplicationRecord
   end
 
   def location
-    use_address = address || partner&.address
-    #  (address if address.present?) ||
-    #  (partner.address if partner.present?)
-
+    use_address = address || partner_at_location&.address || partner&.address
     return '' if use_address.nil?
 
     use_address.to_s
+  end
+
+  def partner_at_location
+    @partner_at_location ||= Partner.find_from_event_address(address) || place
   end
 
   # TODO: plan this out on paper, currently half finished

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -146,7 +146,7 @@ class Event < ApplicationRecord
   end
 
   def partner_at_location
-    @partner_at_location ||= Partner.find_from_event_address(address) || place
+    @partner_at_location ||= place || Partner.find_from_event_address(address)
   end
 
   # TODO: plan this out on paper, currently half finished

--- a/app/policies/partner_policy.rb
+++ b/app/policies/partner_policy.rb
@@ -50,7 +50,7 @@ class PartnerPolicy < ApplicationPolicy
              :public_name, :public_email, :public_phone,
              :partner_name, :partner_email, :partner_phone,
              :address_id, :url, :facebook_link, :twitter_handle, :instagram_handle,
-             :opening_times,
+             :opening_times, :can_be_assigned_events,
              { calendars_attributes: %i[id name source strategy place_id partner_id _destroy],
                address_attributes: %i[id street_address street_address2 street_address3 city postcode],
                service_areas_attributes: %i[id neighbourhood_id _destroy],

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -171,6 +171,10 @@
           controller: 'select2',
         } } %>
     <hr>
+    <h2>Event matching</h2>
+    <p>Can events imported from other partner's calendars be listed at this partner if their address matches?</p>
+    <%= f.input :can_be_assigned_events, class: "form-control" %>
+    <hr>
     <% unless @partner.new_record? %>
       <% if policy(@partner).permitted_attributes.include? :hidden %>
         <div class="alert alert-light border" role="alert">

--- a/app/views/events/index_simple.html.erb
+++ b/app/views/events/index_simple.html.erb
@@ -6,7 +6,7 @@
   <strong><%= event.summary %></strong><br>
   <%= "#{event.date}, #{event.time}" %><br>
   <%= event.description %><br>
-  <%= "#{event.place}, #{event.location}" %><br>
+  <%= "#{event.partner_at_location}, #{event.location}" %><br>
   <%= link_to "https://placecal.org#{event_path(event)}", "https://placecal.org#{event_path(event)}" %>
 </p>
 

--- a/app/views/shared/_events.text.erb
+++ b/app/views/shared/_events.text.erb
@@ -12,7 +12,7 @@
 
 #{sanitize(event.description, tags: [])}
 ) %>
-<%= event.place.to_s + ', ' if event.place %><%= event.location %>
+<%= event.partner_at_location.to_s + ', ' if event.partner_at_location %><%= event.location %>
 <%= %(
 https://placecal.org#{event_path(event)}
 ) %>

--- a/db/migrate/20240411192949_add_can_be_assigned_events_to_partner.rb
+++ b/db/migrate/20240411192949_add_can_be_assigned_events_to_partner.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCanBeAssignedEventsToPartner < ActiveRecord::Migration[7.1]
+  def change
+    add_column :partners, :can_be_assigned_events, :boolean, default: false
+  end
+end

--- a/db/migrate/20240411200641_partner_can_be_assigned_events_set_value.rb
+++ b/db/migrate/20240411200641_partner_can_be_assigned_events_set_value.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PartnerCanBeAssignedEventsSetValue < ActiveRecord::Migration[7.1]
+  def up
+    Partner.where(can_be_assigned_events: nil).update_all(hidden: false)
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_21_160911) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_11_200641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -236,6 +236,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_160911) do
     t.integer "hidden_blame_id"
     t.string "hidden_reason_html"
     t.string "instagram_handle"
+    t.boolean "can_be_assigned_events", default: false
     t.index ["address_id"], name: "index_partners_on_address_id"
     t.index ["slug"], name: "index_partners_on_slug", unique: true
   end

--- a/test/factories/neighbourhood.rb
+++ b/test/factories/neighbourhood.rb
@@ -174,4 +174,24 @@ FactoryBot.define do
       ward.save
     end
   end
+
+  factory :eventbrite_valid_address_hood, class: 'Neighbourhood' do
+    name { '' }
+    name_abbr { '' }
+    unit { '' }
+    unit_code_key { '' }
+    unit_code_value { 'E05013808' }
+    unit_name { '' }
+    release_date { '' }
+  end
+
+  factory :ldjson_valid_address_hood, class: 'Neighbourhood' do
+    name { '' }
+    name_abbr { '' }
+    unit { '' }
+    unit_code_key { '' }
+    unit_code_value { 'E05012263' }
+    unit_name { '' }
+    release_date { '' }
+  end
 end

--- a/test/factories/partner.rb
+++ b/test/factories/partner.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     partner_phone { '0161 0000001' }
 
     hidden { false }
+    can_be_assigned_events { false }
 
     summary { 'A cool garden centre' }
     description { 'Our cool garden centre is a very cool and neat garden centre. Come to our events. Now.' }

--- a/test/jobs/calendar_importer/calendar_importer_task_test.rb
+++ b/test/jobs/calendar_importer/calendar_importer_task_test.rb
@@ -70,6 +70,7 @@ class CalendarImporterTaskTest < ActiveSupport::TestCase
 
   test 'can import Eventbrite' do
     VCR.use_cassette(:eventbrite_events, allow_playback_repeats: true) do
+      create(:eventbrite_valid_address_hood)
       calendar = create(
         :calendar,
         name: 'Eventbrite calendar',
@@ -86,7 +87,7 @@ class CalendarImporterTaskTest < ActiveSupport::TestCase
       assert_equal 'eventbrite', calendar.importer_used
 
       created_events = calendar.events
-      assert_equal 3, created_events.count
+      assert_equal 1, created_events.count
     end
   end
 
@@ -134,6 +135,7 @@ class CalendarImporterTaskTest < ActiveSupport::TestCase
 
   test 'can import from generic ld+json source' do
     VCR.use_cassette(:heart_of_torbay, allow_playback_repeats: true) do
+      create(:ldjson_valid_address_hood)
       calendar = create(
         :calendar,
         name: 'Generic LD+JSON Calendar',
@@ -196,7 +198,7 @@ class CalendarImporterTaskTest < ActiveSupport::TestCase
         :calendar,
         name: 'Generic iCal Calendar',
         source: 'https://www.birchcommunitycentre.co.uk/events.ics',
-        strategy: 'event'
+        strategy: 'place'
       )
 
       calendar.update calendar_state: 'in_worker'
@@ -208,7 +210,7 @@ class CalendarImporterTaskTest < ActiveSupport::TestCase
       assert_equal 'ical', calendar.importer_used
 
       created_events = calendar.events
-      assert_equal 29, created_events.count # (at time of recording)
+      assert_equal 50, created_events.count # (at time of recording)
     end
   end
 
@@ -218,7 +220,7 @@ class CalendarImporterTaskTest < ActiveSupport::TestCase
         :calendar,
         name: 'Generic webcal Calendar',
         source: 'webcal://p14-calendars.icloud.com/published/2/MTQ2NzIwNzk1NDE0NjcyMM7jQu_vEJtKcvFoPn3S2FrA6WGkdMmCuNCcP44HV1RjEsev_l3T5lO94XkBevJwb5wd-ayWykRsarVoSJrwZvc',
-        strategy: 'event'
+        strategy: 'place'
       )
 
       calendar.update calendar_state: 'in_worker'

--- a/test/jobs/calendar_importer/event_resolver_strategy_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_strategy_test.rb
@@ -90,7 +90,7 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
     partner, address = resolver.event_strategy(calendar.place)
 
-    assert_equal partner, calendar.place
+    assert_nil partner
     assert_not_equal address, @address_partner.address
     assert_equal address.street_address, @event_data.location
     assert_equal address.postcode, @event_data.postcode
@@ -105,7 +105,7 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
     partner, address = resolver.event_override_strategy(calendar.place)
 
-    assert_equal partner, calendar.place
+    assert_nil partner
     assert_not_equal address, @address_partner.address
     assert_equal address.street_address, @event_data.location
     assert_equal address.postcode, @event_data.postcode

--- a/test/jobs/calendar_importer/event_resolver_strategy_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_strategy_test.rb
@@ -81,39 +81,22 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
     end
   end
 
-  def test_event_strategy_with_data_location_with_place_uses_partner_place
-    # theory of test:
-    #   given
-    #     data location is present
-    #     calendar strategy is 'event'
-    #
-    #   then
-    #     use location from data
-    #       (not from calendar)
+  def test_event_strategy_with_data_location_with_place_keeps_address
     @event_data.location = @address_partner.name
     @event_data.postcode = @address_partner.address.postcode
 
     calendar = create_calendar_with(strategy: 'event', place: @other_address_partner)
 
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
-    place, address = resolver.event_strategy(calendar.place)
+    partner, address = resolver.event_strategy(calendar.place)
 
-    # these come from the event data
-    assert_equal place, @address_partner
-    assert_equal address, @address_partner.address
+    assert_equal partner, calendar.place
+    assert_not_equal address, @address_partner.address
+    assert_equal address.street_address, @event_data.location
+    assert_equal address.postcode, @event_data.postcode
   end
 
-  def test_event_overide_strategy_with_data_location_with_place_uses_partner_place
-    # (same as above?)
-
-    # theory of test:
-    #   given
-    #     data location is present
-    #     calendar strategy is 'event_override'
-    #   then
-    #     use location from data
-    #       (not from calendar)
-
+  def test_event_overide_strategy_with_data_location_with_place_keeps_address
     @event_data.location = @address_partner.name
     @event_data.postcode = @address_partner.address.postcode
 
@@ -122,8 +105,10 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
     partner, address = resolver.event_override_strategy(calendar.place)
 
-    # these come from the event data
-    assert_equal partner, @address_partner
+    assert_equal partner, calendar.place
+    assert_not_equal address, @address_partner.address
+    assert_equal address.street_address, @event_data.location
+    assert_equal address.postcode, @event_data.postcode
   end
 
   def test_place_strategy_works

--- a/test/jobs/calendar_importer/event_resolver_strategy_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_strategy_test.rb
@@ -147,20 +147,10 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
     #     event address = calendar place address
 
     calendar = create_calendar_with(strategy: 'event_override', place: @address_partner)
-
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
 
-    assert_raises(CalendarImporter::EventResolver::Problem) do
-      place, address = resolver.event_override_strategy(calendar.place)
-    end
-
-    # puts "address_partner=#{@address_partner.to_json}"
-    # puts "place=#{place.to_json}"
-    # puts "address=#{address.to_json}"
-
-    # FIXME
-    # these come from the calendar
-    # assert_equal place, @address_partner
-    # assert_equal address, @address_partner.address
+    place, address = resolver.event_override_strategy(calendar.place)
+    assert_nil place
+    assert_nil address
   end
 end

--- a/test/jobs/calendar_importer/event_resolver_strategy_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_strategy_test.rb
@@ -149,8 +149,8 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
     calendar = create_calendar_with(strategy: 'event_override', place: @address_partner)
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
 
-    place, address = resolver.event_override_strategy(calendar.place)
-    assert_nil place
-    assert_nil address
+    assert_raises CalendarImporter::EventResolver::Problem do
+      resolver.event_override_strategy(calendar.place)
+    end
   end
 end

--- a/test/jobs/calendar_importer/event_resolver_strategy_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_strategy_test.rb
@@ -148,6 +148,16 @@ class EventResolverStrategyTest < ActiveSupport::TestCase
 
     calendar = create_calendar_with(strategy: 'event_override', place: @address_partner)
     resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
+    place, address = resolver.event_override_strategy(calendar.place)
+
+    assert_equal place, calendar.place
+    assert_equal address, calendar.place.address
+  end
+
+  def test_override_strategy_fails_with_no_data_location_and_no_place
+    calendar = create_calendar_with(strategy: 'event_override')
+    calendar.place = nil
+    resolver = CalendarImporter::EventResolver.new(@event_data, calendar, @notices, @from_date)
 
     assert_raises CalendarImporter::EventResolver::Problem do
       resolver.event_override_strategy(calendar.place)

--- a/test/jobs/calendar_importer/event_resolver_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_test.rb
@@ -149,7 +149,7 @@ class EventsResolverTest < ActiveSupport::TestCase
     @fake_ics_event[:description] = "Join us on jitsi: #{jitsi_link} words words words"
     ics_event_data = CalendarImporter::Events::IcsEvent.new(@fake_ics_event, @start_date, @end_date)
 
-    calendar = make_calendar_for_strategy('event')
+    calendar = make_calendar_for_strategy('place')
 
     resolver = CalendarImporter::EventResolver.new(ics_event_data, calendar, [], @start_date)
     resolver.determine_online_location
@@ -254,7 +254,7 @@ class EventsResolverTest < ActiveSupport::TestCase
     assert_equal(["Summary can't be blank"], notices)
   end
 
-  test 'generate notices when missing address' do
+  test 'raises error when missing address' do
     calendar = make_calendar_for_strategy('no_location')
     calendar.strategy = 'event'
 
@@ -262,10 +262,9 @@ class EventsResolverTest < ActiveSupport::TestCase
     from_date = @start_date
 
     resolver = CalendarImporter::EventResolver.new(@ics_event_data, calendar, notices, from_date)
-    resolver.determine_location_for_strategy
 
-    resolver.save_all_occurences
-
-    assert_equal(['No place or address could be created or found for the event location: A location'], notices)
+    assert_raises CalendarImporter::EventResolver::Problem do
+      resolver.determine_location_for_strategy
+    end
   end
 end

--- a/test/jobs/calendar_importer/events_import_test.rb
+++ b/test/jobs/calendar_importer/events_import_test.rb
@@ -33,7 +33,7 @@ class EventsImportTest < ActiveSupport::TestCase
       # assert_equal 3, Address.count
 
       # Were the correct number of events found at each partner location?
-      assert_equal 2, Event.where(place: partner).count
+      assert_equal 2, Event.joins(:address).where('lower(addresses.street_address) = (?)', partner.name.downcase).count
     end
   end
 

--- a/test/models/partner_test.rb
+++ b/test/models/partner_test.rb
@@ -509,4 +509,33 @@ class PartnerTest < ActiveSupport::TestCase
 
     assert partner.warn_user_clear_address?(other_citizen)
   end
+
+  test '#self.find_from_event_address does not return partner with matching name and postcode unless events can be assigned' do
+    partner = create(:moss_side_partner)
+    address = create(:moss_side_address, street_address: partner.name)
+    found_partner = Partner.find_from_event_address(address)
+
+    assert_not found_partner
+  end
+
+  test '#self.find_from_event_address does not return partner if events can be assigned but name or postcode do not match' do
+    partner = create(:moss_side_partner, can_be_assigned_events: true)
+    address_with_right_postcode_wrong_name = create(:moss_side_address)
+    address_with_wrong_postcode_right_name = create(:address, street_address: partner.name)
+
+    found_partner_a = Partner.find_from_event_address(address_with_right_postcode_wrong_name)
+    found_partner_b = Partner.find_from_event_address(address_with_wrong_postcode_right_name)
+
+    assert_not found_partner_a
+    assert_not found_partner_b
+  end
+
+  test '#self.find_from_event_address returns partner with matching name and postcode if events can be assigned' do
+    partner = create(:moss_side_partner, can_be_assigned_events: true)
+    address = create(:moss_side_address, street_address: partner.name)
+    found_partner = Partner.find_from_event_address(address)
+
+    assert found_partner
+    assert_equal(found_partner.address.postcode, address.postcode)
+  end
 end


### PR DESCRIPTION
Fixes #2381 

## Description

- Adds a field to partners 'can be assigned events' that enables users to decide whether or not their partner can be linked up to events imported from other calendars
- Events imported with a strategy that takes the address from an event no longer attach the event to partners whose address matches - they just give the event their own address
- In the front end, when an event's address is shown:
  - if it was imported to display at the partner's location then that partner is shown OR
  - if it matches the name and postcode of a partner who can be assigned events, then that partner is shown OR
  - the event's own address is shown
- changes & adds some tests to assert the above is working as it should

### still to do:
- [ ] give every event its own address in the event importer
- [ ] assign the address to display based on the calendar importer strategy rather than assigning 'places' in the importer
- [ ] refactor event.place and calendar.place as methods on these classes that return the associated partner if a calendar's import strategy allows it