### PR TITLE
Update event design to make organising partner clearer

### DIFF
--- a/app/assets/stylesheets/base/grid.scss
+++ b/app/assets/stylesheets/base/grid.scss
@@ -116,6 +116,24 @@ $column: 17.38317%;
 	}
 }
 
+.three-col {
+	-moz-column-count: 3;
+	-webkit-column-count: 3;
+	column-count: 3;
+	-webkit-column-width: 20rem;
+	-moz-column-width: 20rem;
+	column-width: 20rem;
+	margin-top: 1.35rem !important;
+
+	li:first-of-type {
+		margin-top: -1.35rem;
+	}
+
+	a {
+		display: inline-block;
+	}
+}
+
 @supports (display: grid) {
 	.two-col {
 		display: grid;
@@ -123,6 +141,22 @@ $column: 17.38317%;
 
 		@include for-tablet-landscape-up {
 			grid-template-columns: 1fr 1fr;
+		}
+
+		grid-gap: 1rem;
+		align-items: start;
+
+		li:first-of-type {
+			margin-top: 0;
+		}
+	}
+
+	.three-col {
+		display: grid;
+		grid-template-columns: 1fr;
+
+		@include for-tablet-landscape-up {
+			grid-template-columns: 1fr 1fr 1fr;
 		}
 
 		grid-gap: 1rem;

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,7 +4,7 @@
 
 <%= render_component "event", context: :page, event: @event, primary_neighbourhood: @primary_neighbourhood %>
 
-<div class="c c--narrow c--space-after event__fullinfo">
+<div class="c c--narrowish c--space-after event__fullinfo">
   <%= @event.description_html.to_s.html_safe %>
   <%= event_link(@event) %>
 
@@ -12,8 +12,8 @@
 
   <%= online_link %>
 
-  <div class="g two-col">
-    <div class="gi gi__1-2">
+  <div class="g three-col">
+    <div class="gi gi__1-3">
       <% if @event.partner %>
         <h3 class="h4 udl">Contact information</h3>
         <div class="small">
@@ -26,13 +26,19 @@
         <% end %>
       </div>
     </div>
-    <div class="gi gi__1-2">
+    <div class="gi gi__1-3">
       <h3 class="h4 udl">Event address</h3>
       <div class="small">
         <%= render_component "address",
             address: @event.address,
 	    raw_location: @event.raw_location_from_source
         %>
+      </div>
+    </div>
+    <div class="gi gi__1-3">
+      <h3 class="h4 udl">Event organiser</h3>
+      <div class="small">
+        <span><%= link_to @event.partner, @event.partner %></span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #2426 

## Description

Adds another column to the event page, just to make it clear who the partner owner of an event is, ie who is the source of its calendar.