### PR TITLE
 handle failing partner address gracefully

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -51,7 +51,17 @@ class Partner < ApplicationRecord
 
   accepts_nested_attributes_for :calendars, allow_destroy: true
 
-  accepts_nested_attributes_for :address, reject_if: ->(c) { c[:postcode].blank? && c[:street_address].blank? }
+  accepts_nested_attributes_for :address # accepts_nested_attributes_for :address, reject_if: ->(c) { c[:postcode].blank? && c[:street_address].blank? }
+
+  validates_associated :address, if: lambda { |partner|
+                                       [
+                                         partner.address.street_address,
+                                         partner.address.street_address2,
+                                         partner.address.street_address3,
+                                         partner.address.city,
+                                         partner.address.postcode
+                                       ].any?(&:present?)
+                                     }
 
   accepts_nested_attributes_for :service_areas, allow_destroy: true
 
@@ -91,8 +101,6 @@ class Partner < ApplicationRecord
   validates :public_email, :partner_email,
             format: { with: EMAIL_REGEX, message: 'invalid email address' },
             allow_blank: true
-
-  validates_associated :address, if: ->(p) { p.address.present? }
 
   validate :check_neighbourhood_access
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -53,7 +53,13 @@ class Partner < ApplicationRecord
 
   # If any of the address formfields are present we attempt to create an address
   # this will trigger the validation
-  accepts_nested_attributes_for :address, reject_if: ->(c) { c[:city].blank? && c[:postcode].blank? && c[:street_address].blank? && c[:street_address2].blank? && c[:street_address3].blank? }
+  accepts_nested_attributes_for :address, reject_if: lambda { |c|
+    [c[:city].blank?,
+     c[:postcode].blank?,
+     c[:street_address].blank?,
+     c[:street_address2].blank?,
+     c[:street_address3].blank?].all?
+  }
 
   validates_associated :address
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -54,11 +54,11 @@ class Partner < ApplicationRecord
   # If any of the address formfields are present we attempt to create an address
   # this will trigger the validation
   accepts_nested_attributes_for :address, reject_if: lambda { |c|
-    [c[:city].blank?,
-     c[:postcode].blank?,
-     c[:street_address].blank?,
-     c[:street_address2].blank?,
-     c[:street_address3].blank?].all?
+    [c[:city],
+     c[:postcode],
+     c[:street_address],
+     c[:street_address2],
+     c[:street_address3]].all?(&:blank?)
   }
 
   validates_associated :address

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -51,17 +51,11 @@ class Partner < ApplicationRecord
 
   accepts_nested_attributes_for :calendars, allow_destroy: true
 
-  accepts_nested_attributes_for :address # accepts_nested_attributes_for :address, reject_if: ->(c) { c[:postcode].blank? && c[:street_address].blank? }
+  # If any of the address formfields are present we attempt to create an address
+  # this will trigger the validation
+  accepts_nested_attributes_for :address, reject_if: ->(c) { c[:city].blank? && c[:postcode].blank? && c[:street_address].blank? && c[:street_address2].blank? && c[:street_address3].blank? }
 
-  validates_associated :address, if: lambda { |partner|
-                                       [
-                                         partner.address.street_address,
-                                         partner.address.street_address2,
-                                         partner.address.street_address3,
-                                         partner.address.city,
-                                         partner.address.postcode
-                                       ].any?(&:present?)
-                                     }
+  validates_associated :address
 
   accepts_nested_attributes_for :service_areas, allow_destroy: true
 


### PR DESCRIPTION
fixes #2391 

We basically had two ways of intercepting the validation and both were covering half the use cases but not working in unison which was quite confusing. Now we always validate address creation from a partner but we never attempt to create an address if all the fields are blank.

This means we don't get silent failure if someone puts the first line of their address in line two by mistake, we get warnings at the top of the page and highlighted fields that need attention and we retain user input even if it's bad.