### PR TITLE
WIP: Redirect to home after join form submission

### DIFF
--- a/app/controllers/joins_controller.rb
+++ b/app/controllers/joins_controller.rb
@@ -12,7 +12,7 @@ class JoinsController < ApplicationController
     @join = Join.new(join_params)
 
     if @join.submit
-      redirect_to get_in_touch_path, notice: "Thank you for your interest in PlaceCal. We'll  be in touch with you shortly."
+      redirect_to '/', notice: "Thank you for your interest in PlaceCal. We'll  be in touch with you shortly."
     else
       flash[:error] = 'Please fill out the required fields below'
       render :new


### PR DESCRIPTION
What the title says

# Checklist:

- [x] I have performed a self-review of my own code,

Resolves #1908

## Description

^^^

### Motivation and Context

Currently, you're returned to the join form after submitting it. This change redirects back to home. The 'Thank you for your interest...' notice still appears.

I couldn't find a path or route def for home that `redirect_to` liked so I used the string '/' for now. I'll change it if you can tell me a more correct way.

I could refactor so we redirect to a dedicated after-submission page if you prefer. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Submitted the form and verified new behaviour

### Screenshots

<img width="625" height="450" alt="image" src="https://github.com/user-attachments/assets/aa7e5969-6162-4a26-b42e-363876fddfa1" />

