### PR TITLE
build: add mutex_m dependency to resolve warnings in console output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,7 @@ group :development do
   gem 'rubocop-rake', require: false
   gem 'spring'
   # gem 'spring-watcher-listen'
+  gem 'mutex_m'
   gem 'web-console'
   gem 'yard'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ group :development do
   gem 'foreman'
   gem 'graphiql-rails'
   gem 'letter_opener'
+  gem 'mutex_m'
   gem 'rails-erd'
   gem 'rdoc'
   gem 'rubocop', '1.75.8', require: false
@@ -111,7 +112,6 @@ group :development do
   gem 'rubocop-rake', require: false
   gem 'spring'
   # gem 'spring-watcher-listen'
-  gem 'mutex_m'
   gem 'web-console'
   gem 'yard'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,7 @@ GEM
     msgpack (1.5.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
+    mutex_m (0.2.0)
     net-imap (0.5.9)
       date
       net-protocol
@@ -557,6 +558,7 @@ DEPENDENCIES
   minitest-rails-capybara
   minitest-reporters
   mountain_view
+  mutex_m
   net-imap
   net-pop
   net-smtp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--Read comments, before committing pull request read checklist again

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] Title include "WIP" if work is in progress.
-->

Resolves # <!--fill issue number-->

## Description

Add the `mutex_m` gem dependency to resolve this noisy warning

```
/usr/local/bundle/gems/spring-2.1.1/lib/spring/watcher/abstract.rb:3: warning: /usr/local/lib/ruby/3.3.0/mutex_m.rb was loaded from the standard library, but will no longer be part of the def
ault gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
Also please contact the author of spring-2.1.1 to request adding mutex_m into its gemspec.
```

### Motivation and Context

This is required in order to improve developer experience, particularly for new developers. It makes runs of `./bin/setup` much cleaner

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

In a Docker image built with the following Dockerfile

```dockerfile
FROM ruby:3.3.6
WORKDIR /src
EXPOSE 3000
ENV MISE_DATA_DIR="/mise"
ENV MISE_CONFIG_DIR="/mise"
ENV MISE_CACHE_DIR="/mise/cache"
ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
ENV PATH="/mise/shims:$PATH"
ENV SITE_DOMAIN=lvh.me
ENV PGPASSWORD=placecal
ENV POSTGRES_USER=placecal
ENV POSTGRES_HOST=postgres
RUN gem install rails bundler
RUN curl https://mise.run | sh
RUN mise use -g yarn@1.22.22 node@20.19.5
RUN mise settings add idiomatic_version_file_enable_tools ruby

ENTRYPOINT [ "/bin/bash" ]
```

This appears to be the same version of Ruby that is being used elsewhere, but somebody should check this

### How Will This Be Deployed?

In development environments this gets run with `./bin/setup`

In production it requires running whatever commands would normally install gem dependencies