### PR TITLE
Fix site seed

### DIFF
--- a/db/seeds/004_sites.rb
+++ b/db/seeds/004_sites.rb
@@ -7,7 +7,7 @@ module SeedTags
     Site.create!(
       name: 'Default Site',
       slug: 'default-site',
-      url: 'default-site.placecal.org'
+      url: 'https://default-site.placecal.org'
     )
   end
 end

--- a/db/seeds/004_sites.rb
+++ b/db/seeds/004_sites.rb
@@ -7,7 +7,7 @@ module SeedTags
     Site.create!(
       name: 'Default Site',
       slug: 'default-site',
-      url: 'https://default-site.placecal.org'
+      url: 'http://default-site.lvh.me:3000'
     )
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--Read comments, before committing pull request read checklist again

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Title include "WIP" if work is in progress.
-->

Resolves # 

## Description

Fixes a big bug in the seed scripts that means that no default site is created when rails db:seed is run on a fresh checkout

### Motivation and Context

This makes the intial setup easier.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I forked the repo, pulled down a copy onto my machine and ran the `bin/setup` script as directed in the readme.  When I started the dev server I saw the message 'You have no site in your database, have you run `rails db:seed`?' which prompted me to check the postgres instance where I could see there wasn't any rows in the site table. I then tried to run the code from `db/seeds/004_sites.rb` in `rails console` and got a message about URLs beginning with https://.  I adjusted the url in the code and re-ran manually at which point it worked.

After that I have deleted the dev and test databases and re-ran `rails db:create`, `rails db:migrate` and `rails db:seed` to check the site has been populated correclty.

### How Will This Be Deployed?

N/A