### PR TITLE
Add User-Agent header for TicketSource API requests

### DIFF
--- a/app/jobs/calendar_importer/parsers/api_base.rb
+++ b/app/jobs/calendar_importer/parsers/api_base.rb
@@ -22,6 +22,11 @@ module CalendarImporter
         @calendar.api_token
       end
 
+      # Override in subclasses to set a custom User-Agent header
+      def user_agent
+        nil
+      end
+
       def validate_api_key!
         return if api_key.present?
 
@@ -32,13 +37,13 @@ module CalendarImporter
       def make_api_request(url)
         encoded_key = Base64.strict_encode64("#{api_key}:")
 
-        response = HTTParty.get(
-          url,
-          headers: {
-            'Accept' => 'application/json',
-            'Authorization' => "Basic #{encoded_key}"
-          }
-        )
+        headers = {
+          'Accept' => 'application/json',
+          'Authorization' => "Basic #{encoded_key}"
+        }
+        headers['User-Agent'] = user_agent if user_agent
+
+        response = HTTParty.get(url, headers: headers)
 
         unless response.success?
           case response.code

--- a/app/jobs/calendar_importer/parsers/ticketsource.rb
+++ b/app/jobs/calendar_importer/parsers/ticketsource.rb
@@ -12,12 +12,17 @@ module CalendarImporter
       DOMAINS = %w[www.ticketsource.co.uk ticketsource.co.uk].freeze
 
       API_BASE_URL = 'https://api.ticketsource.io'
+      USER_AGENT = 'ticketsource-placecal'
 
       # Match TicketSource venue pages like:
       # https://www.ticketsource.co.uk/fairfield-house
       # https://ticketsource.co.uk/some-venue
       def self.allowlist_pattern
         %r{^https://(www\.)?ticketsource\.co\.uk/[^/]+/?$}i
+      end
+
+      def user_agent
+        USER_AGENT
       end
 
       def import_events_from(data)


### PR DESCRIPTION
## Summary
- Fixes #2937
- TicketSource's Cloudflare Bot Fight Mode blocks server requests unless a whitelisted User-Agent is set
- TicketSource support provided `ticketsource-placecal` as the required value
- Adds an overridable `user_agent` method to `ApiBase` so other API parsers can set custom headers if needed

## Test plan
- [ ] All 21 TicketSource parser specs pass
- [ ] Deploy to staging and trigger import for calendar 287 (TicketSource / Hive)
- [ ] Verify events are imported successfully