### PR TITLE
Readme updates to support ongoing development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 PlaceCal is an online calendar which lists events and activities by and for members of local communities, curated around interests and locality.
 
-The codebase doesn't currently have enough seeds to create a dev environment suitable for developing from scratch. If you're interested in contributing to PlaceCal please get in touch with us at support@Placecal.org
+The codebase doesn't currently have enough seeds to create a dev environment suitable for developing from scratch. If you're interested in contributing to PlaceCal please get in touch at support@placecal.org
 
 To get an idea of the project and what we're about, check out [the handbook](https://handbook.placecal.org/).
 
@@ -12,13 +12,13 @@ To get an idea of the project and what we're about, check out [the handbook](htt
 
 To run PlaceCal locally you will need to install the following dependencies:
 
-- Docker
-- Ruby 3.1.2
-- Node.js 16.x & (optional) NVM to manage it
-- Yarn 1.x
-- ImageMagick for image manipulation
+- [Docker](https://docs.docker.com/get-docker/)
+- [Ruby 3.1.2](https://www.ruby-lang.org/en/news/2022/04/12/ruby-3-1-2-released/)
+- [Node.js](https://nodejs.org/en/download) 16.x & (optional) [nvm](https://github.com/nvm-sh/nvm) to manage it
+- [Yarn 1.x](https://classic.yarnpkg.com/lang/en/)
+- [ImageMagick](https://imagemagick.org/index.php) for image manipulation
 - [Graphviz](https://voormedia.github.io/rails-erd/install.html) for documentation diagrams
-- Chrome/Chromium for system tests along with a matching version of [Chromedriver](https://chromedriver.chromium.org/)
+- [Chrome/Chromium](https://www.chromium.org/chromium-projects/) for system tests along with a matching version of [Chromedriver](https://chromedriver.chromium.org/)
 
 ## Quickstart with docker for GFSC devs
 
@@ -38,7 +38,7 @@ Some other useful commands for developing can be found in the makefile.
 
 If the make command fails and you can't work out why, here are some suggestions:
 
-- Do you have an older version of the database hanging around? Try running `rails:db:drop:all`
+- Do you have an older version of the database hanging around? Try running `rails db:drop:all`
 - Is the docker daemon running?
 - Is the port in use by another application or docker container? Try stopping or removing any conflicting containers
 - Are you using the correct node version? Try running `nvm use`
@@ -81,15 +81,14 @@ make test
 
 ## Documentation for Developers
 
-The documentation for PlaceCal currently stored in notion and can be read [here](https://www.notion.so/gfsc/PlaceCal-developer-handbook-01649b69009340e3ae3035e9cf346f27). There is also a small amount of documentation sprinkled throughout the code itself and can be turned into HTML by running `rails yard`. If you are working with the code and are completely lost you can also try the [GFSC discord server](http://discord.gfsc.studio) where you can prod a human for answers. Good Luck!
+The documentation for PlaceCal is currently stored in notion and can be read [here](https://handbook.placecal.org/placecal-developer-handbook). There is also a small amount of documentation sprinkled throughout the code itself and can be turned into HTML by running `rails yard`. If you are working with the code and are completely lost you can also try the [GFSC discord server](http://discord.gfsc.studio) where you can prod a human for answers. Good Luck!
 
 ### Generating new components
 
 We use view_component to make components, and you can create a new one by running `rails g component <Name> <args>`
+Previously this system used mountain view, and some of the components are still generated using this.
 More info here: https://viewcomponent.org/guide/generators.html
 
 ## Donations
 
-If you'd like to support development, please consider sending us a one-off or regular donation on Ko-fi.
-
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/M4M43THUM)
+If you'd like to support development, please consider sending us a one-off or regular donation on Ko-fi. You can do this through the "support" button in GitHub at the top of this repo.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Make sure all of the above dependencies are installed (and ask someone to add yo
 
 Then make sure the docker daemon is running, and run
 
-`make setup_with_docker`
+```sh
+make setup_with_docker
+```
 
 Local site is now running at `lvh.me:3000`
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,21 @@
 # PlaceCal
 
-## Introduction / Warning
+## Introduction
 
-PlaceCal is a large and very complicated app for collating organisation and event information from a large variety of sources. In the words of one developer: "I'm not sure where the interface between the app and the real world is here".
+PlaceCal is an online calendar which lists events and activities by and for members of local communities, curated around interests and locality.
+
+The codebase doesn't currently have enough seeds to create a dev environment suitable for developing from scratch. If you're interested in contributing to PlaceCal please get in touch with us at support@Placecal.org
 
 To get an idea of the project and what we're about, check out [the handbook](https://handbook.placecal.org/).
 
 ## Requirements
 
-To run PlaceCal locally you will need:
+To run PlaceCal locally you will need to install the following dependencies:
 
-- A Mac or a Linux machine (we don't support Windows at present)
-- GNU Compiler Collection (gcc) (for compiling ruby and gems)
-- Docker (optional) (for isolating and automating postgres management)
-- Postgres relational database. We are currently using v14.
-  - Server
-    - either installed for your distribution or as a docker image (with the correct open port -- see below)
-  - Client
-    - you will still need the local developer libraries for postgres
-    - these are distribution specific so you need to find out what they are called to install them
-      - `libpq-dev` (debian)
-      - `postgresql-libs` (arch)
-      - `dev-db/postgresql` (gentoo)
-- Ruby 3.1.2 - We recommend using a version manager for this such as `rvm` or `rbenv`. Current version we are using is in `.ruby-version`.
-  - [rvm](https://rvm.io/)
-  - [rbenv](https://github.com/rbenv/rbenv)
-    - [ruby-build](https://github.com/rbenv/ruby-build)
-    - [rbenv-gemset](https://github.com/jf/rbenv-gemset) (optional)
-- Node.js 16.x. We recommend using a version manager for this such as `nvm` or `nodenv`. Current version we are using is in `.node-version`.
-  - [nvm](https://github.com/nvm-sh/nvm)
-  - [nodenv](https://github.com/nodenv/nodenv)
+- Docker
+- Ruby 3.1.2
+- Node.js 16.x & (optional) NVM to manage it
 - Yarn 1.x
-  - [yarn](https://classic.yarnpkg.com/en/docs/install)
 - ImageMagick for image manipulation
 - [Graphviz](https://voormedia.github.io/rails-erd/install.html) for documentation diagrams
 - Chrome/Chromium for system tests along with a matching version of [Chromedriver](https://chromedriver.chromium.org/)
@@ -42,13 +26,20 @@ Make sure all of the above dependencies are installed (and ask someone to add yo
 
 Then make sure the docker daemon is running, and run
 
-```sh
-make setup_with_docker
-```
+`make setup_with_docker`
 
 Local site is now running at `lvh.me:3000`
 
 Some other useful commands for developing can be found in the makefile.
+
+## Troubleshooting
+
+If the make command fails and you can't work out why, here are some suggestions:
+
+- Do you have an older version of the database hanging around? Try running `rails:db:drop:all`
+- Is the docker daemon running?
+- Is the port in use by another application or docker container? Try stopping or removing any conflicting containers
+- Are you using the correct node version? Try running `nvm use`
 
 ## Quickstart for everyone else
 
@@ -74,58 +65,26 @@ Amongst other things, this will create an admin user for you:
 - The admin interface is at `admin.lvh.me:3000`
 - Access code docs through your local filesystem and update them with `bin/rails yard`
 
-## Testing
+## Testing, linting and formatting
 
-PlaceCal tests are written in minitest.
+PlaceCal tests are written in minitest. We use Rubocop to lint our Ruby code.
 
-Before running the tests please make sure your development environment is up to date (you can run `bin/update` to quickly do that).
+We use [Prettier](https://prettier.io/) to format everything it's able to parse. We run this automatically as part of a pre-commit hook.
 
-You can run the tests with:
+You can run the tests & rubocop with:
 
 ```sh
-make              # will run all unit and system tests then lint check all code
-rails test        # will run all unit tests
-rails test:system # will run system tests
+make test
 ```
-
-Note that the system tests can take a while to run and are quite resource-intensive. To perform more advanced usage like executing only a specific test or test file, see the [Rails documentation on testing](https://guides.rubyonrails.org/testing.html).
 
 ## Documentation for Developers
 
-The documentation for PlaceCal currently stored in notion and can be read [here](https://www.notion.so/gfsc/PlaceCal-developer-handbook-01649b69009340e3ae3035e9cf346f27). There is also a small amount of documentation sprinkled throughout the code itself and can be turned into HTML by running `rails yard`. If you are working with the code and are completely lost you can also try the GFSC discord server where you can prod a human for answers. Good Luck!
+The documentation for PlaceCal currently stored in notion and can be read [here](https://www.notion.so/gfsc/PlaceCal-developer-handbook-01649b69009340e3ae3035e9cf346f27). There is also a small amount of documentation sprinkled throughout the code itself and can be turned into HTML by running `rails yard`. If you are working with the code and are completely lost you can also try the [GFSC discord server](http://discord.gfsc.studio) where you can prod a human for answers. Good Luck!
 
 ### Generating new components
 
 We use view_component to make components, and you can create a new one by running `rails g component <Name> <args>`
 More info here: https://viewcomponent.org/guide/generators.html
-
-## Formatting
-
-We use [Prettier](https://prettier.io/) to format everything it's able to parse. It will run as a pre-commit hook and format your changes as you make commits so you shouldn't have to think about it much.
-
-If you do want to run it manually, you can:
-
-```sh
-bin/yarn run format
-```
-
-It's also run for you by the test runner.
-
-Note that we use tabs over spaces because [tabs are more accessible to people using braille displays](https://twitter.com/Rich_Harris/status/1541761871585464323).
-
-## Linting
-
-We use Rubocop to lint our Ruby code. Because of the time it can take to run, this is a manual step:
-
-```sh
-bin/bundle exec rubocop --autocorrect
-```
-
-It's also run for you by the test runner.
-
-## Contributing
-
-We welcome new contributors but strongly recommend you have a chat with us in [Geeks for Social Change's Discord server](http://discord.gfsc.studio) and say hi before you do. We will be happy to onboard you properly before you get stuck in.
 
 ## Donations
 


### PR DESCRIPTION
Fixes #2088 

## Description

Slims down the readme to include only the essentials:
- dependencies
- getting set up as a staff member
- troubleshooting (this is to highlight the fixes for issues we encountered during a fresh install)
- getting set up if you're not a staff member (with a caveat at the start that this is currently broken)
- testing, formatting, linting info
- the component generator (decided to leave this in as it is not obvious when developing)