### PR TITLE
Strip whitespace around partner, calendar and address information

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem 'graphql'
 gem 'rack-cors', require: 'rack/cors'
 
 # Utilities
+gem 'auto_strip_attributes'
 gem 'bootsnap', require: false
 gem 'enumerize'
 gem 'friendly_id'

--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ end
 
 group :development do
   gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'foreman'
   gem 'graphiql-rails'
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
       rack (>= 0.9.0)
     bigdecimal (3.1.7)
     bindex (0.8.1)
+    binding_of_caller (1.0.1)
+      debug_inspector (>= 1.2.0)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     bootstrap (4.6.2)
@@ -138,6 +140,7 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.4)
+    debug_inspector (1.2.0)
     delayed_job (4.1.10)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)
@@ -490,6 +493,7 @@ DEPENDENCIES
   ajax-datatables-rails
   ancestry
   better_errors
+  binding_of_caller
   bootsnap
   bootstrap
   capybara-select-2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
       activerecord (>= 5.2.6)
     ansi (1.5.0)
     ast (2.4.2)
+    auto_strip_attributes (2.6.0)
+      activerecord (>= 4.0)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     base64 (0.2.0)
@@ -492,6 +494,7 @@ PLATFORMS
 DEPENDENCIES
   ajax-datatables-rails
   ancestry
+  auto_strip_attributes
   better_errors
   binding_of_caller
   bootsnap

--- a/app/javascript/controllers/partner_tags_controller.js
+++ b/app/javascript/controllers/partner_tags_controller.js
@@ -4,6 +4,8 @@ export default class extends Controller {
 	static values = { permittedTags: [String] };
 
 	connect() {
+		console.log("PartnerTagsController.connect");
+
 		const getSelectValues = (select) => {
 			return [...(select && select.options)].reduce((accumulator, option) => {
 				if (option.selected) {

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -15,6 +15,8 @@ class Address < ApplicationRecord
 
   belongs_to :neighbourhood, optional: true
 
+  auto_strip_attributes :street_address, :street_address2, :street_address3, :city, :postcode
+
   scope :find_by_street_or_postcode, lambda { |street, postcode|
     where(street_address: street).or(where(postcode: postcode))
   }

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -30,7 +30,7 @@ class Calendar < ApplicationRecord
   # Output the calendar's name when it's requested as a string
   alias_attribute :to_s, :name
 
-  auto_strip_attributes :name, :url, :public_contact_name, :public_contact_email, :public_contact_phone
+  auto_strip_attributes :name, :source, :public_contact_name, :public_contact_email, :public_contact_phone
 
   # Defines the strategy this Calendar uses to assign events to locations.
   # @attr [Enumerable<Symbol>] :strategy

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -30,6 +30,8 @@ class Calendar < ApplicationRecord
   # Output the calendar's name when it's requested as a string
   alias_attribute :to_s, :name
 
+  auto_strip_attributes :name, :url, :public_contact_name, :public_contact_email, :public_contact_phone
+
   # Defines the strategy this Calendar uses to assign events to locations.
   # @attr [Enumerable<Symbol>] :strategy
   enumerize(

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -112,7 +112,7 @@ class Partner < ApplicationRecord
 
   validate :three_or_less_category_tags
 
-  validate :partnership_admins_must_add_tag, on: %i[create]
+  validate :partnership_admins_must_add_partnership, on: %i[create]
 
   validate :must_give_reason_to_hide
 
@@ -507,13 +507,13 @@ class Partner < ApplicationRecord
     errors.add :categories, 'Partners can have a maximum of 3 Category tags'
   end
 
-  def partnership_admins_must_add_tag
+  def partnership_admins_must_add_partnership
     return if accessed_by_user.nil? # HACK: to stop factory breaking tests
     return unless accessed_by_user.partnership_admin?
 
-    if tags.any?
-      accessed_by_user.tags.each do |t|
-        return true if tags.include? t
+    if partnership_ids.any?
+      accessed_by_user.tags.pluck(:id).each do |t|
+        return true if partnership_ids.include? t
       end
     end
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -65,6 +65,8 @@ class Partner < ApplicationRecord
 
   accepts_nested_attributes_for :service_areas, allow_destroy: true
 
+  auto_strip_attributes :name, :summary, :url, :twitter_handle, :instagram_handle, :facebook_link, :public_phone, :public_email
+
   # Validations
   validates :name,
             presence: true,

--- a/app/views/admin/partners/new.html.erb
+++ b/app/views/admin/partners/new.html.erb
@@ -52,13 +52,12 @@
         </div>
       </div>
     </div>
-    <hr>
+
     <% if  current_user.partnership_admin? || current_user.root? %>
-    <h2>Tags</h2>
-    <p>What other associations does this partner have?</p>
+    <h2>Partnerships</h2>
       <%= f.association :partnerships,
           label: "Partnerships",
-          hint: "Which communities of interest should this partner appear on?",
+          hint: "Which partnerships is this partner in?",
           collection: options_for_partner_partnerships(),
           input_html: { class: 'form-check', data: { 
             controller: 'partner-tags',


### PR DESCRIPTION
This is causing a few issues:

- Partners can be created with dupe names but for a space
- Unnessecary validation messages are popping up for url fields with a whitespace before or after when we can just deal with this for people
- Addresss are outputting slightly strangely if they have spcaes at the end of lines

This is just a bit of a QoL tidyup improvement that will solve some of the issues we're seeing from live partners.

Fixes #2450 
Fixes #2452