### PR TITLE
Fix deploy: prevent Sprockets from loading removed sass gem

### DIFF
--- a/config/initializers/sprockets_scss.rb
+++ b/config/initializers/sprockets_scss.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Prevent Sprockets from trying to compile .scss files.
+#
+# SCSS compilation is handled entirely by dartsass-rails, which outputs
+# pre-built CSS into app/assets/builds/. However, Sprockets auto-registers
+# a text/scss -> text/css transformer (ScsscProcessor) that tries to load
+# the removed 'sass' gem. Override it with a no-op so Sprockets skips
+# SCSS processing.
+Rails.application.config.after_initialize do
+  noop = ->(input) { { data: input[:data] } }
+  Sprockets.register_transformer 'text/scss', 'text/css', noop
+end


### PR DESCRIPTION
## Summary

- Fixes the deploy failure introduced by #3078 (dartsass-rails migration)
- Sprockets 4 auto-registers a `text/scss` → `text/css` transformer (`ScsscProcessor`) that tries to `require 'sass'`, which was removed when we switched to `dartsass-rails`
- Overrides the transformer with a no-op since dartsass-rails handles all SCSS compilation into `app/assets/builds/`

## Test plan

- [x] `SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile` succeeds locally
- [ ] CI deploy step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)