### PR TITLE
Partner hidden warning

### DIFF
--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -177,7 +177,7 @@
     <hr>
     <% unless @partner.new_record? %>
       <% if policy(@partner).permitted_attributes.include? :hidden %>
-        <div class="alert alert-light border" role="alert">
+        <div id='partner-moderation' class="alert alert-light border" role="alert">
           <h2 class="alert-heading">Moderation</h2>
           <p>Hiding a partner is a last resort, and will remove them from all PlaceCal sites, not just yours. This is appropriate if a partner suddenly starts publishing things like spam or hate speech. In such cases, hiding a partner is the right action and we appreciate your help in keeping PlaceCal a safe place to be.</p>
           <p>Hiding a partner does not delete them. It will notify both the partner and the PlaceCal team, using the information you fill out.</p>

--- a/app/views/admin/partners/edit.html.erb
+++ b/app/views/admin/partners/edit.html.erb
@@ -2,6 +2,13 @@
 <h1 class="page-header">Edit Partner: <em><%= @partner.name %></em></h1>
 
 <p>ID: <%= @partner.id %></p>
+
+<% if @partner.hidden %>
+  <div class='alert alert-danger'>
+    This partner is set to <strong>hidden</strong> and will not show on any public sites! (<a href='#partner-moderation'>Change this</a>)
+  </div>
+<% end %>
+
 <%# Show the Neighbourhood the partner is related to via Address %>
 <% if @partner.address&.neighbourhood&.present? -%>
     <p>Address in neighbourhood <%= link_to_neighbourhood(@partner.address.neighbourhood) %>.</p>
@@ -11,6 +18,7 @@
 <% if @partner.service_areas.any? -%>
     <p>In service areas <%= service_area_links(@partner) %>.</p>
 <% end -%>
+
 
 <%# Show a list of sites that the partner is related to %>
 <span id="partner-sites">

--- a/app/views/admin/partners/edit.html.erb
+++ b/app/views/admin/partners/edit.html.erb
@@ -18,7 +18,7 @@
     <% if partners_sites_links.present? %>
 	<p>View this partner on: <%= site_links %> (opens in new tab).</p>
     <% else %>
-	<p class="text-danger">This partner does not appear on any sites. This usually means one of two things:</p>
+	<p class="text-danger">This partner does not appear on any sites. This usually means one of three things:</p>
 	<ul>
 	    <li>The address is outside any current PlaceCal instance's range due to where actual ward boundaries happen to fall. Please contact your PlaceCal organiser if this is the case.</li>
 	    <li>It is inside a PlaceCal range, but you forgot to add a tag. Resave this partner with the appropriate tag.</li>


### PR DESCRIPTION
Closes #2364 #2419

Fixes text

Add warning banner to admins that partner is hidden
![Screenshot_2024-04-22_16-07-59](https://github.com/geeksforsocialchange/PlaceCal/assets/109223824/1567a0f7-329e-46a7-b9b8-2ffae8abfce4)


(Copy/Layout TBC)