### PR TITLE
fix: Remove ref to deleted asset

### DIFF
--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -18,18 +18,6 @@
         <% if @collection.description %>
           <div class="first-ele-lg"><%# = markdown @collection.description %></div>
         <% end %>
-
-        <%# FIXME: this needs to be killed after launch! %>
-        <% if @collection.id == 1 %>
-          <p>
-            <%= link_to 'Download winter leaflet (PDF, colour)', asset_path('2017/12/placecal_winter2017.pdf'), class: 'btn' %><br>
-            <%= link_to 'Download winter leaflet (PDF, B&W)', asset_path('2017/12/placecal_winter2017_bw.pdf'), class: 'btn' %>
-          </p>
-          <p>
-            <%= link_to 'Download winter A3 Poster (PDF, colour)', asset_path('2017/12/placecal_winter2017_poster.pdf'), class: 'btn' %><br>
-            <%= link_to 'Download winter A3 Poster (PDF, B&W)', asset_path('2017/12/placecal_winter2017_poster_bw.pdf'), class: 'btn' %>
-          </p>
-        <% end %>
       </div>
       <div class="gi gi__2-5 gi--image">
         <% if @collection.image? %>


### PR DESCRIPTION
No idea how this slipped through but this test failing. Note the whole collections system needs removing but this gets CI passing again.

```
 Error:
CollectionsControllerTest#test_should_show_collection:
ActionView::Template::Error: The asset "2017/12/placecal_winter2017.pdf" is not present in the asset pipeline.

    app/views/collections/show.html.erb:25
    test/controllers/collections_controller_test.rb:12:in `block in <class:CollectionsControllerTest>'

663 tests, 1914 assertions, 0 failures, 1 errors, 0 skips
```

<sub><a href="https://huly.app/guest/geeksforsocialchange?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU4YTNlZjFlMDYzMmRkMDhlMmMwNjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2ltLWdlZWtzZm9yc29jaS02NzFlNzVmOS03ZTVlMTU1YzMwLTIxZjkwZCJ9.CvHScLcUGBC_1Vk4VY3TdARaKkSxJfVVIIypy7UFo2U">Huly&reg;: <b>PC-2665</b></a></sub>