### PR TITLE
2373 calendar last updated

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -373,6 +373,7 @@ Rails/SkipsModelValidations:
     - 'lib/tasks/fixes/users.rake'
     - 'db/migrate/20240125175508_partner_hidden_attribute_set_value.rb'
     - 'db/migrate/20240411200641_partner_can_be_assigned_events_set_value.rb'
+    - 'db/migrate/20240422092628_set_calendar_checksum_date.rb'
 
 # Offense count: 22
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/app/controllers/admin/calendars_controller.rb
+++ b/app/controllers/admin/calendars_controller.rb
@@ -107,7 +107,8 @@ module Admin
         :importer_mode,
         :public_contact_name,
         :public_contact_phone,
-        :public_contact_email
+        :public_contact_email,
+        :checksum_updated_at
       )
     end
   end

--- a/app/datatables/calendar_datatable.rb
+++ b/app/datatables/calendar_datatable.rb
@@ -18,7 +18,7 @@ class CalendarDatatable < Datatable
       events: { source: 'Calendar.events', searchable: false, orderable: false },
       state: { source: 'Calendar.calendar_state', searchable: false, orderable: false },
       last_import_at: { source: 'Calendar.last_import_at', searchable: false, orderable: false },
-      updated_at: { source: 'Calendar.updated_at', searchable: false, orderable: false }
+      checksum_updated_at: { source: 'Calendar.checksum_updated_at', searchable: false, orderable: false }
     }
   end
 
@@ -32,7 +32,7 @@ class CalendarDatatable < Datatable
         events: record.events&.count&.to_s || 0,
         state: record.calendar_state,
         last_import_at: json_datetime(record.last_import_at),
-        updated_at: json_datetime(record.updated_at)
+        checksum_updated_at: json_datetime(record.checksum_updated_at)
       }
     end
   end

--- a/app/jobs/calendar_importer/calendar_importer_task.rb
+++ b/app/jobs/calendar_importer/calendar_importer_task.rb
@@ -27,7 +27,7 @@ class CalendarImporter::CalendarImporterTask
       purge_stale_events_from_calendar
     end
 
-    calendar.flag_complete_import_job! notices, calendar_source.checksum, parser::KEY
+    calendar.flag_complete_import_job! notices, parser::KEY
   end
 
   private
@@ -53,7 +53,7 @@ class CalendarImporter::CalendarImporterTask
   end
 
   def event_data_from_parser
-    return [] if !force_import && calendar.last_checksum == calendar_source.checksum
+    return [] if !force_import && !calendar_source.checksum_changed
 
     calendar_source.events.map do |event_data|
       CalendarImporter::EventResolver.new(event_data, calendar, notices, from_date)

--- a/app/jobs/calendar_importer/parsers/base.rb
+++ b/app/jobs/calendar_importer/parsers/base.rb
@@ -32,6 +32,15 @@ module CalendarImporter::Parsers
       data = download_calendar
       checksum = digest(data)
 
+      ## record if checksum has changed since last time we interacted with it.
+      ## if download_calendar fails it should raise an exception so this code won't run
+      if @calendar.last_checksum != checksum
+        @calendar.update!(
+          last_checksum: checksum,
+          checksum_updated_at: DateTime.current
+        )
+      end
+
       return Output.new([], checksum) if !@force_import && (@calendar.last_checksum == checksum)
 
       Output.new(import_events_from(data), checksum)

--- a/app/jobs/calendar_importer/parsers/ics.rb
+++ b/app/jobs/calendar_importer/parsers/ics.rb
@@ -36,7 +36,9 @@ module CalendarImporter::Parsers
     def download_calendar
       # Why are we doing this?
       url = @url.gsub(%r{webcal://}, 'https://') # Remove the webcal:// and just use the part after it
-      Base.read_http_source url
+      res = Base.read_http_source url
+      # sanatize google calendar to prevent each requesting resetting the checksum
+      res.split("\n").reject { |l| l.include? 'DTSTAMP' }.join("\n")
     end
 
     def import_events_from(data)

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -174,7 +174,7 @@ class Calendar < ApplicationRecord
   # @param checksum [integer]
   #   integer checksum of retrieved source payload
   # @return nothing
-  def flag_complete_import_job!(notices, checksum, importer_used)
+  def flag_complete_import_job!(notices, _checksum, importer_used)
     transaction do
       return unless calendar_state.in_worker?
 
@@ -183,9 +183,7 @@ class Calendar < ApplicationRecord
       update!(
         calendar_state: :idle,
         notices: notices,
-        last_checksum: checksum,
         last_import_at: DateTime.current,
-        checksum_updated_at: DateTime.current,
         critical_error: nil,
         importer_used: importer_used
       )

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -174,7 +174,7 @@ class Calendar < ApplicationRecord
   # @param checksum [integer]
   #   integer checksum of retrieved source payload
   # @return nothing
-  def flag_complete_import_job!(notices, _checksum, importer_used)
+  def flag_complete_import_job!(notices, importer_used)
     transaction do
       return unless calendar_state.in_worker?
 
@@ -188,6 +188,18 @@ class Calendar < ApplicationRecord
         importer_used: importer_used
       )
 
+    ensure
+      Calendar.record_timestamps = true
+    end
+  end
+
+  def flag_checksum_change!(checksum)
+    transaction do
+      Calendar.record_timestamps = false
+      update!(
+        last_checksum: checksum,
+        checksum_updated_at: DateTime.current
+      )
     ensure
       Calendar.record_timestamps = true
     end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -185,6 +185,7 @@ class Calendar < ApplicationRecord
         notices: notices,
         last_checksum: checksum,
         last_import_at: DateTime.current,
+        checksum_updated_at: DateTime.current,
         critical_error: nil,
         importer_used: importer_used
       )

--- a/app/views/admin/calendars/_form.html.erb
+++ b/app/views/admin/calendars/_form.html.erb
@@ -5,7 +5,7 @@
 </p>
 
 <%# don't show importer stats if it's never run %>
-<% unless @calendar.last_import_at == nil %>
+<% if @calendar.last_import_at.present? %>
   <%= render('importer_overview', calendar: @calendar) %>
 <% end %>
 <hr>

--- a/app/views/admin/calendars/_form.html.erb
+++ b/app/views/admin/calendars/_form.html.erb
@@ -4,7 +4,10 @@
       class: "btn btn-sm btn-primary" unless @calendar.new_record? %>
 </p>
 
-<%= render 'importer_overview', calendar: @calendar %>
+<%# don't show importer stats if it's never run %>
+<% unless @calendar.last_import_at == nil %>
+  <%= render('importer_overview', calendar: @calendar) %>
+<% end %>
 <hr>
 
 <div id="js-calendar-form">

--- a/app/views/admin/calendars/_importer_overview.html.erb
+++ b/app/views/admin/calendars/_importer_overview.html.erb
@@ -3,6 +3,13 @@
     <hr>
     <h3>Import status</h3>
 
+    <% if calendar.checksum_updated_at < 6.month.ago || calendar.last_import_at < 6.month.ago %>
+      <div class="alert alert-warning" role="alert">
+        <h4 class="alert-heading">Potential stale calender</h4>
+        <p>Is this calender still active? It has not been updated in over 6 months</p>
+      </div>
+    <% end %>
+
     <% if calendar.calendar_state.idle? %>
       <% retry_button = :idle %>
       <h4><span class="badge badge-success">success</span></h4>
@@ -32,7 +39,7 @@
 
       <% if calendar.last_import_at.present? %>
           <p>
-        <strong>Last update to calendar events made <%= time_ago_in_words(calendar.last_import_at) %> ago</strong> (<%= calendar.last_import_at %>)
+        <strong>Last import ran <%= time_ago_in_words(calendar.last_import_at) %> ago</strong> (<%= calendar.last_import_at %>)
           </p>
       <% end %>
 

--- a/app/views/admin/calendars/_importer_overview.html.erb
+++ b/app/views/admin/calendars/_importer_overview.html.erb
@@ -2,15 +2,10 @@
     <% retry_button = nil %>
     <hr>
     <h3>Import status</h3>
-    
+
     <% if calendar.calendar_state.idle? %>
-	<% retry_button = :idle %>
-	<h4><span class="badge badge-success">success</span></h4>
-	<% if calendar.last_import_at.present? %>
-	    <p>
-		<strong>Last updated <%= time_ago_in_words(calendar.last_import_at) %> ago</strong> (<%= calendar.last_import_at %>)
-	    </p>
-	<% end %>
+      <% retry_button = :idle %>
+      <h4><span class="badge badge-success">success</span></h4>
     <% end %>
 
     <% if calendar.calendar_state.in_queue? || calendar.calendar_state.in_worker? %>
@@ -27,6 +22,19 @@
 	    Error: <%= calendar.critical_error %>
 	</div>
     <% end %>
+
+    
+    <% if calendar.checksum_updated_at.present? %>
+      <p>
+        <strong>Source data last changed <%= time_ago_in_words(calendar.checksum_updated_at) %> ago</strong> (<%= calendar.checksum_updated_at %>)
+      </p>
+    <% end %>
+
+      <% if calendar.last_import_at.present? %>
+          <p>
+        <strong>Last update to calendar events made <%= time_ago_in_words(calendar.last_import_at) %> ago</strong> (<%= calendar.last_import_at %>)
+          </p>
+      <% end %>
 
     <% if calendar.notices.present? %>
 	<% retry_button = :error %>

--- a/app/views/admin/calendars/index.html.erb
+++ b/app/views/admin/calendars/index.html.erb
@@ -25,7 +25,7 @@ var columns = [
     title: 'Calendars',
     model: :calendars,
     column_titles: ['Name', 'Partners', 'Notices', 'Events', 'Status', 'Last imported', 'Last updated'],
-    columns: %i[name partner notice_count events calendar_state last_import_at updated_at],
+    columns: %i[name partner notice_count events calendar_state last_import_at checksum_updated_at],
     data: @calendars,
     source: admin_calendars_path(format: :json),
     new_link: new_admin_calendar_path

--- a/app/views/admin/calendars/index.html.erb
+++ b/app/views/admin/calendars/index.html.erb
@@ -11,7 +11,7 @@ var columns = [
          return (type == "display") ? date.strtime : date.unixtime;
      }
     },
-    {"data": "updated_at",
+    {"data": "checksum_updated_at",
      "render": function (data, type, row) {
          date = JSON.parse(data.replace(/&quot;/g, '"'));
          return (type == "display") ? date.strtime : date.unixtime;

--- a/app/views/admin/calendars/index.html.erb
+++ b/app/views/admin/calendars/index.html.erb
@@ -24,7 +24,7 @@ var columns = [
 <%= render partial: 'layouts/admin/datatable', locals: {
     title: 'Calendars',
     model: :calendars,
-    column_titles: ['Name', 'Partners', 'Notices', 'Events', 'Status', 'Last imported', 'Last updated'],
+    column_titles: ['Name', 'Partners', 'Notices', 'Events', 'Status', 'Last imported', 'Source updated'],
     columns: %i[name partner notice_count events calendar_state last_import_at checksum_updated_at],
     data: @calendars,
     source: admin_calendars_path(format: :json),

--- a/app/views/admin/sites/show.html.erb
+++ b/app/views/admin/sites/show.html.erb
@@ -9,6 +9,7 @@
       <th>Name</th>
       <th>State</th>
       <th>Last imported at</th>
+      <th>Last source data change at</th>
     </tr>
   </thead>
   <tbody>
@@ -17,8 +18,10 @@
       <td><%= calendar.id %></td>
       <td><%= link_to calendar.name, edit_admin_calendar_path(calendar) %></td>
       <td><%= calendar.calendar_state %></td>
-      <td><span title="<%= calendar.last_import_at %>"><%= calendar_last_imported(calendar) %></span></td>
+      <td><span title="<%= calendar.last_import_at %>"><%= time_ago_in_words(calendar.last_import_at) %></span></td>
+      <td><span title="<%= calendar.checksum_updated_at %>"><%= time_ago_in_words(calendar.checksum_updated_at) %></span></td>
     </tr>
     <% end %>
   <tbody>
 </table>
+

--- a/db/migrate/20240422091648_calendar_checksum_date.rb
+++ b/db/migrate/20240422091648_calendar_checksum_date.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CalendarChecksumDate < ActiveRecord::Migration[7.1]
-  def change
+  def up
     add_column :calendars, :checksum_updated_at, :datetime
   end
 end

--- a/db/migrate/20240422091648_calendar_checksum_date.rb
+++ b/db/migrate/20240422091648_calendar_checksum_date.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CalendarChecksumDate < ActiveRecord::Migration[7.1]
+  def change
+    add_column :calendars, :checksum_updated_at, :datetime
+  end
+end

--- a/db/migrate/20240422092628_set_calendar_checksum_date.rb
+++ b/db/migrate/20240422092628_set_calendar_checksum_date.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SetCalendarChecksumDate < ActiveRecord::Migration[7.1]
+  def change
+    Calendar.update_all('checksum_updated_at=last_import_at')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_11_200641) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_22_092628) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_200641) do
     t.string "calendar_state", default: "idle"
     t.string "importer_mode", default: "auto"
     t.string "importer_used"
+    t.datetime "checksum_updated_at"
     t.index ["partner_id"], name: "index_calendars_on_partner_id"
     t.index ["place_id"], name: "index_calendars_on_place_id"
   end

--- a/test/controllers/admin/calendars_controller_test.rb
+++ b/test/controllers/admin/calendars_controller_test.rb
@@ -14,6 +14,7 @@ class Admin::CalendarControllerTest < ActionDispatch::IntegrationTest
       @neighbourhood_admin.neighbourhoods << @neighbourhood
 
       @calendar = create(:calendar, partner: @partner, place: @partner)
+      @calendar.update!(last_import_at: 1.month.ago)
 
       @citizen = create(:user)
 

--- a/test/factories/calendar.rb
+++ b/test/factories/calendar.rb
@@ -3,6 +3,9 @@
 FactoryBot.define do
   factory(:calendar) do
     name { 'Zion Centre' }
+    after :create do |cal|
+      cal.last_import_at = 1.month.ago
+    end
 
     # VCR.use_cassette(:import_test_calendar) do
     source { 'https://calendar.google.com/calendar/ical/mgemn0rmm44un8ucifb287coto%40group.calendar.google.com/public/basic.ics' }
@@ -10,7 +13,6 @@ FactoryBot.define do
     public_contact_name { 'Public Calendar Name' }
     public_contact_email { 'public@communitygroup.com' }
     public_contact_phone { '0161 0000000' }
-    last_import_at { 1.month.ago }
     checksum_updated_at { 1.month.ago }
 
     partner

--- a/test/factories/calendar.rb
+++ b/test/factories/calendar.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
     public_contact_name { 'Public Calendar Name' }
     public_contact_email { 'public@communitygroup.com' }
     public_contact_phone { '0161 0000000' }
+    last_import_at { 1.month.ago }
+    checksum_updated_at { 1.month.ago }
 
     partner
 

--- a/test/integration/admin/calendars_integration_test.rb
+++ b/test/integration/admin/calendars_integration_test.rb
@@ -15,6 +15,7 @@ class Admin::CalendarsTest < ActionDispatch::IntegrationTest
 
     VCR.use_cassette(:import_test_calendar) do
       @calendar = create(:calendar, partner: @partner, place: @partner)
+      @calendar.update!(last_import_at: 1.month.ago)
     end
 
     host! 'admin.lvh.me'

--- a/test/jobs/calendar_importer/calendar_importer_task_test.rb
+++ b/test/jobs/calendar_importer/calendar_importer_task_test.rb
@@ -235,4 +235,32 @@ class CalendarImporterTaskTest < ActiveSupport::TestCase
       assert_equal 52, created_events.count # (at time of recording)
     end
   end
+
+  test 'checksum date does not change on each import' do
+    VCR.use_cassette('Placecal Hulme & Moss Side Google Cal', allow_playback_repeats: true) do
+      calendar = create(
+        :calendar,
+        name: 'Placecal Hulme & Moss Side',
+        source: 'https://calendar.google.com/calendar/ical/alliscalm.net_u2ktkhtig0b7u9bd9j8re3af2k%40group.calendar.google.com/public/basic.ics',
+        strategy: 'place'
+      )
+
+      calendar.update calendar_state: 'in_worker'
+
+      importer_task = CalendarImporter::CalendarImporterTask.new(calendar, Date.today, true)
+      importer_task.run
+      assert_equal 'idle', calendar.calendar_state
+      checksum_date = calendar.checksum_updated_at
+
+      Timecop.freeze(16.days.from_now) do
+        calendar.update calendar_state: 'in_worker'
+        future_task = CalendarImporter::CalendarImporterTask.new(calendar, Date.today, true)
+        future_task.run
+        assert_equal 'idle', calendar.calendar_state
+      end
+
+      assert_not_equal calendar.last_import_at, calendar.checksum_updated_at
+      assert_equal checksum_date, calendar.checksum_updated_at
+    end
+  end
 end

--- a/test/models/calendar_state_test.rb
+++ b/test/models/calendar_state_test.rb
@@ -55,7 +55,7 @@ class CalendarStateTest < ActiveSupport::TestCase
   test 'can move into idle state' do
     VCR.use_cassette(:import_test_calendar) do
       calendar = create(:calendar, calendar_state: :in_worker, source: SOURCE_URL)
-      calendar.flag_complete_import_job! [], 0, 'ical'
+      calendar.flag_complete_import_job! [], 'ical'
       assert_predicate calendar.calendar_state, :idle?
       # are we close enough?
       # deal with weird database encoding serialisations

--- a/test/models/calendar_test.rb
+++ b/test/models/calendar_test.rb
@@ -162,7 +162,7 @@ class CalendarTest < ActiveSupport::TestCase
 
       # flag_complete_import_job
       calendar.calendar_state = :in_worker
-      calendar.flag_complete_import_job! [], 123_456, 'null'
+      calendar.flag_complete_import_job! [],  'null'
       assert_equal today, calendar.updated_at
 
       # flag_bad_source


### PR DESCRIPTION
fixes #2373 

- added date of checksum to modal and record when we update.
- set this on all existing calendars to be the same as the import date as that's when the checksum would have been made before
- update the checksum as soon as we can / separate it out from the importer completion
- I thought I would need to stop it hashing a failed network request but the whole job stops running if that happens so no problem
-  remove request date from ical feeds, only effecting google but that makes up a very high percentage of our feeds.
- add a test to show importer / checksum increment independantly
- update ui to surface info
  - I changed "events changed" to "importer ran" which differs from the AC but that date can be incremented even if the import finds no new events.
  - I referenced "source data" / "source" as I thought that might make more sense than "checksum"
  - warning shows up on the calendar form (not index) if either import or checksum date are older than  6 months

We unfortunately won't get a sense of how out of date stuff is for a while as the two figures will only start diverging from release date.

form view

![image](https://github.com/geeksforsocialchange/PlaceCal/assets/6824891/374d5d99-5e17-4f7a-9abf-8901b1ba1a72)

sites calendar index

![image](https://github.com/geeksforsocialchange/PlaceCal/assets/6824891/93642e41-e831-42fb-b2ca-d70bfc1b323d)

Calendars index view

![image](https://github.com/geeksforsocialchange/PlaceCal/assets/6824891/2fe0a057-355a-4937-a3fd-269907d438f6)


6 month warning

![image](https://github.com/geeksforsocialchange/PlaceCal/assets/6824891/a277d35c-a211-49b7-aeac-f6664e6df1ac)
