### PR TITLE
chore: Add component guidelines for PlaceCal

### DIFF
--- a/app/components/guidelines.md
+++ b/app/components/guidelines.md
@@ -1,0 +1,47 @@
+# Component Guidelines
+
+## About
+
+This serves as the reference documentation for components in PlaceCal (how to generate them etc).
+In case you find something unclear, inaccurate or out of date, please feel to create a new issue describing what needs doing :smile:
+
+## Technical Details
+
+PlaceCal currently uses [ViewComponent](https://viewcomponent.org/) for all new components. Previously the gem [`mountain_view`](https://github.com/devnacho/mountain_view) was used but has since been deprecated and is in the process of being removed (see [this issue](https://github.com/geeksforsocialchange/PlaceCal/issues/2270))
+
+### Creating a new component
+
+[Follow the instructions](https://viewcomponent.org/guide/generators.html) over on the ViewComponents' documentation to generate a new component.
+
+### Folder structure
+
+For simple components, the component and its template should appear in `app/components/` as shown below:
+
+```
+components
+├── address_component.rb            # Component definition
+└── address_component.html.erb      # HTML template
+```
+
+For more complex components, they should have their own folder. Using the above as an example, the folder structure would look like so:
+
+```
+components
+├── address_component.rb            # Component definition
+└── address_component
+    ├── address_component.html.erb  # HTML template
+    ├── address_component.js        # Optional: Stimulus controller
+    └── address_component.scss      # Optional: Component-namespaced scss
+```
+
+### Linting
+
+Components follow the same conventions as regular Ruby on Rails code. RuboCop gets run as part of our [pre-commit](https://github.com/geeksforsocialchange/PlaceCal/blob/main/package.json#L33-L36) hooks so any violations found will automatically be fixed. Whatever can't be fixed, you'll have to fix yourself :grinning:
+
+### Testing
+
+When testing components, please make sure that you write unit tests that only exercise the component's rendering logic. This means that no usage of VCR or an overly elaborate test data setup within the component test.
+
+### Il8n
+
+Localization is handled by the files in the `config/locales` directory.


### PR DESCRIPTION
Added component guidelines for PlaceCal. 

# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,

Partially resolves #2551 (the component guidelines item in the checklist)

## Description

Added component guidelines for PlaceCal. 
This will allow new contributors easily understand how to interact with components when developing.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is meant to provide clarity on how we structure components in the PlaceCal repository as well as what we expect when new components are added/modified/removed

Relevant issues are #2641 (for reading the discussion there) as well as #2638 (the first PR in moving components from `mountain_view` to `view_component`

### Type of change

- [x] Documentation update

### How Has This Been Tested?

By previewing the resulting markdown file.