### PR TITLE
Fix neighbourhood admin can't see self in users index (#3057)

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -125,30 +125,37 @@ class UserPolicy < ApplicationPolicy
         scope
           .left_joins(partners: %i[address service_areas partner_tags])
           .where(
-            '(partner_tags.tag_id IN (:tags) AND
+            'users.id = :self_id OR
+            (partner_tags.tag_id IN (:tags) AND
               (
                 addresses.neighbourhood_id IN (:ids) OR
                 service_areas.neighbourhood_id IN (:ids)
               )
             ) OR partners.id IN (:partner_ids)',
+            self_id: user.id,
             ids: user_neighbourhood_ids,
             tags: user_partnership_tag_ids,
             partner_ids: user_partner_ids
           ).distinct
 
-      else
+      elsif user.neighbourhood_admin? || user.partner_admin?
         user_neighbourhood_ids = user.owned_neighbourhood_ids
         user_partner_ids = user.partners.map(&:id)
 
         scope
           .left_joins(partners: %i[address service_areas])
           .where(
-            'addresses.neighbourhood_id IN (:ids) OR
+            'users.id = :self_id OR
+            addresses.neighbourhood_id IN (:ids) OR
             service_areas.neighbourhood_id IN (:ids) OR
             partners.id IN (:partner_ids)',
+            self_id: user.id,
             ids: user_neighbourhood_ids,
             partner_ids: user_partner_ids
           ).distinct
+
+      else
+        scope.none
       end
     end
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -95,5 +95,28 @@ RSpec.describe UserPolicy, type: :policy do
         expect(scope).not_to include(user1)
       end
     end
+
+    describe "for neighbourhood admin" do
+      let(:ward) { create(:riverside_ward) }
+      let(:current_user) { create(:neighbourhood_admin, neighbourhood: ward) }
+
+      it "always includes themselves" do
+        scope = Pundit.policy_scope(current_user, User)
+        expect(scope).to include(current_user)
+      end
+
+      it "includes users with partners in their neighbourhood" do
+        partner_in_hood = create(:partner, address: create(:address, neighbourhood: ward))
+        user_with_partner = create(:user, partners: [partner_in_hood])
+
+        scope = Pundit.policy_scope(current_user, User)
+        expect(scope).to include(user_with_partner)
+      end
+
+      it "excludes users with partners outside their neighbourhood" do
+        scope = Pundit.policy_scope(current_user, User)
+        expect(scope).not_to include(user1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Neighbourhood and partner admins now always see themselves in the users index
- Fixes the `UserPolicy::Scope` which joined through `partners` — admins without partner associations got no results, so they couldn't see their own account
- Citizens now explicitly get `scope.none` instead of falling through to the neighbourhood admin branch
- Adds scope tests for neighbourhood admins (self-inclusion, in-neighbourhood, out-of-neighbourhood)

Closes #3057

## Test plan

- [ ] Log in as a neighbourhood admin with no partner associations — verify you appear in the users index
- [ ] Log in as a neighbourhood admin — verify you can add yourself as a partner admin on a partner in your neighbourhood
- [ ] Log in as a citizen — verify users index is still denied
- [ ] Run `bundle exec rspec spec/policies/user_policy_spec.rb` — 20 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)