### PR TITLE
Add Y offset to leaflet_controller for marker height

### DIFF
--- a/app/javascript/controllers/leaflet_controller.js
+++ b/app/javascript/controllers/leaflet_controller.js
@@ -43,9 +43,13 @@ export default class extends Controller {
 
 			iconSize: [46, 43], // size of the icon
 			shadowSize: [46, 43], // size of the shadow
-			iconAnchor: [17, 43], // point of the icon which will correspond to marker's location
-			shadowAnchor: [17, 43], // the same for the shadow
-			popupAnchor: [0, 0], // point from which the popup should open relative to the iconAnchor
+
+			// [x,y] offsets. x is left edge to tip of point, y is icon height
+			iconAnchor: [17, 43],
+			shadowAnchor: [17, 43],
+
+			// offset relative to tip of iconAnchor's point. so x=0, y=-iconSize.y
+			popupAnchor: [0, -43],
 		});
 
 		this.map.setView(this.argsValue.center, this.argsValue.zoom);


### PR DESCRIPTION
Resolves #2033

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Updated coords on and address in my local db to match the coords from the example in the linked issue
Panned and zoomed and all looks ok
<img width="483" height="384" alt="image" src="https://github.com/user-attachments/assets/37199e03-bfdd-4e72-95ad-80a63a0c0d1a" />

<img width="483" height="384" alt="image" src="https://github.com/user-attachments/assets/c4943053-8ce7-441a-b332-105ad496300c" />

<img width="483" height="384" alt="image" src="https://github.com/user-attachments/assets/c5f77d37-a2fc-4982-9ab8-d9f8270181bb" />

