### PR TITLE
Add packages:write permission to deploy job

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -186,6 +186,9 @@ jobs:
     concurrency:
       group: deploy-${{ github.event_name == 'release' && 'production' || github.event.inputs.destination || 'staging' }}
       cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: write
 
     env:
       DOCKER_BUILDKIT: 1


### PR DESCRIPTION
## Summary
- GITHUB_TOKEN defaults to read-only for packages in org repos, causing 403 Forbidden when Kamal pushes the Docker image to ghcr.io
- Adds `permissions: packages: write` to the deploy job

## Test plan
- [ ] CI deploys successfully to staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)