### PR TITLE
Add daily cron job to clean orphaned addresses

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,6 +15,10 @@
 		{
 			"command": "bundle exec rails counters:refresh_all",
 			"schedule": "30 4 * * *"
+		},
+		{
+			"command": "bundle exec rails db:clean_bad_addresses",
+			"schedule": "30 5 * * *"
 		}
 	]
 }


### PR DESCRIPTION
## Summary
- Add `db:clean_bad_addresses` as a daily cron task in `app.json` (5:30 AM, after counter refresh at 4:30 AM)
- Production DB has ~2.69M orphaned addresses not linked to any partner or event — this cleans them up automatically
- Prerequisite for #2970 fix: cleaning orphans first makes the subsequent re-geocoding task much faster

## Test plan
- [ ] Verify `app.json` is valid JSON
- [ ] Confirm cron schedule parses correctly (`30 5 * * *`)
- [ ] Deploy and verify the task runs successfully in production logs