### PR TITLE
Handle events with URLs in 'location' field

### DIFF
--- a/app/components/address/address_component.rb
+++ b/app/components/address/address_component.rb
@@ -12,6 +12,10 @@ class AddressComponent < MountainView::Presenter
       return address_lines.join(', <br>').html_safe
     end
 
+    uri = URI.parse(raw_location)
+    "<a href='#{uri}'>#{uri.hostname}</a>".html_safe
+
+  rescue URI::InvalidURIError
     raw_location
   end
 end

--- a/app/jobs/calendar_importer/events/ics_event.rb
+++ b/app/jobs/calendar_importer/events/ics_event.rb
@@ -52,6 +52,7 @@ module CalendarImporter::Events
       # Either return the google conference value, or find the link in the description
       link = @event.url
       link ||= @event.custom_properties['x_google_conference']
+      link ||= maybe_location_is_link
       link ||= find_event_link
 
       link = link.first if link.is_a?(Array)
@@ -65,6 +66,15 @@ module CalendarImporter::Events
     end
 
     private
+
+    def maybe_location_is_link
+      return if location.blank?
+
+      URI.parse(location).to_s
+
+    rescue URI::InvalidURIError
+      # no URL found
+    end
 
     def have_direct_url_to_stream?(link)
       domain = event_link_types.keys.find { |domain| link.include?(domain) }


### PR DESCRIPTION
Closes #2437 

If an event has a URL as its location field, make it in to an Online event. 

Also the location is still the URL (on the show event page) but now it is a link

![Screenshot_2024-04-25_15-26-08](https://github.com/geeksforsocialchange/PlaceCal/assets/109223824/6e0aa548-8eff-47e3-936a-cf31414d322e)