### PR TITLE
docs: Update CIC to new name

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -40,7 +40,7 @@
       <p>Your information is securely stored on our server in London, UK.</p>
       <p>We keep personal identifiers, contacts and characteristics (as described in the "Type of information we collect" section above) for as long as this information is relevant – meaning as long as a partner, user or calendar this information is associated with is active. ‘Active’ in this sense refers to being a live account which can be logged into by the user, a partner with an associated calendar, or a linked calendar with a working source.</p>
       <p>When a user requests to delete their account we will remove all personal identifying information associated with that user account. This does not automatically remove that same individual’s information from partners and calendars. For a user’s information to be removed from a partner or calendar, or for a partner or calendar that user manages to be deleted, this needs to be specified. Once a user account is deleted their information will be removed from PlaceCal and no longer be accessible by any user or staff.</p>
-      <p>Copies of this data may be created by employees and registered volunteers of Geeks for Social Change Ltd and Place Health Technology CIC solely for development purposes. This information is destroyed when employees leave the company or volunteer agreements end.</p>
+      <p>Copies of this data may be created by employees and registered volunteers of GFSC Community Interest Company solely for development purposes. This information is destroyed when employees leave the company or volunteer agreements end.</p>
 
       <h4>Your data protection rights</h4>
       <p>Under data protection law, you have rights including:</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,7 @@
 en:
   colophon:
     year: "© 2019-%{year}"
-    copyright: "Place Health Technology CIC"
+    copyright: "GFSC Community Interest Company"
     company: "Registered in England and Wales #12135472"
     address: "5 Ribston Street, Manchester, M15 5RH"
   contact:


### PR DESCRIPTION
We have renamed PHT CIC to GFSC CIC for clarity.

This PR changes the name in footer and privacy policy.