### PR TITLE
Fix Renovate to sync Node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install Node.js
+# renovate: datasource=node-version depName=node
 ARG NODE_VERSION=24.14.1
 ENV PATH=/usr/local/node/bin:$PATH
 RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
 	"extends": [
 		"config:recommended",
 		"helpers:pinGitHubActionDigests",
-		"schedule:nonOfficeHours"
+		"schedule:nonOfficeHours",
+		"customManagers:dockerfileVersions"
 	],
 	"automerge": true,
 	"automergeStrategy": "squash",
@@ -26,6 +27,11 @@
 		{
 			"matchManagers": ["npm", "rubygems"],
 			"minimumReleaseAge": "7 days"
+		},
+		{
+			"groupName": "node version",
+			"matchDepNames": ["node"],
+			"matchManagers": ["nodenv", "npm", "custom.regex"]
 		}
 	]
 }


### PR DESCRIPTION
## Summary
- Add `# renovate: datasource=node-version depName=node` annotation to Dockerfile so Renovate detects the `ARG NODE_VERSION` line
- Extend `customManagers:dockerfileVersions` preset in `renovate.json`
- Add grouping rule so `.node-version`, `package.json` engines, and Dockerfile ARG are all bumped in a single PR

Closes #3092

## Test plan
- [ ] Verify JSON is valid (`cat renovate.json | python3 -m json.tool`)
- [ ] After merge, check that the next Renovate run detects all three Node version sources and groups them