### PR TITLE
Fix OutSavvy address and time issues

### DIFF
--- a/app/jobs/calendar_importer/events/linked_data_event.rb
+++ b/app/jobs/calendar_importer/events/linked_data_event.rb
@@ -38,8 +38,17 @@ module CalendarImporter::Events
       return if loc.blank?
 
       address = loc['address']
-      address = address['street_address'] if address.is_a?(Hash)
-      address
+      return loc['name'] unless address.is_a?(Hash)
+
+      # Build full address from components
+      components = [
+        address['street_address'],
+        address['address_locality'],
+        address['address_region'],
+        address['postal_code']
+      ].compact_blank
+
+      components.join(', ').presence || loc['name']
     end
 
     def attributes

--- a/app/jobs/calendar_importer/events/outsavvy_event.rb
+++ b/app/jobs/calendar_importer/events/outsavvy_event.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module CalendarImporter::Events
+  class OutsavvyEvent < LinkedDataEvent
+    # OutSavvy uses malformed timestamps like "2025-06-01T11:00:00:00+01:00"
+    # The extra ":00" before the timezone causes DateTime.parse to ignore the offset.
+    # This override fixes the timestamp before parsing.
+    def parse_timestamp(value)
+      timestamp = value.to_s
+
+      # Remove the extra seconds component before the timezone offset
+      timestamp = timestamp.sub(/:\d{2}([+-])/, '\1') if timestamp.match?(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}:\d{2}[+-]/)
+
+      DateTime.parse timestamp
+    rescue Date::Error
+      nil
+    end
+  end
+end

--- a/app/jobs/calendar_importer/parsers/base.rb
+++ b/app/jobs/calendar_importer/parsers/base.rb
@@ -26,6 +26,10 @@ module CalendarImporter::Parsers
       'event' => 'http://schema.org/event',
       'name' => 'http://schema.org/name',
       'street_address' => 'http://schema.org/streetAddress',
+      'address_locality' => 'http://schema.org/addressLocality',
+      'address_region' => 'http://schema.org/addressRegion',
+      'postal_code' => 'http://schema.org/postalCode',
+      'address_country' => 'http://schema.org/addressCountry',
 
       'logo_url' => { '@id' => 'http://schema.org/logo', '@type' => '@id' },
       'image_url' => { '@id' => 'http://schema.org/image', '@type' => '@id' },

--- a/app/jobs/calendar_importer/parsers/outsavvy.rb
+++ b/app/jobs/calendar_importer/parsers/outsavvy.rb
@@ -6,6 +6,13 @@ module CalendarImporter::Parsers
     KEY = 'outsavvy'
     DOMAINS = %w[outsavvy.com].freeze
 
+    # Custom EventConsumer that uses OutsavvyEvent to handle malformed timestamps
+    class EventConsumer < LdJson::EventConsumer
+      def consume_event(data)
+        events << ::CalendarImporter::Events::OutsavvyEvent.new(data)
+      end
+    end
+
     def self.allowlist_pattern
       %r{^https://www\.outsavvy\.com/organiser/[^/]*/?$}
     end
@@ -29,7 +36,7 @@ module CalendarImporter::Parsers
     end
 
     def import_events_from(data)
-      consumer = CalendarImporter::Parsers::LdJson::EventConsumer.new
+      consumer = EventConsumer.new
       consumer.consume data
       consumer.validate_events
       consumer.events

--- a/spec/jobs/calendar_importer/events/linked_data_event_spec.rb
+++ b/spec/jobs/calendar_importer/events/linked_data_event_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CalendarImporter::Events::LinkedDataEvent do
+  describe "#extract_location" do
+    it "extracts full address with all components" do
+      data = {
+        "url" => "https://example.com/event/123",
+        "name" => "Test Event",
+        "start_date" => { "@value" => "2026-06-01T11:00:00+01:00" },
+        "location" => {
+          "name" => "Test Venue",
+          "address" => {
+            "street_address" => "123 Main Street",
+            "address_locality" => "London",
+            "address_region" => "England",
+            "postal_code" => "SE1 1AA"
+          }
+        }
+      }
+
+      event = described_class.new(data)
+
+      expect(event.location).to eq("123 Main Street, London, England, SE1 1AA")
+    end
+
+    it "extracts postcode from full address" do
+      data = {
+        "url" => "https://example.com/event/123",
+        "name" => "Test Event",
+        "start_date" => { "@value" => "2026-06-01T11:00:00+01:00" },
+        "location" => {
+          "name" => "Test Venue",
+          "address" => {
+            "street_address" => "123 Main Street",
+            "address_locality" => "London",
+            "postal_code" => "SE1 1AA"
+          }
+        }
+      }
+
+      event = described_class.new(data)
+
+      expect(event.postcode).to eq("SE1 1AA")
+    end
+
+    it "handles missing address components gracefully" do
+      data = {
+        "url" => "https://example.com/event/123",
+        "name" => "Test Event",
+        "start_date" => { "@value" => "2026-06-01T11:00:00+01:00" },
+        "location" => {
+          "name" => "Test Venue",
+          "address" => {
+            "street_address" => "123 Main Street",
+            "postal_code" => "SE1 1AA"
+          }
+        }
+      }
+
+      event = described_class.new(data)
+
+      expect(event.location).to eq("123 Main Street, SE1 1AA")
+    end
+
+    it "falls back to venue name when no address hash" do
+      data = {
+        "url" => "https://example.com/event/123",
+        "name" => "Test Event",
+        "start_date" => { "@value" => "2026-06-01T11:00:00+01:00" },
+        "location" => {
+          "name" => "Test Venue"
+        }
+      }
+
+      event = described_class.new(data)
+
+      expect(event.location).to eq("Test Venue")
+    end
+
+    it "returns nil when no location" do
+      data = {
+        "url" => "https://example.com/event/123",
+        "name" => "Test Event",
+        "start_date" => { "@value" => "2026-06-01T11:00:00+01:00" }
+      }
+
+      event = described_class.new(data)
+
+      expect(event.location).to be_nil
+    end
+  end
+
+  describe "#parse_timestamp" do
+    it "parses standard ISO 8601 timestamps" do
+      data = {
+        "url" => "https://example.com/event/123",
+        "name" => "Test Event",
+        "start_date" => { "@value" => "2026-06-01T11:00:00+01:00" }
+      }
+
+      event = described_class.new(data)
+
+      expect(event.start_time).to eq(DateTime.new(2026, 6, 1, 11, 0, 0, "+01:00"))
+    end
+  end
+end

--- a/spec/jobs/calendar_importer/events/outsavvy_event_spec.rb
+++ b/spec/jobs/calendar_importer/events/outsavvy_event_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CalendarImporter::Events::OutsavvyEvent do
+  describe "#parse_timestamp" do
+    it "fixes malformed OutSavvy timestamps with extra seconds component" do
+      # OutSavvy produces timestamps like "2025-06-01T11:00:00:00+01:00"
+      # Note the extra ":00" before the timezone offset
+      data = {
+        "url" => "https://www.outsavvy.com/event/123",
+        "name" => "Test Event",
+        "start_date" => { "@value" => "2025-06-01T11:00:00:00+01:00" },
+        "end_date" => { "@value" => "2025-06-01T18:00:00:00+01:00" }
+      }
+
+      event = described_class.new(data)
+
+      # Should correctly parse as 11:00 BST (British Summer Time, +01:00)
+      expect(event.start_time).to eq(DateTime.new(2025, 6, 1, 11, 0, 0, "+01:00"))
+      expect(event.end_time).to eq(DateTime.new(2025, 6, 1, 18, 0, 0, "+01:00"))
+    end
+
+    it "handles standard timestamps without modification" do
+      data = {
+        "url" => "https://www.outsavvy.com/event/123",
+        "name" => "Test Event",
+        "start_date" => { "@value" => "2025-06-01T11:00:00+01:00" }
+      }
+
+      event = described_class.new(data)
+
+      expect(event.start_time).to eq(DateTime.new(2025, 6, 1, 11, 0, 0, "+01:00"))
+    end
+
+    it "preserves timezone offset from malformed timestamps" do
+      # This test verifies that the timezone is NOT lost (the original bug)
+      data = {
+        "url" => "https://www.outsavvy.com/event/123",
+        "name" => "Test Event",
+        "start_date" => { "@value" => "2025-12-01T19:00:00:00+00:00" }
+      }
+
+      event = described_class.new(data)
+
+      # Should be 19:00 UTC, not 19:00 in local time
+      expect(event.start_time.zone).to eq("+00:00")
+      expect(event.start_time.hour).to eq(19)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fixes #2767 and #2770

## Problem
1. **#2767**: OutSavvy events had address data but it wasn't appearing in the GraphQL API. The address was visible in the UI but the `address` field returned null.

2. **#2770**: OutSavvy events showed times 1 hour off. An event listed as "11AM - 6PM" on OutSavvy was showing as "12PM - 7PM" in PlaceCal.

## Root Causes
1. **Address issue**: The JSON-LD context was missing mappings for `addressLocality`, `addressRegion`, `postalCode`, and `addressCountry`. Also, `LinkedDataEvent#extract_location` was only using `street_address`, discarding the postcode and other components.

2. **Time issue**: OutSavvy produces malformed ISO 8601 timestamps like `2025-06-01T11:00:00:00+01:00` (note the extra `:00` before the timezone). This causes `DateTime.parse` to ignore the timezone offset.

## Solution
1. Added missing address field mappings to the JSON-LD `CONTEXT`
2. Updated `LinkedDataEvent#extract_location` to combine all address components
3. Created `OutsavvyEvent` class (extends `LinkedDataEvent`) that fixes the malformed timestamps
4. Updated `Outsavvy` parser to use a custom `EventConsumer` that creates `OutsavvyEvent` instances

## Testing
- Added `spec/jobs/calendar_importer/events/linked_data_event_spec.rb`
- Added `spec/jobs/calendar_importer/events/outsavvy_event_spec.rb`
- All 163 calendar importer tests pass