### PR TITLE
fix: reduce event limit to switch to weekly view a touch

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,7 +19,7 @@ class EventsController < ApplicationController
     @repeating = params[:repeating] || 'on'
     @events = filter_events(@period, repeating: @repeating, site: current_site)
     # Duration to view - default to day view if there are too many future events
-    if params[:period].to_s == '' && @events.count > 200
+    if params[:period].to_s == '' && @events.count > 150
       @period = 'week'
       @events = filter_events(@period, repeating: @repeating, site: current_site)
     end


### PR DESCRIPTION
I think this is a little high atm and feedback from organisers has been wanting to switch earlier.

At some point we can add in a feature to pick this manually but for now let's just knock it down a touch.