### PR TITLE
Fix og:image on partners with no image set

### DIFF
--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, @partner.name %>
 <% 
-  if @partner.image
+  if @partner.image.present?
     content_for :image, @partner.image
   else
     content_for :image, @site.og_image


### PR DESCRIPTION
Oversight in the conditional is resulting in the default og image, not the site one, showing up if the partner does not have an image set.

Fixes #2491