### PR TITLE
Extend ical_feed scope to 6 months

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -95,7 +95,7 @@ class Event < ApplicationRecord
   scope :past, -> { where(dtstart: ..DateTime.current.beginning_of_day) }
 
   # Global feed
-  scope :ical_feed, -> { where(dtstart: (Time.now - 1.week)..).where(dtend: ...(Time.now + 6.months)) }
+  scope :ical_feed, -> { where(dtstart: (Time.now - 1.week)..).where(dtend: ...(Time.now + 2.years)) }
 
   def repeat_frequency
     rrule[0]['table']['frequency'].titleize if rrule


### PR DESCRIPTION
iCal feed is overly truncated. This expands it to 6 months in the future.

Fixes #2968