### PR TITLE
Replace sass-rails with dartsass-rails (fixes Ruby 4 CSS breakage)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,9 @@ gem 'puma'                        # Web server
 gem 'rails', '~> 8.0'             # Web framework
 
 # Frontend
+gem 'dartsass-rails'              # SCSS stylesheets (public site)
 gem 'importmap-rails'             # ES module imports without bundling
-gem 'sass-rails', '6.0.0'         # SCSS stylesheets (public site)
+gem 'sprockets-rails'             # Asset pipeline (was pulled in by sass-rails)
 gem 'stimulus-rails'              # Stimulus JS controllers
 gem 'turbo-rails'                 # Turbo Drive/Frames/Streams
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,9 @@ GEM
       cucumber (>= 7, < 11)
       railties (>= 6.1, < 9)
     cucumber-tag-expressions (8.1.0)
+    dartsass-rails (0.5.1)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
@@ -326,6 +329,27 @@ GEM
       csv (>= 3.0.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.34.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
     graphiql-rails (1.10.5)
       railties
     graphql (2.5.21)
@@ -674,16 +698,22 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (3.2.2)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.98.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     securerandom (0.4.1)
     selenium-webdriver (4.41.0)
       base64 (~> 0.2)
@@ -730,7 +760,6 @@ GEM
       memoist3 (~> 1.0.0)
     thor (1.5.0)
     thread_safe (0.3.6)
-    tilt (2.7.0)
     timecop (0.9.10)
     timeout (0.6.1)
     traces (0.18.2)
@@ -799,6 +828,7 @@ DEPENDENCIES
   claude-on-rails
   csv
   cucumber-rails
+  dartsass-rails
   database_cleaner-active_record
   database_consistency
   delayed_job_active_record
@@ -847,12 +877,12 @@ DEPENDENCIES
   rubocop-rspec
   ruby-lsp
   ruby-lsp-rails
-  sass-rails (= 6.0.0)
   selenium-webdriver
   shoulda-matchers (~> 7.0)
   simple_form
   simplecov
   spring
+  sprockets-rails
   stimulus-rails
   strict_ivars
   timecop

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,5 @@
 web: bin/rails server -p 3000 -b 0.0.0.0
 css: ./node_modules/.bin/tailwindcss -i ./app/tailwind/admin_tailwind.css -o ./public/assets/admin_tailwind.css --watch=always
+sass: bin/rails dartsass:watch
 job_worker: bin/rails jobs:work
 yard: yard server --reload

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,16 +1,12 @@
 //= link_tree ../fonts
 //= link_tree ../images
 
-// Public site CSS (compiled by Sprockets from SCSS)
-//= link application.css
+// Public site CSS (pre-built by Dart Sass into app/assets/builds/)
+//= link_tree ../builds .css
 
 // NOTE: admin_tailwind.css is built directly to public/assets/ by Tailwind CLI
 // to bypass Sprockets/Sass processing (which fails on modern CSS syntax)
 
-// Site-specific stylesheets (compiled via Sprockets)
-//= link home.css
-//= link_directory ../stylesheets/themes .css
-//= link_directory ../stylesheets/themes/custom .css
 //= link print.css
 
 // JavaScript files for importmap

--- a/app/assets/stylesheets/base/layout.scss
+++ b/app/assets/stylesheets/base/layout.scss
@@ -9,7 +9,8 @@ body {
 
 	@include for-desktop-up {
 		background-image:
-			image-url("patterns/widescreen.svg"), image-url("patterns/widescreen.svg");
+			url("/assets/patterns/widescreen.svg"),
+			url("/assets/patterns/widescreen.svg");
 		background-position:
 			calc(50% - #{$bg-offset}) $bg-top,
 			calc(50% + #{$bg-offset}) $bg-top;

--- a/app/assets/stylesheets/components/hero_component.scss
+++ b/app/assets/stylesheets/components/hero_component.scss
@@ -8,7 +8,7 @@
 
 	// Background graphics
 	background-image:
-		image-url("patterns/mobile-l.svg"), image-url("patterns/mobile-r.svg");
+		url("/assets/patterns/mobile-l.svg"), url("/assets/patterns/mobile-r.svg");
 	background-position:
 		(-2.5rem) 1.5rem,
 		right -2.5rem top 1.5rem;
@@ -16,7 +16,7 @@
 
 	@include for-tablet-portrait-up {
 		background-image:
-			image-url("patterns/tablet-l.svg"), image-url("patterns/tablet-r.svg");
+			url("/assets/patterns/tablet-l.svg"), url("/assets/patterns/tablet-r.svg");
 		background-position:
 			(-6.5rem) -1rem,
 			right -6.5rem top -1rem;

--- a/app/assets/stylesheets/components/home_strapline_component.scss
+++ b/app/assets/stylesheets/components/home_strapline_component.scss
@@ -8,8 +8,8 @@
 
 	@include for-tablet-landscape-up {
 		background-image:
-			image-url("home/site_title/landscape_left.svg"),
-			image-url("home/site_title/landscape_right.svg");
+			url("/assets/home/site_title/landscape_left.svg"),
+			url("/assets/home/site_title/landscape_right.svg");
 		background-repeat: no-repeat;
 		background-position:
 			0 50%,
@@ -24,8 +24,8 @@
 
 	@include for-desktop-up {
 		background-image:
-			image-url("home/site_title/desktop_left.svg"),
-			image-url("home/site_title/desktop_right.svg");
+			url("/assets/home/site_title/desktop_left.svg"),
+			url("/assets/home/site_title/desktop_right.svg");
 		min-height: 477px;
 	}
 }
@@ -40,8 +40,8 @@
 		// the top margin is extending outside of the card and causing layout bugs at smaller sizes
 		margin-top: 0;
 		background-image:
-			image-url("home/site_title/mobile_top.svg"),
-			image-url("home/site_title/mobile_bottom.svg");
+			url("/assets/home/site_title/mobile_top.svg"),
+			url("/assets/home/site_title/mobile_bottom.svg");
 		background-repeat: no-repeat;
 		background-position:
 			50% 0,

--- a/app/assets/stylesheets/home/_card.scss
+++ b/app/assets/stylesheets/home/_card.scss
@@ -49,8 +49,8 @@
 		@include for-phone-only {
 			.card__title {
 				background-image:
-					image-url("home/site_title/mobile_top.svg"),
-					image-url("home/site_title/mobile_bottom.svg");
+					url("/assets/home/site_title/mobile_top.svg"),
+					url("/assets/home/site_title/mobile_bottom.svg");
 				background-repeat: no-repeat;
 				background-position:
 					50% 0,
@@ -72,8 +72,8 @@
 
 		@include for-tablet-portrait-up {
 			background-image:
-				image-url("home/site_title/portrait_left.svg"),
-				image-url("home/site_title/portrait_right.svg");
+				url("/assets/home/site_title/portrait_left.svg"),
+				url("/assets/home/site_title/portrait_right.svg");
 			background-repeat: no-repeat;
 			background-position:
 				0 50%,
@@ -100,8 +100,8 @@
 
 		@include for-tablet-landscape-up {
 			background-image:
-				image-url("home/site_title/landscape_left.svg"),
-				image-url("home/site_title/landscape_right.svg");
+				url("/assets/home/site_title/landscape_left.svg"),
+				url("/assets/home/site_title/landscape_right.svg");
 			min-height: 409px;
 
 			.card__body {
@@ -111,8 +111,8 @@
 
 		@include for-desktop-up {
 			background-image:
-				image-url("home/site_title/desktop_left.svg"),
-				image-url("home/site_title/desktop_right.svg");
+				url("/assets/home/site_title/desktop_left.svg"),
+				url("/assets/home/site_title/desktop_right.svg");
 			min-height: 477 px;
 
 			.card__body {

--- a/app/assets/stylesheets/home/_layout.scss
+++ b/app/assets/stylesheets/home/_layout.scss
@@ -1,7 +1,7 @@
 // this was previously named _headers.scss and additionally contained default site overrides for navigation_component. those are now in the css for navigation_component
 
 body {
-	background-image: image-url("patterns/PlaceCal_Backing.svg");
+	background-image: url("/assets/patterns/PlaceCal_Backing.svg");
 	background-color: $base-text;
 	background-repeat: repeat;
 	background-size: 75rem auto;

--- a/app/assets/stylesheets/home/_pattern.scss
+++ b/app/assets/stylesheets/home/_pattern.scss
@@ -5,8 +5,8 @@
 	&--audience {
 		@include for-tablet-landscape-up {
 			background-image:
-				image-url("home/patterns/landscape/audience_bl.svg"),
-				image-url("home/patterns/landscape/audience_br.svg");
+				url("/assets/home/patterns/landscape/audience_bl.svg"),
+				url("/assets/home/patterns/landscape/audience_br.svg");
 			background-position:
 				bottom left,
 				bottom right;
@@ -14,8 +14,8 @@
 
 		@include for-desktop-up {
 			background-image:
-				image-url("home/patterns/desktop/audience_bl.svg"),
-				image-url("home/patterns/desktop/audience_br.svg");
+				url("/assets/home/patterns/desktop/audience_bl.svg"),
+				url("/assets/home/patterns/desktop/audience_br.svg");
 		}
 	}
 
@@ -23,8 +23,8 @@
 	&--fixall {
 		@include for-tablet-landscape-up {
 			background-image:
-				image-url("home/patterns/landscape/fixall_bl.svg"),
-				image-url("home/patterns/landscape/fixall_tr.svg");
+				url("/assets/home/patterns/landscape/fixall_bl.svg"),
+				url("/assets/home/patterns/landscape/fixall_tr.svg");
 			background-position:
 				bottom left,
 				top right;
@@ -32,8 +32,8 @@
 
 		@include for-desktop-up {
 			background-image:
-				image-url("home/patterns/desktop/fixall_br.svg"),
-				image-url("home/patterns/desktop/fixall_tl.svg");
+				url("/assets/home/patterns/desktop/fixall_br.svg"),
+				url("/assets/home/patterns/desktop/fixall_tl.svg");
 			background-position:
 				bottom right,
 				top left;
@@ -44,22 +44,22 @@
 	&--research {
 		@include for-tablet-portrait-up {
 			background-image:
-				image-url("home/patterns/portrait/research_br.svg"),
-				image-url("home/patterns/portrait/research_tl.svg");
+				url("/assets/home/patterns/portrait/research_br.svg"),
+				url("/assets/home/patterns/portrait/research_tl.svg");
 			background-position:
 				bottom right,
 				top left;
 		}
 
 		@include for-tablet-landscape-up {
-			background-image: image-url("home/patterns/landscape/research_bl.svg");
+			background-image: url("/assets/home/patterns/landscape/research_bl.svg");
 			background-position: bottom left;
 		}
 
 		@include for-desktop-up {
 			background-image:
-				image-url("home/patterns/desktop/research_br.svg"),
-				image-url("home/patterns/desktop/research_tl.svg");
+				url("/assets/home/patterns/desktop/research_br.svg"),
+				url("/assets/home/patterns/desktop/research_tl.svg");
 			background-position:
 				bottom right,
 				top left;
@@ -70,8 +70,8 @@
 	&--thrive {
 		@include for-tablet-portrait-up {
 			background-image:
-				image-url("home/patterns/portrait/thrive_br.svg"),
-				image-url("home/patterns/portrait/thrive_tl.svg");
+				url("/assets/home/patterns/portrait/thrive_br.svg"),
+				url("/assets/home/patterns/portrait/thrive_tl.svg");
 			background-position:
 				bottom right,
 				top left;
@@ -79,14 +79,14 @@
 
 		@include for-tablet-landscape-up {
 			background-image:
-				image-url("home/patterns/landscape/thrive_br.svg"),
-				image-url("home/patterns/landscape/thrive_tl.svg");
+				url("/assets/home/patterns/landscape/thrive_br.svg"),
+				url("/assets/home/patterns/landscape/thrive_tl.svg");
 		}
 
 		@include for-desktop-up {
 			background-image:
-				image-url("home/patterns/desktop/thrive_br.svg"),
-				image-url("home/patterns/desktop/thrive_tl.svg");
+				url("/assets/home/patterns/desktop/thrive_br.svg"),
+				url("/assets/home/patterns/desktop/thrive_tl.svg");
 		}
 	}
 
@@ -94,8 +94,8 @@
 	&--who {
 		@include for-tablet-landscape-up {
 			background-image:
-				image-url("home/patterns/landscape/who_bl.svg"),
-				image-url("home/patterns/landscape/who_tr.svg");
+				url("/assets/home/patterns/landscape/who_bl.svg"),
+				url("/assets/home/patterns/landscape/who_tr.svg");
 			background-position:
 				bottom left,
 				top right;
@@ -103,8 +103,8 @@
 
 		@include for-desktop-up {
 			background-image:
-				image-url("home/patterns/desktop/who_bl.svg"),
-				image-url("home/patterns/desktop/who_tr.svg");
+				url("/assets/home/patterns/desktop/who_bl.svg"),
+				url("/assets/home/patterns/desktop/who_tr.svg");
 		}
 	}
 }

--- a/app/assets/stylesheets/home/pages/_our_story.scss
+++ b/app/assets/stylesheets/home/pages/_our_story.scss
@@ -14,8 +14,8 @@
 			padding-left: $text-spacing-desktop;
 			padding-right: $text-spacing-desktop;
 			background-image:
-				image-url("home/our_story/patterns/intro_tl.svg"),
-				image-url("home/our_story/patterns/intro_br.svg");
+				url("/assets/home/our_story/patterns/intro_tl.svg"),
+				url("/assets/home/our_story/patterns/intro_br.svg");
 			background-position:
 				top left,
 				bottom right;
@@ -36,8 +36,8 @@
 
 		@include for-desktop-up {
 			background-image:
-				image-url("home/our_story/patterns/fix_tl.svg"),
-				image-url("home/our_story/patterns/fix_br.svg");
+				url("/assets/home/our_story/patterns/fix_tl.svg"),
+				url("/assets/home/our_story/patterns/fix_br.svg");
 			background-size:
 				275px 480px,
 				300px 480px;

--- a/app/assets/stylesheets/themes/custom/mossley.scss
+++ b/app/assets/stylesheets/themes/custom/mossley.scss
@@ -26,10 +26,10 @@ body {
 	color: $mossley-text;
 
 	@include for-desktop-up {
-		background-image: image-url("regions/mossley/background@1x.png");
+		background-image: url("/assets/regions/mossley/background@1x.png");
 
 		@include for-retina {
-			background-image: image-url("regions/mossley/background@2x.png");
+			background-image: url("/assets/regions/mossley/background@2x.png");
 		}
 
 		background-position: 50% 3rem;
@@ -159,7 +159,7 @@ a {
 }
 
 .hero_image--mossley {
-	background-image: image-url("regions/mossley/hero-desktop.jpg");
+	background-image: url("/assets/regions/mossley/hero-desktop.jpg");
 	background-size: auto 100%;
 	height: 220px;
 
@@ -236,16 +236,16 @@ a {
 
 .hero {
 	background-image:
-		image-url("regions/mossley/hero-bg@1x.png"),
-		image-url("regions/mossley/hero-bg@1x.png");
+		url("/assets/regions/mossley/hero-bg@1x.png"),
+		url("/assets/regions/mossley/hero-bg@1x.png");
 	background-position:
 		(-7.5rem) 1.5rem,
 		right -9.5rem top 2.5rem;
 
 	@include for-retina {
 		background-image:
-			image-url("regions/mossley/hero-bg@2x.png"),
-			image-url("regions/mossley/hero-bg@2x.png");
+			url("/assets/regions/mossley/hero-bg@2x.png"),
+			url("/assets/regions/mossley/hero-bg@2x.png");
 		background-size: 246px 199px;
 	}
 
@@ -257,16 +257,16 @@ a {
 
 	@include for-tablet-landscape-up {
 		background-image:
-			image-url("regions/mossley/hero-bg-landscape@1x.png"),
-			image-url("regions/mossley/hero-bg-landscape@1x.png");
+			url("/assets/regions/mossley/hero-bg-landscape@1x.png"),
+			url("/assets/regions/mossley/hero-bg-landscape@1x.png");
 		background-position:
 			(-2.5rem) 0rem,
 			right -3.5rem top 1rem;
 
 		@include for-retina {
 			background-image:
-				image-url("regions/mossley/hero-bg-landscape@2x.png"),
-				image-url("regions/mossley/hero-bg-landscape@2x.png");
+				url("/assets/regions/mossley/hero-bg-landscape@2x.png"),
+				url("/assets/regions/mossley/hero-bg-landscape@2x.png");
 			background-size: 400px 327px;
 		}
 	}

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -19,18 +19,8 @@ Rails.application.config.assets.paths << Rails.root.join(Rails.public_path, 'upl
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
 
-# Bypass segfault in sassc 2.* + sprockets 4: https://github.com/rails/sprockets/issues/581#issuecomment-486984663
-Rails.application.config.assets.configure do |env|
-  env.export_concurrent = false
-end
-
 Rails.application.config.assets.precompile += %w[
   print.css
-  sites/hulme.css
-  sites/moss-side.css
-  sites/rusholme.css
-  sites/moston.css
-  sites/mossley.css
   es-module-shims.js
 ]
 

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Configure Dart Sass build entry points.
+# Each key is a source file (relative to app/assets/stylesheets/),
+# each value is the output file (relative to app/assets/builds/).
+
+Rails.application.config.dartsass.builds = {
+  'application.scss' => 'application.css',
+  'home.scss' => 'home.css',
+  'themes/blue.scss' => 'themes/blue.css',
+  'themes/green.scss' => 'themes/green.css',
+  'themes/orange.scss' => 'themes/orange.css',
+  'themes/pink.scss' => 'themes/pink.css',
+  'themes/custom/mossley.scss' => 'themes/custom/mossley.css'
+}
+
+# Silence @import deprecation warnings — migration to @use/@forward is a separate task.
+Rails.application.config.dartsass.build_options = [
+  '--style=compressed',
+  '--no-source-map',
+  '--silence-deprecation=import'
+]


### PR DESCRIPTION
## Summary

- `sassc` (C extension for libsass) segfaults on Ruby 4.0, causing all component `@import` statements in `application.scss` to silently fail — the entire public site has been visually broken since the Ruby 4 upgrade
- Replace `sass-rails`/`sassc` with `dartsass-rails` (Dart Sass, the canonical Sass implementation) which has no native C extensions
- Replace Sprockets `image-url()` helper calls with standard CSS `url()` references
- Add `sprockets-rails` as explicit dependency (was previously pulled in by `sass-rails`)

## What changed

- **Gemfile**: `sass-rails` → `dartsass-rails` + `sprockets-rails`
- **config/initializers/dartsass.rb**: Configure build entry points for all SCSS files and silence `@import` deprecation warnings
- **Procfile.dev**: Add `sass` watcher process for dev
- **manifest.js**: Link pre-built CSS from `app/assets/builds/` instead of individual Sprockets-compiled stylesheets
- **8 SCSS files**: `image-url("path")` → `url("/assets/path")` (Dart Sass doesn't have Sprockets helpers)
- **assets.rb**: Remove old sassc segfault workaround and stale precompile entries

## Follow-up work

- Migrate `@import` to `@use`/`@forward` (currently silenced with `--silence-deprecation=import`)
- `@import` will be removed in Dart Sass 3.0

## Test plan

- [x] `dartsass:build` compiles all entry points successfully
- [x] Dev server screenshot matches staging (background images, layout, component styles all render correctly)
- [ ] Verify on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)