### PR TITLE
Strip whitespace before saving attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem 'graphql'
 gem 'rack-cors', require: 'rack/cors'
 
 # Utilities
+gem 'auto_strip_attributes'
 gem 'bootsnap', require: false
 gem 'enumerize'
 gem 'friendly_id'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
       activerecord (>= 5.2.6)
     ansi (1.5.0)
     ast (2.4.2)
+    auto_strip_attributes (2.6.0)
+      activerecord (>= 4.0)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     base64 (0.2.0)
@@ -489,6 +491,7 @@ PLATFORMS
 DEPENDENCIES
   ajax-datatables-rails
   ancestry
+  auto_strip_attributes
   better_errors
   bootsnap
   bootstrap

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -15,6 +15,8 @@ class Address < ApplicationRecord
 
   belongs_to :neighbourhood, optional: true
 
+  auto_strip_attributes :street_address, :street_address2, :street_address3, :city, :postcode
+
   scope :find_by_street_or_postcode, lambda { |street, postcode|
     where(street_address: street).or(where(postcode: postcode))
   }

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -30,6 +30,8 @@ class Calendar < ApplicationRecord
   # Output the calendar's name when it's requested as a string
   alias_attribute :to_s, :name
 
+  auto_strip_attributes :name, :source, :public_contact_name, :public_contact_email, :public_contact_phone
+
   # Defines the strategy this Calendar uses to assign events to locations.
   # @attr [Enumerable<Symbol>] :strategy
   enumerize(

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -65,6 +65,8 @@ class Partner < ApplicationRecord
 
   accepts_nested_attributes_for :service_areas, allow_destroy: true
 
+  auto_strip_attributes :name, :summary, :url, :twitter_handle, :instagram_handle, :facebook_link, :public_phone, :public_email
+
   # Validations
   validates :name,
             presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,8 @@ class User < ApplicationRecord
   has_many :tags, through: :tags_users
   has_many :partnerships, through: :tags_users, source: :tag, class_name: 'Partnership'
 
+  auto_strip_attributes :first_name, :last_name, :email, :phone
+
   validates :email,
             presence: true,
             uniqueness: true,


### PR DESCRIPTION
This is causing a few issues:

- Partners can be created with dupe names but for a space
- Unnessecary validation messages are popping up for url fields with a whitespace before or after when we can just deal with this for people
- Addresss are outputting slightly strangely if they have spcaes at the end of lines
- Gem also does things like remove double spaces and stuff like that -- looks well thought out and zero depends

This is just a bit of a QoL tidyup improvement that will solve some of the issues we're seeing from live partners.

Second attempt at this, first one is [here](https://github.com/geeksforsocialchange/PlaceCal/pull/2457).

Fixes #2450 
Fixes #2452