### PR TITLE
Fix partner events paginator and breadcrumb alignment

### DIFF
--- a/app/assets/stylesheets/components/filters.scss
+++ b/app/assets/stylesheets/components/filters.scss
@@ -6,6 +6,9 @@
 	}
 
 	&__toggle {
+		display: flex;
+		align-items: center;
+
 		a {
 			text-decoration: none;
 		}

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -153,8 +153,9 @@ class Views::Partners::Show < Views::Base
 
   def render_events_section
     turbo_frame_tag 'events-browser', data: { turbo_action: 'advance' } do
+      render_events_paginator if paginator
+
       if events.any?
-        render_events_paginator if paginator
         EventList(
           events: events,
           period: period,
@@ -164,7 +165,7 @@ class Views::Partners::Show < Views::Base
           site_tagline: site.tagline
         )
       else
-        p { em { no_event_message } }
+        p { em { no_event_message || empty_period_message } }
       end
     end
   end
@@ -191,6 +192,14 @@ class Views::Partners::Show < Views::Base
           today: current_day == today
         )
       end
+    end
+  end
+
+  def empty_period_message
+    case period
+    when 'day' then 'No events this day.'
+    when 'future' then 'No upcoming events.'
+    else 'No events this week.'
     end
   end
 


### PR DESCRIPTION
## Summary
- **Paginator vanishes on empty weeks**: When navigating to a week with no events on a partner page, the paginator disappeared (it was inside the `events.any?` check), stranding the user with no way to navigate back. Moved it outside so it always renders when pagination is active.
- **Empty state message**: The `no_event_message` was nil for the paginated case, rendering a blank `<em>` tag. Added period-aware fallback messages ("No events this week/day/No upcoming events").
- **Breadcrumb filter stacking**: `.filters__toggle` lacked `display: flex`, causing "Today" and "Go to date" to stack vertically instead of sitting inline.

## Test plan
- [ ] Visit a partner with 30+ upcoming events (e.g. GFSC on manchester)
- [ ] Click a week in the timeline that has no events — paginator should remain visible with "No events this week." message
- [ ] Navigate back using the paginator — should work normally
- [ ] On the events index, navigate to a non-today date — "Today" and "Go to date" should be inline in the breadcrumb bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)