### PR TITLE
Migrate the AddressComponent to using ViewComponent

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,4 +131,5 @@ Lint/SelfAssignment:
   Enabled: false
 Lint/RedundantCopDisableDirective:
   Enabled: false
-
+Lint/MissingSuper:
+  Enabled: false

--- a/app/components/address_component.html.erb
+++ b/app/components/address_component.html.erb
@@ -1,0 +1,3 @@
+<p class="place_info__address" property="address" typeof="PostalAddress">
+  <%= formatted_address %>
+</p>

--- a/app/components/address_component.rb
+++ b/app/components/address_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddressComponent < ViewComponent::Base
+  def initialize(address, raw_location: nil)
+    @address = address
+    @raw_location = raw_location
+  end
+
+  def formatted_address
+    # rubocop:disable Rails/OutputSafety
+    if address.present?
+
+      address_lines = address.all_address_lines.map(&:strip)
+      return address_lines.join(', <br>').html_safe
+    end
+
+    uri = URI.parse(raw_location)
+    "<a href='#{uri}'>#{uri.hostname}</a>".html_safe
+
+  rescue URI::InvalidURIError
+    raw_location
+  end
+  # rubocop:enable Rails/OutputSafety
+end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,9 +29,9 @@
     <div class="gi gi__1-3">
       <h3 class="h4 udl">Event address</h3>
       <div class="small">
-        <%= render_component "address",
-            address: @event.address,
-	    raw_location: @event.raw_location_from_source
+        <%= render(
+          AddressComponent.new(address: @event.address, raw_location: @event.raw_location_from_source)
+        )
         %>
       </div>
     </div>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -97,9 +97,10 @@
         <div class="gi gi__1-2">
           <h3 class="udl udl--fw allcaps h4">Address</h3>
           <div class="small">
-            <%= render_component "address",
-              address: place.address
-            %>
+        <%= render(
+          AddressComponent.new(address: place.address)
+        )
+        %>
           </div>
           <h3 class="udl udl--fw allcaps h4">Contact</h3>
           <div class="small">

--- a/test/components/address_component_test.rb
+++ b/test/components/address_component_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'view_component/test_case'
+
+class AddressComponentTest < ViewComponent::TestCase
+  setup do
+    VCR.use_cassette('import_test_calendar') do
+      @test_event = create(:event)
+      @address = @test_event.address.street_address
+      @raw_location = @test_event.raw_location_from_source
+    end
+  end
+
+  def test_component_renders_address
+    render_inline AddressComponent.new(address: @address, raw_location: @raw_location)
+    assert_text 'Unformatted Address, Ungeolocated Lane, Manchester'
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--Read comments, before committing pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] Title include "WIP" if work is in progress.
-->

Partially resolves #2270 

## Description

This PR migrates the `AddressComponent` to use `ViewComponent` instead of Mountain View. 
Updated the calls to `AddressComponent` as well to partners' and events' index pages.

### Motivation and Context
From [the issue](https://github.com/geeksforsocialchange/PlaceCal/issues/2270):

> `mountain_view` gem has not scaled at all well and has a bunch of weird issues with integrating with JavaScript.

> We therefore need to migrate to a newer solution, `view_component`

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### How Has This Been Tested?

Currently the attempt at a test in `test/components/address_component_test.rb` is failing.
Need to see how to display the event and partner pages.