### PR TITLE
Prevent browser autofill from triggering email validation

### DIFF
--- a/app/javascript/controllers/partner_wizard_controller.js
+++ b/app/javascript/controllers/partner_wizard_controller.js
@@ -346,6 +346,8 @@ export default class extends Controller {
 	}
 
 	checkAdminEmail() {
+		// Skip if triggered by browser autofill (field not focused)
+		if (document.activeElement !== this.adminEmailTarget) return;
 		this.checkAdminEmailDebounced();
 	}
 

--- a/app/javascript/controllers/user_wizard_controller.js
+++ b/app/javascript/controllers/user_wizard_controller.js
@@ -85,6 +85,8 @@ export default class extends Controller {
 
 	// Email validation
 	checkEmail() {
+		// Skip if triggered by browser autofill (field not focused)
+		if (document.activeElement !== this.emailInputTarget) return;
 		this.checkEmailDebounced();
 	}
 


### PR DESCRIPTION
## Summary
- Fixes #2933 — unable to add a Partner Admin with same name as a Site Admin
- When creating a user with the same first/last name as an existing user, browsers autofill the email field and fire `input` events, triggering the Stimulus email validation showing false "invalid email" errors
- Fix: skip email validation when the email field isn't focused — if the `input` event fired but the user is typing elsewhere, it's browser autofill

## Test plan
- [ ] Create a new user with the same first and last name as an existing user — email field validation should not trigger from autofill
- [ ] Create a new partner and reach step 5 (Invite Admin) — enter a name matching an existing user and verify email validation doesn't trigger from autofill
- [ ] Verify email validation still works correctly when manually typing in the email field