### PR TITLE
Fix: don't render HTML layout around plaintext events output

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -40,7 +40,7 @@ class EventsController < ApplicationController
           )
         end
       end
-      format.text { render Views::Events::IndexText.new(events: @events) }
+      format.text { render Views::Events::IndexText.new(events: @events), layout: false }
       format.ics { render_ical }
     end
   end


### PR DESCRIPTION
## Summary
- Adds `layout: false` to the `.text` format render in `EventsController#index` so plain text responses don't get wrapped in the HTML application layout

## Credit
Patch from @wheresalice

## Test plan
- [ ] Visit `/events.txt` and verify the response is plain text without HTML wrapper