### PR TITLE
Fix partner creation validations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ end
 
 group :development do
   gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'foreman'
   gem 'graphiql-rails'
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
       rack (>= 0.9.0)
     bigdecimal (3.1.7)
     bindex (0.8.1)
+    binding_of_caller (1.0.1)
+      debug_inspector (>= 1.2.0)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     bootstrap (4.6.2)
@@ -138,6 +140,7 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.4)
+    debug_inspector (1.2.0)
     delayed_job (4.1.10)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)
@@ -490,6 +493,7 @@ DEPENDENCIES
   ajax-datatables-rails
   ancestry
   better_errors
+  binding_of_caller
   bootsnap
   bootstrap
   capybara-select-2

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -23,7 +23,7 @@ module Admin
 
     def new
       @partner = params[:partner] ? Partner.new(permitted_attributes(Partner)) : Partner.new
-      @partner.tags = current_user.tags
+      @partner.partnerships = current_user.partnerships
 
       authorize @partner
     end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -18,10 +18,10 @@ module PartnersHelper
   end
 
   def options_for_partner_partnerships
-    options = policy_scope(Partnership)
-              .select(:name, :type, :id)
-              .order(:name)
-              .map { |r| [r.name, r.id] }
+    policy_scope(Partnership)
+      .select(:name, :type, :id)
+      .order(:name)
+      .map { |r| [r.name, r.id] }
   end
 
   def permitted_options_for_partner_tags

--- a/app/javascript/controllers/partner_form_validation_controller.js
+++ b/app/javascript/controllers/partner_form_validation_controller.js
@@ -6,8 +6,6 @@ export default class extends Controller {
 	static targets = ["source"];
 
 	connect() {
-		console.log("PartnerFormValidationController.connect");
-
 		const inputDebouncePeriod = 500; // ms
 		const baseUrl = "/partners/lookup_name";
 

--- a/app/javascript/controllers/partner_tags_controller.js
+++ b/app/javascript/controllers/partner_tags_controller.js
@@ -4,8 +4,6 @@ export default class extends Controller {
 	static values = { permittedTags: [String] };
 
 	connect() {
-		console.log("PartnerTagsController.connect");
-
 		const getSelectValues = (select) => {
 			return [...(select && select.options)].reduce((accumulator, option) => {
 				if (option.selected) {

--- a/app/javascript/controllers/partner_tags_controller.js
+++ b/app/javascript/controllers/partner_tags_controller.js
@@ -4,6 +4,8 @@ export default class extends Controller {
 	static values = { permittedTags: [String] };
 
 	connect() {
+		console.log("PartnerTagsController.connect");
+
 		const getSelectValues = (select) => {
 			return [...(select && select.options)].reduce((accumulator, option) => {
 				if (option.selected) {

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -112,7 +112,7 @@ class Partner < ApplicationRecord
 
   validate :three_or_less_category_tags
 
-  validate :partnership_admins_must_add_tag, on: %i[create]
+  validate :partnership_admins_must_add_partnership, on: %i[create]
 
   validate :must_give_reason_to_hide
 
@@ -507,13 +507,13 @@ class Partner < ApplicationRecord
     errors.add :categories, 'Partners can have a maximum of 3 Category tags'
   end
 
-  def partnership_admins_must_add_tag
+  def partnership_admins_must_add_partnership
     return if accessed_by_user.nil? # HACK: to stop factory breaking tests
     return unless accessed_by_user.partnership_admin?
 
-    if tags.any?
-      accessed_by_user.tags.each do |t|
-        return true if tags.include? t
+    if partnership_ids.any?
+      accessed_by_user.tags.pluck(:id).each do |t|
+        return true if partnership_ids.include? t
       end
     end
 

--- a/app/views/admin/partners/_form.html.erb
+++ b/app/views/admin/partners/_form.html.erb
@@ -144,17 +144,7 @@
     <hr>
     <h2>Tags</h2>
     <p>What other associations does this partner have?</p>
-    <% if  current_user.partnership_admin? || current_user.root? %>
-      <%= f.association :partnerships,
-          label: "Partnerships",
-          hint: "Which communities of interest should this partner appear on?",
-          collection: options_for_partner_partnerships(),
-          input_html: { class: 'form-check', data: { 
-            controller: 'partner-tags',
-            "partner-tags-permitted-tags-value": permitted_options_for_partner_tags 
-          } } %>
-      <hr>
-    <% end %>
+    <%= render 'partnership_fields', f: f %>
     <%= f.association :facilities,
         label: "Facilities",
         hint: "What infrastructure does this partner provide?",

--- a/app/views/admin/partners/_partnership_fields.html.erb
+++ b/app/views/admin/partners/_partnership_fields.html.erb
@@ -1,0 +1,14 @@
+<% if current_user.partnership_admin? || current_user.root? -%>
+<h2>Partnerships</h2>
+<%= f.association :partnerships,
+    label: "Partnerships",
+    hint: "Which partnerships is this partner in?",
+    collection: options_for_partner_partnerships,
+    input_html: { 
+      class: 'form-check', data: { 
+        controller: 'partner-tags',
+        "partner-tags-permitted-tags-value": permitted_options_for_partner_tags 
+      } 
+    } 
+%>
+<% end -%>

--- a/app/views/admin/partners/new.html.erb
+++ b/app/views/admin/partners/new.html.erb
@@ -52,13 +52,12 @@
         </div>
       </div>
     </div>
-    <hr>
+
     <% if  current_user.partnership_admin? || current_user.root? %>
-    <h2>Tags</h2>
-    <p>What other associations does this partner have?</p>
+    <h2>Partnerships</h2>
       <%= f.association :partnerships,
           label: "Partnerships",
-          hint: "Which communities of interest should this partner appear on?",
+          hint: "Which partnerships is this partner in?",
           collection: options_for_partner_partnerships(),
           input_html: { class: 'form-check', data: { 
             controller: 'partner-tags',

--- a/app/views/admin/partners/new.html.erb
+++ b/app/views/admin/partners/new.html.erb
@@ -53,22 +53,14 @@
       </div>
     </div>
 
-    <% if  current_user.partnership_admin? || current_user.root? %>
-    <h2>Partnerships</h2>
-      <%= f.association :partnerships,
-          label: "Partnerships",
-          hint: "Which partnerships is this partner in?",
-          collection: options_for_partner_partnerships(),
-          input_html: { class: 'form-check', data: { 
-            controller: 'partner-tags',
-            "partner-tags-permitted-tags-value": permitted_options_for_partner_tags 
-          } } %>
-      <hr>
-    <% end %>
+    <%= render 'partnership_fields', f: f %>
+
+    <hr>
+    
     <br>
     <div class="row">
       <div class="col-sm-12">
-        <%= f.submit "Save Partner", class: "btn btn-primary btn-lg" %><br><br><br>
+        <%= f.submit "Save and continue...", class: "btn btn-primary btn-lg" %><br><br><br>
         <% unless @partner.new_record? %>
           <% if policy(@partner).destroy? %>
             <%= link_to "Delete Partner", @partner, method: :delete, class: "btn btn-danger btn-sm", id: 'destroy-partner'  %>

--- a/test/models/partner_test.rb
+++ b/test/models/partner_test.rb
@@ -420,7 +420,7 @@ class PartnerTest < ActiveSupport::TestCase
 
   test 'partnership_admin can create a partner that is part of their partnership' do
     pa = create(:partnership_admin)
-    partner = create(:partner, :accessed_by_user => pa, :tags => [pa.tags.first])
+    partner = create(:partner, :accessed_by_user => pa, :partnerships => [pa.partnerships.first])
     assert_predicate partner, :valid?
   end
 

--- a/test/system/admin/partner_test.rb
+++ b/test/system/admin/partner_test.rb
@@ -174,7 +174,7 @@ class AdminPartnerTest < ApplicationSystemTestCase
     assert_predicate service_areas, :present?
     select2 @neighbourhood_one, xpath: service_areas.last.path
 
-    click_button 'Save Partner'
+    click_button 'Save and continue...'
     assert_selector '.alert-success'
   end
 end


### PR DESCRIPTION
- Added back in a gem that drops console into the error pages (unclear why this was removed)
- Did some refactoring to reduce duplicate code
- Fixed validation error
- Renamed methods to make clearer
- Create partner form now properly pre-populates

Fixes #2454