### PR TITLE
Add hover and transition styles from partner calendar buttons to place calendar buttons

### DIFF
--- a/app/assets/stylesheets/components/neighbourhood_home_card_component.scss
+++ b/app/assets/stylesheets/components/neighbourhood_home_card_component.scss
@@ -19,6 +19,7 @@
 .neighbourhood_home_card__name {
 	margin: 0;
 }
+
 .neighbourhood_home_card__text {
 	margin: 0;
 }
@@ -40,4 +41,12 @@
 	text-decoration: none;
 	white-space: nowrap;
 	width: 100%;
+	transition-property: background-color, color;
+	transition-duration: 0.3s;
+	transition-timing-function: ease-in-out;
+
+	&:hover {
+		background-color: $base-text;
+		color: $base-background;
+	}
 }


### PR DESCRIPTION
Add hover and transition styles from partner calendar buttons to place calendar buttons

# Checklist:

- [x] I have performed a self-review of my own code,

Resolves #1925

## Description

^^^

### Motivation and Context

Addresses UI inconsistency

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested new hover behaviour in Firefox and Chromium

### How Will This Be Deployed?

### Screenshots

existing partner button (no hover)
<img width="648" height="77" alt="image" src="https://github.com/user-attachments/assets/a668fe4d-c903-40c0-9e17-86e712840a85" />

existing partner button (with hover)
<img width="648" height="77" alt="image" src="https://github.com/user-attachments/assets/eefc0beb-59b2-4696-be64-59d51d6d8504" />

existing place button (no hover)
<img width="513" height="87" alt="image" src="https://github.com/user-attachments/assets/cb2aef6d-4e31-4c58-ac78-3ba5d9e7faf5" />

updated place button (with hover)
<img width="513" height="87" alt="image" src="https://github.com/user-attachments/assets/3f4b428c-72ec-48e7-ba63-f5048ff97a53" />
