### PR TITLE
Fix uploaded SVG logos not rendering in navigation

### DIFF
--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -23,22 +23,27 @@ class Components::Navigation < Components::Base
   end
 
   def render_logo
-    # ensure nil if whitespace string
     logo_url = @site&.logo&.url.presence
 
     if @site&.default_site?
-      # home logo for default site
       raw(view_context.svg_image('home/icons/logo.svg', alt_text: 'PlaceCal'))
     elsif logo_url
-      # inline svg or use an image tag if the site has a logo
       if /\.svg$/i.match?(logo_url)
-        raw(view_context.svg_image(logo_url.sub(%r{^/uploads/}, ''), alt_text: @site.name))
+        render_uploaded_svg(logo_url)
       else
         image_tag(logo_url, alt: @site.name)
       end
     else
-      # fallback to header logo
       raw(view_context.svg_image('header.svg', alt_text: 'PlaceCal'))
+    end
+  end
+
+  def render_uploaded_svg(logo_url)
+    file_path = Rails.public_path.join(logo_url.delete_prefix('/'))
+    if File.exist?(file_path)
+      raw(safe(File.read(file_path)))
+    else
+      image_tag(logo_url, alt: @site.name)
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes uploaded SVG logos not rendering in navigation on staging/production.

**Root cause**: PR #3030 changed `navigation.rb#render_logo` to use `inline_svg_tag()` for uploaded SVG logos. The `inline_svg` gem uses `StaticAssetFinder`, which in production (`config.assets.compile = false`) looks up the Sprockets precompiled manifest. User-uploaded files in `public/uploads/` are never precompiled, so `inline_svg_tag` can't find them — rendering `<!-- SVG file not found -->` instead.

**Fix**: For uploaded SVGs, read the file directly from disk with `File.read(Rails.public_path.join(...))` instead of using `inline_svg_tag`. This is safe because SVGs are sanitized on upload by `SvgSanitizer` in `DefaultUploader` (PR #3022). Falls back to an `<img>` tag if the file doesn't exist on disk.

## Changes

- `app/components/navigation.rb` — Extract `render_uploaded_svg` method that reads uploaded SVGs from disk instead of going through Sprockets/inline_svg

## Why not fix inline_svg?

The `inline_svg` gem's asset finder relies on Sprockets' manifest, and `public/uploads` is not part of the precompiled pipeline. Adding it to `config.assets.paths` only helps in development (dynamic compilation), not production. The correct fix is to bypass the asset pipeline entirely for user-uploaded files. See #3037 for Propshaft migration which would simplify this long-term.

## Test plan

- [ ] Visit a sub-site with an uploaded SVG logo (e.g. `manchester.placecal-staging.org`) — logo renders as inline SVG
- [ ] Visit a sub-site with a PNG logo — logo renders as `<img>` tag
- [ ] Visit the default PlaceCal site — default logo renders correctly
- [ ] Visit a sub-site with no logo — fallback header.svg renders
- [ ] `bundle exec rspec spec/components/` — all examples pass