### PR TITLE
2400 next eventful period

### DIFF
--- a/app/components/event_list/_event_list.html.erb
+++ b/app/components/event_list/_event_list.html.erb
@@ -24,5 +24,5 @@
     </ol>
   <% end %>
 <% else %>
-  <p>No events with this selection. <a href=<%= next_url(@next, period, sort, repeating)%>>skip to next date with events</a>.</p>
+  <p>No events with this selection.<% if @next.present? %> <a href=<%= next_url(@next, period, sort, repeating)%>>skip to next date with events</a>.<% end %></p>
 <% end %>

--- a/app/components/event_list/_event_list.html.erb
+++ b/app/components/event_list/_event_list.html.erb
@@ -24,5 +24,5 @@
     </ol>
   <% end %>
 <% else %>
-  <p>No events with this selection.</p>
+  <p>No events with this selection. <a href=<%= next_url(@next, period, sort, repeating)%>>skip to next date with events</a>.</p>
 <% end %>

--- a/app/components/event_list/_event_list.html.erb
+++ b/app/components/event_list/_event_list.html.erb
@@ -24,5 +24,5 @@
     </ol>
   <% end %>
 <% else %>
-  <p>No events with this selection.<% if @next.present? %> <a href=<%= next_url(@next, period, sort, repeating)%>>skip to next date with events</a>.<% end %></p>
+  <p>No events with this selection.<% if @next.present? %> <a href=<%= next_url(@next)%>>skip to next date with events</a>.<% end %></p>
 <% end %>

--- a/app/components/event_list/_event_list.html.erb
+++ b/app/components/event_list/_event_list.html.erb
@@ -24,5 +24,5 @@
     </ol>
   <% end %>
 <% else %>
-  <p>No events with this selection.<% if @next.present? %> <a href=<%= next_url(@next)%>>skip to next date with events</a>.<% end %></p>
+  <p>No events with this selection.<%= link_to 'skip to next date with events.', next_url(@next) if @next.present? %></p>
 <% end %>

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -29,10 +29,15 @@ class EventsController < ApplicationController
     @multiple_days = true
 
     @next = if params[:year]
-              Event.for_site(current_site).future(
+              date = begin
                 Date.new(params[:year].to_i,
                          params[:month].to_i,
                          params[:day].to_i)
+              rescue Date::Error
+                Time.zone.today
+              end
+              Event.for_site(current_site).future(
+                date
               ).first
             else
               Event.for_site(current_site).future(

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -28,7 +28,7 @@ class EventsController < ApplicationController
     @events = sort_events(@events, @sort)
     @multiple_days = true
 
-    @next = if params[:year]
+    @next = if params[:year].present?
               date = begin
                 Date.new(params[:year].to_i,
                          params[:month].to_i,

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -28,6 +28,18 @@ class EventsController < ApplicationController
     @events = sort_events(@events, @sort)
     @multiple_days = true
 
+    @next = if params[:year]
+              Event.for_site(current_site).future(
+                Date.new(params[:year].to_i,
+                         params[:month].to_i,
+                         params[:day].to_i)
+              ).first
+            else
+              Event.for_site(current_site).future(
+                Time.zone.today
+              ).first
+            end
+
     respond_to do |format|
       format.html do
         if params[:simple].present?

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -35,4 +35,17 @@ module EventsHelper
   def html_to_plaintext(input)
     Nokogiri::HTML.fragment(input).text
   end
+
+  def next_url(next_event, period, sort, repeating)
+    # "/#{path}/#{next_event.dtstart.year}/#{next_event.dtstart.month}/#{next_event.dtstart.day}#{url_suffix}#paginator"
+    opts = []
+    opts << "period=#{period}"
+    opts << "sort=#{sort}" if sort
+    opts << "repeating=#{repeating}" if repeating
+
+    # http://climatejustice.lvh.me:3000/events/2024/5/15[%22period=day%22,
+
+    opts = "?#{opts.join('&')}" if opts.any?
+    "/events/#{next_event.dtstart.year}/#{next_event.dtstart.month}/#{next_event.dtstart.day}#{opts}#paginator"
+  end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -36,12 +36,17 @@ module EventsHelper
     Nokogiri::HTML.fragment(input).text
   end
 
-  def next_url(next_event, period, sort, repeating)
-    opts = []
-    opts << "period=#{period}"
-    opts << "sort=#{sort}" if sort
-    opts << "repeating=#{repeating}" if repeating
-    opts = "?#{opts.join('&')}" if opts.any?
-    "/events/#{next_event.dtstart.year}/#{next_event.dtstart.month}/#{next_event.dtstart.day}#{opts}#paginator"
+  def next_url(next_event)
+    opts = {
+      year: next_event.dtstart.year,
+      month: next_event.dtstart.month,
+      day: next_event.dtstart.day,
+      anchor: 'paginator',
+      period: @period,
+      sort: @sort,
+      repeating: @repeating
+    }.keep_if { |_key, value| value.present? }
+
+    events_by_date_path(opts)
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -37,14 +37,10 @@ module EventsHelper
   end
 
   def next_url(next_event, period, sort, repeating)
-    # "/#{path}/#{next_event.dtstart.year}/#{next_event.dtstart.month}/#{next_event.dtstart.day}#{url_suffix}#paginator"
     opts = []
     opts << "period=#{period}"
     opts << "sort=#{sort}" if sort
     opts << "repeating=#{repeating}" if repeating
-
-    # http://climatejustice.lvh.me:3000/events/2024/5/15[%22period=day%22,
-
     opts = "?#{opts.join('&')}" if opts.any?
     "/events/#{next_event.dtstart.year}/#{next_event.dtstart.month}/#{next_event.dtstart.day}#{opts}#paginator"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
 
   # Events
   resources :events, only: %i[index show]
-  get '/events/:year/:month/:day' => 'events#index', constraints: ymd
+  get '/events/:year/:month/:day' => 'events#index', constraints: ymd, as: :events_by_date
 
   # Partners
   resources :partners, only: %i[index show]


### PR DESCRIPTION
fixes #2400 

Grabs the next future event, takes it's start date and links to it using the same logic as the paginator. Retains "period" mode and won't show if there's no future events.

https://github.com/geeksforsocialchange/PlaceCal/assets/6824891/ee771365-b9b1-4eb0-bf2c-161958834802