### PR TITLE
add a max-height:100% to img in base styles

### DIFF
--- a/app/assets/stylesheets/base/image.scss
+++ b/app/assets/stylesheets/base/image.scss
@@ -1,13 +1,14 @@
 img {
 	max-width: 100%;
-}
+	max-height: 100%;
 
-img.rounded {
-	border-radius: 1rem;
-}
+	&.rounded {
+		border-radius: 1rem;
+	}
 
-img.round {
-	border-radius: 50%;
+	&.round {
+		border-radius: 50%;
+	}
 }
 
 figure {


### PR DESCRIPTION
Fruit salad logo was overflowing container on https://placecal.org/find-placecal
This just adds a a max-height: 100% to the existing max-width: 100% in a base rule targetting img elements

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] Title include "WIP" if work is in progress.

Resolves #2947

## Description

^^^

### Motivation and Context

^^^

### Type of change

~- [ ] Bug fix (non-breaking change which fixes an issue)~
~- [ ] Breaking change (fix or feature that would cause existing functionality to change)~
I mean it's a bit of both. Fundamentally there is a root-level CSS change. I haven't found any negative side effects but maybe there's some image somewhere in production which is relying on overflowing vertically

### How Has This Been Tested?

Firefox and Chromium desktop and mobile layout

### How Will This Be Deployed?

### Screenshots

before:
<img width="371" height="275" alt="image" src="https://github.com/user-attachments/assets/6794b4a9-404f-4c81-abf8-818c8ff9e4a7" />
after:
<img width="371" height="275" alt="image" src="https://github.com/user-attachments/assets/4d8bd15d-8977-4cff-9aa9-60685aeb249a" />
