### PR TITLE
Sanitize SVG uploads to prevent XSS injection

### DIFF
--- a/app/uploaders/default_uploader.rb
+++ b/app/uploaders/default_uploader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'svg_sanitizer'
+
 class DefaultUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
@@ -12,5 +14,16 @@ class DefaultUploader < CarrierWave::Uploader::Base
   # remember to change max_request_body in config/deploy.yml proxy settings
   def size_range
     (1.byte)..(10.megabytes)
+  end
+
+  # Strip script tags, event handlers, and other dangerous content from SVGs.
+  # Runs automatically after upload for any file with an .svg extension.
+  process :sanitize_svg
+
+  def sanitize_svg
+    return unless file && File.extname(file.file).casecmp('.svg').zero?
+
+    sanitized = SvgSanitizer.sanitize(file.read)
+    File.write(file.file, sanitized)
   end
 end

--- a/lib/svg_sanitizer.rb
+++ b/lib/svg_sanitizer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Sanitizes SVG content by removing script tags, event handlers, and other
+# potentially dangerous elements/attributes that could enable XSS attacks.
+#
+# Uses Nokogiri (already a Rails dependency) for XML parsing.
+module SvgSanitizer
+  # Elements that can execute code or load external resources
+  DANGEROUS_ELEMENTS = %w[
+    script
+    foreignObject
+    set
+    use
+  ].freeze
+
+  # Values that indicate JavaScript execution
+  DANGEROUS_VALUE_PATTERN = /\A\s*javascript:/i
+
+  def self.sanitize(svg_content)
+    doc = Nokogiri::XML(svg_content)
+
+    # Remove dangerous elements
+    DANGEROUS_ELEMENTS.each do |element|
+      doc.css(element).each(&:remove)
+    end
+
+    # Remove dangerous attributes from all elements
+    doc.traverse do |node|
+      next unless node.element?
+
+      node.attributes.each do |name, attr|
+        # Remove event handlers (onclick, onload, onerror, etc.)
+        if name.start_with?('on')
+          attr.remove
+          next
+        end
+
+        # Remove javascript: values from any attribute
+        attr.remove if attr.value.match?(DANGEROUS_VALUE_PATTERN)
+      end
+    end
+
+    doc.to_xml
+  end
+end

--- a/spec/lib/svg_sanitizer_spec.rb
+++ b/spec/lib/svg_sanitizer_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "svg_sanitizer"
+
+RSpec.describe SvgSanitizer do
+  describe ".sanitize" do
+    it "preserves valid SVG content" do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100" fill="red"/></svg>'
+      result = described_class.sanitize(svg)
+      expect(result).to include("<rect")
+      expect(result).to include('fill="red"')
+    end
+
+    it "removes script tags" do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert("xss")</script><rect width="100" height="100"/></svg>'
+      result = described_class.sanitize(svg)
+      expect(result).not_to include("<script")
+      expect(result).not_to include("alert")
+      expect(result).to include("<rect")
+    end
+
+    it "removes foreignObject elements" do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><body xmlns="http://www.w3.org/1999/xhtml"><script>alert(1)</script></body></foreignObject></svg>'
+      result = described_class.sanitize(svg)
+      expect(result).not_to include("foreignObject")
+      expect(result).not_to include("alert")
+    end
+
+    it "removes event handler attributes" do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100" onclick="alert(1)" onload="alert(2)" onerror="alert(3)"/></svg>'
+      result = described_class.sanitize(svg)
+      expect(result).not_to include("onclick")
+      expect(result).not_to include("onload")
+      expect(result).not_to include("onerror")
+      expect(result).to include("<rect")
+    end
+
+    it "removes javascript: hrefs" do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><text>click me</text></a></svg>'
+      result = described_class.sanitize(svg)
+      expect(result).not_to include("javascript:")
+      expect(result).to include("<text")
+    end
+
+    it "preserves safe href values" do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><a href="https://example.com"><text>link</text></a></svg>'
+      result = described_class.sanitize(svg)
+      expect(result).to include('href="https://example.com"')
+    end
+
+    it "removes set elements" do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg"><set attributeName="onmouseover" to="alert(1)"/><rect width="100" height="100"/></svg>'
+      result = described_class.sanitize(svg)
+      expect(result).not_to include("<set")
+      expect(result).to include("<rect")
+    end
+
+    it "handles SVGs with viewBox and other standard attributes" do
+      svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100"><circle cx="50" cy="50" r="40"/></svg>'
+      result = described_class.sanitize(svg)
+      expect(result).to include('viewBox="0 0 100 100"')
+      expect(result).to include("<circle")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `SvgSanitizer` module that strips dangerous content from SVG files on upload
- Removes `<script>`, `<foreignObject>`, `<set>`, `<use>` elements
- Removes event handler attributes (`onclick`, `onload`, `onerror`, etc.)
- Removes `javascript:` URLs from any attribute
- Preserves valid SVG structure and safe attributes
- Applies automatically to all uploaders via `DefaultUploader` (site logos, supporter logos, article images)

## Test plan
- [x] 8 specs covering all sanitization cases
- [ ] Manual test: upload an SVG with a script tag, verify it's stripped
- [ ] Verify existing SVG uploads still render correctly after re-upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)