### PR TITLE
Change 'domain' attribute to 'url' in Site seed

### DIFF
--- a/db/seeds/004_sites.rb
+++ b/db/seeds/004_sites.rb
@@ -7,7 +7,7 @@ module SeedTags
     Site.create!(
       name: 'Default Site',
       slug: 'default-site',
-      domain: 'default-site.placecal.org'
+      url: 'default-site.placecal.org'
     )
   end
 end


### PR DESCRIPTION
This change fixes an error that occurs when running `bin/setup`.

The Site seed referenced a `domain` attribute that's no longer part of the DB schema. It looks like `domain` was renamed to `url` in [this commit](https://github.com/geeksforsocialchange/PlaceCal/commit/888ef007da74d11cf5e3ec558cd35049752de58a), but this file wasn't updated to reflect that.