### PR TITLE
Tiny tweak to skip to next date copy

### DIFF
--- a/app/components/event_list/_event_list.html.erb
+++ b/app/components/event_list/_event_list.html.erb
@@ -24,5 +24,6 @@
     </ol>
   <% end %>
 <% else %>
-  <p>No events with this selection.<%= link_to 'skip to next date with events.', next_url(@next) if @next.present? %></p>
+  <p>No events with this selection.</p>
+  <p><%= link_to 'Skip to next date with events.', next_url(@next) if @next.present? %></p>
 <% end %>


### PR DESCRIPTION
Lil spacing /formatting issue: addressing this

<img width="580" alt="Screenshot 2024-04-29 at 15 29 28" src="https://github.com/geeksforsocialchange/PlaceCal/assets/511734/13fac4f3-78d9-472e-a6e5-79ea4e7d6162">

