### PR TITLE
Be more permissive about calendar event URLs

### DIFF
--- a/app/jobs/calendar_importer/events/ics_event.rb
+++ b/app/jobs/calendar_importer/events/ics_event.rb
@@ -59,10 +59,6 @@ module CalendarImporter::Events
 
       return if link.blank?
 
-      # Then grab the first element of either the match object or the conference array
-      # (The match object returns ICal Text, not a String, so we have to cast)
-      # (We can't use .first here because the match object doesn't support it!)
-      #
       online_address = OnlineAddress.find_or_create_by(url: link,
                                                        link_type: have_direct_url_to_stream?(link))
       online_address.id

--- a/test/jobs/calendar_importer/event_resolver_test.rb
+++ b/test/jobs/calendar_importer/event_resolver_test.rb
@@ -11,6 +11,7 @@ class EventsResolverTest < ActiveSupport::TestCase
     :rrule,
     :last_modified,
     :custom_properties,
+    :url,
     # Fixes bug where entire argument to .new ended up under the uid value lmao
     # Who knew our importer was *that* robust?!
     keyword_init: true


### PR DESCRIPTION
Closes #2417 

When importing iCal feeds, detect any URL in the URL field and mark it as `indirect`
