### PR TITLE
Enable automerge for all Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
 		"helpers:pinGitHubActionDigests",
 		"schedule:nonOfficeHours"
 	],
+	"automerge": true,
 	"automergeStrategy": "squash",
 	"labels": ["dependencies"],
 	"lockFileMaintenance": {
@@ -16,21 +17,6 @@
 		"labels": ["security"]
 	},
 	"packageRules": [
-		{
-			"matchUpdateTypes": ["pin", "digest"],
-			"automerge": true
-		},
-		{
-			"matchManagers": ["bundler", "npm"],
-			"matchUpdateTypes": ["minor", "patch"],
-			"matchCurrentVersion": ">=1.0.0",
-			"automerge": true
-		},
-		{
-			"matchManagers": ["nodenv"],
-			"matchUpdateTypes": ["patch"],
-			"automerge": true
-		},
 		{
 			"matchDatasources": ["docker"],
 			"matchPackageNames": ["postgres"],


### PR DESCRIPTION
## Summary

- Adds top-level `automerge: true` to Renovate config so all dependency PRs (including lock file maintenance) automerge after CI passes
- Removes redundant per-rule `automerge: true` settings that are now covered by the global default
- Repo already has "Allow auto-merge" enabled in GitHub settings

## Test plan

- [ ] Verify next Renovate PR gets auto-merge enabled
- [ ] Confirm CI (`ci` job) still gates the merge