### PR TITLE
Update rubocop to 1.84.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,7 @@ group :development do
   gem 'letter_opener'
   gem 'rails-erd'
   gem 'rdoc'
-  gem 'rubocop', '1.82.1', require: false
+  gem 'rubocop', '1.84.0', require: false
   gem 'rubocop-graphql', '1.5.6', require: false
   gem 'rubocop-performance', '1.26.1', require: false
   gem 'rubocop-rails', '2.34.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,7 +485,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.8.0)
+    prism (1.9.0)
     psych (5.3.1)
       date
       stringio
@@ -597,7 +597,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.6)
-    rubocop (1.82.1)
+    rubocop (1.84.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -605,7 +605,7 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.49.0)
@@ -811,7 +811,7 @@ DEPENDENCIES
   rails-erd
   rdoc
   rspec-rails (~> 8.0)
-  rubocop (= 1.82.1)
+  rubocop (= 1.84.0)
   rubocop-graphql (= 1.5.6)
   rubocop-performance (= 1.26.1)
   rubocop-rails (= 2.34.3)

--- a/app/models/neighbourhood.rb
+++ b/app/models/neighbourhood.rb
@@ -180,7 +180,7 @@ class Neighbourhood < ApplicationRecord
     # Refresh cached partners_count for all neighbourhoods
     # Run periodically or after bulk partner changes
     def refresh_partners_count!
-      connection.execute(<<-SQL.squish)
+      connection.execute(<<~SQL.squish)
         UPDATE neighbourhoods SET partners_count = (
           SELECT COUNT(*) FROM (
             SELECT DISTINCT p.id

--- a/app/policies/partner_policy.rb
+++ b/app/policies/partner_policy.rb
@@ -83,15 +83,15 @@ class PartnerPolicy < ApplicationPolicy
 
         # If the user is a partner admin,
         # or if they manage their partnership tag AND they neighbourhood admin for them
-        clause = <<-SQL.squish
-        partners_users.user_id = ? OR
-          (
-          partner_tags.tag_id IN (?) AND
+        clause = <<~SQL.squish
+          partners_users.user_id = ? OR
             (
-              addresses.neighbourhood_id IN (?)
-              OR service_areas.neighbourhood_id IN (?)
+            partner_tags.tag_id IN (?) AND
+              (
+                addresses.neighbourhood_id IN (?)
+                OR service_areas.neighbourhood_id IN (?)
+              )
             )
-          )
         SQL
 
         scope
@@ -109,7 +109,7 @@ class PartnerPolicy < ApplicationPolicy
 
         # If the user is a partner admin,
         # or if they neighbourhood admin for them
-        clause = <<-SQL.squish
+        clause = <<~SQL.squish
           partners_users.user_id = ?
             OR addresses.neighbourhood_id IN (?)
             OR service_areas.neighbourhood_id IN (?)

--- a/db/migrate/20250424153646_change_sites_neighbourhoods_neighbourhood_id_null_constraint.rb
+++ b/db/migrate/20250424153646_change_sites_neighbourhoods_neighbourhood_id_null_constraint.rb
@@ -4,8 +4,8 @@ class ChangeSitesNeighbourhoodsNeighbourhoodIdNullConstraint < ActiveRecord::Mig
   def change
     # Step 1: Clean up existing NULLs (only on migrate up, not down)
     up_only do
-      execute <<-SQL.squish
-          DELETE FROM sites_neighbourhoods WHERE neighbourhood_id IS NULL;
+      execute <<~SQL.squish
+        DELETE FROM sites_neighbourhoods WHERE neighbourhood_id IS NULL;
       SQL
     end
 

--- a/db/migrate/20250424153675_change_users_role_null_constraint.rb
+++ b/db/migrate/20250424153675_change_users_role_null_constraint.rb
@@ -4,8 +4,8 @@ class ChangeUsersRoleNullConstraint < ActiveRecord::Migration[7.2]
   def change
     # Step 1: Clean up existing NULLs (only on migrate up, not down)
     up_only do
-      execute <<-SQL.squish
-          DELETE FROM users WHERE role IS NULL;
+      execute <<~SQL.squish
+        DELETE FROM users WHERE role IS NULL;
       SQL
     end
 

--- a/db/migrate/20260115150112_add_level_to_neighbourhoods.rb
+++ b/db/migrate/20260115150112_add_level_to_neighbourhoods.rb
@@ -7,7 +7,7 @@ class AddLevelToNeighbourhoods < ActiveRecord::Migration[7.2]
 
     reversible do |dir|
       dir.up do
-        execute <<-SQL.squish
+        execute <<~SQL.squish
           UPDATE neighbourhoods SET level = CASE unit
             WHEN 'country' THEN 5
             WHEN 'region' THEN 4

--- a/db/migrate/20260115154606_add_partners_count_to_neighbourhoods.rb
+++ b/db/migrate/20260115154606_add_partners_count_to_neighbourhoods.rb
@@ -8,7 +8,7 @@ class AddPartnersCountToNeighbourhoods < ActiveRecord::Migration[7.2]
     reversible do |dir|
       dir.up do
         # Backfill partner counts using efficient SQL
-        execute <<-SQL.squish
+        execute <<~SQL.squish
           UPDATE neighbourhoods SET partners_count = (
             SELECT COUNT(DISTINCT p.id)
             FROM addresses a


### PR DESCRIPTION
Bump rubocop from 1.82.1 to 1.84.0 and fix 7 autocorrected `Layout/HeredocIndentation` offenses (`<<-` to `<<~`).

Replaces #2904.