### PR TITLE
show all should show all future events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,7 +64,7 @@ class ApplicationController < ActionController::Base
     events = events.one_off_events_first if repeating == 'last'
     events =
       if period == 'future'
-        events.future(@current_day).includes(:place)
+        events.future(@today).includes(:place)
       elsif period == 'week'
         events.find_by_week(@current_day).includes(:place)
       else


### PR DESCRIPTION
fixes #2410 

If period is `future` we always consider the current_day to be today regardless of url params.

## thoughts

I briefly toyed with resetting the url because I thought it would be cleaner but I realized it meant you couldn't toggle between views without losing state. 