### PR TITLE
Fix map crash when partners share the same address

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -24,10 +24,7 @@ class PartnersController < ApplicationController
       tag_id: @selected_category
     )
 
-    # When no filters active, show only partners with physical addresses (no service_areas)
-    # When filters are active, show all filtered partners that have addresses
-    addresses_only = @selected_category.blank? && @selected_neighbourhood.blank?
-    @map = get_map_markers(@partners, addresses_only) if @partners.detect(&:address)
+    @map = get_map_markers(@partners) if @partners.detect(&:address)
 
     render Views::Partners::Index.new(
       partners: @partners, site: @site,

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -15,7 +15,7 @@ module MapHelper
       zoom: 16,
       iconUrl: image_path('icons/map/map-marker.png'),
       shadowUrl: image_path('icons/map/map-shadow.png'),
-      markers: data_for_markers,
+      markers: group_colocated_markers(data_for_markers),
       styleUrl: style_url_for_site(site),
       styleClass: map_style_class(data_for_markers, style_mode, compact_mode)
     }.to_json.html_safe
@@ -35,6 +35,17 @@ module MapHelper
            end
     out << 'map--compact' if compact_mode
     out
+  end
+
+  def group_colocated_markers(markers)
+    markers.group_by { |m| m[:position] }.map do |position, group|
+      next group.first if group.length == 1
+
+      anchors = group.filter_map { |m| m[:anchor] }
+      merged = { position: position }
+      merged[:anchor] = safe_join(anchors, tag.br) if anchors.any?
+      merged
+    end
   end
 
   def center(marker_data)

--- a/app/javascript/controllers/leaflet_controller.js
+++ b/app/javascript/controllers/leaflet_controller.js
@@ -67,12 +67,20 @@ export default class extends Controller {
 			this.map.setView(this.argsValue.center, this.argsValue.zoom);
 		} else {
 			// Multiple markers: fit bounds to show all markers
-			// Extend bounds slightly south to account for marker icon height
 			const bounds = markerGroup.getBounds();
-			const south = bounds.getSouth();
-			const offset = (bounds.getNorth() - south) * 0.08; // 8% extra at bottom
-			bounds.extend([south - offset, bounds.getWest()]);
-			this.map.fitBounds(bounds);
+			if (
+				bounds.getNorth() === bounds.getSouth() &&
+				bounds.getEast() === bounds.getWest()
+			) {
+				// All markers at same position: fitBounds would fail on zero-area box
+				this.map.setView(bounds.getCenter(), this.argsValue.zoom);
+			} else {
+				// Extend bounds slightly south to account for marker icon height
+				const south = bounds.getSouth();
+				const offset = (bounds.getNorth() - south) * 0.08; // 8% extra at bottom
+				bounds.extend([south - offset, bounds.getWest()]);
+				this.map.fitBounds(bounds);
+			}
 		}
 	}
 }

--- a/spec/components/map_spec.rb
+++ b/spec/components/map_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe Components::Map, type: :phlex do
     expect(args).to include("map--multiple")
   end
 
+  it "groups colocated points into a single marker" do
+    colocated_points = [
+      { lat: 53.4808, lon: -2.2426, name: "Place A", id: 1 },
+      { lat: 53.4808, lon: -2.2426, name: "Place B", id: 2 }
+    ]
+    render_inline(described_class.new(points: colocated_points, site: site_slug))
+    expect(page).to have_css('[data-controller="leaflet"]')
+    args = JSON.parse(page.find("[data-leaflet-args-value]")["data-leaflet-args-value"])
+    expect(args["markers"].length).to eq(1)
+    expect(args["markers"].first["anchor"]).to include("Place A")
+    expect(args["markers"].first["anchor"]).to include("Place B")
+  end
+
   it "passes compact to the map helper" do
     render_inline(described_class.new(points: points, site: site_slug, compact: true))
     args = page.find("[data-leaflet-args-value]")["data-leaflet-args-value"]

--- a/spec/helpers/map_helper_spec.rb
+++ b/spec/helpers/map_helper_spec.rb
@@ -100,6 +100,58 @@ RSpec.describe MapHelper, type: :helper do
     end
   end
 
+  describe "#group_colocated_markers" do
+    it "returns markers unchanged when all positions are unique" do
+      markers = [
+        { position: [53.0, -2.0], anchor: "A" },
+        { position: [54.0, -3.0], anchor: "B" }
+      ]
+      result = helper.send(:group_colocated_markers, markers)
+      expect(result.length).to eq(2)
+    end
+
+    it "groups markers at the same position into a single marker" do
+      markers = [
+        { position: [53.0, -2.0], anchor: "Link A".html_safe },
+        { position: [53.0, -2.0], anchor: "Link B".html_safe }
+      ]
+      result = helper.send(:group_colocated_markers, markers)
+      expect(result.length).to eq(1)
+      expect(result.first[:position]).to eq([53.0, -2.0])
+    end
+
+    it "combines anchor HTML with br separators" do
+      markers = [
+        { position: [53.0, -2.0], anchor: "<a>A</a>".html_safe },
+        { position: [53.0, -2.0], anchor: "<a>B</a>".html_safe }
+      ]
+      result = helper.send(:group_colocated_markers, markers)
+      expect(result.first[:anchor]).to include("<a>A</a>")
+      expect(result.first[:anchor]).to include("<br")
+      expect(result.first[:anchor]).to include("<a>B</a>")
+    end
+
+    it "handles markers without anchors" do
+      markers = [
+        { position: [53.0, -2.0] },
+        { position: [53.0, -2.0] }
+      ]
+      result = helper.send(:group_colocated_markers, markers)
+      expect(result.length).to eq(1)
+      expect(result.first).not_to have_key(:anchor)
+    end
+
+    it "preserves separate groups at different positions" do
+      markers = [
+        { position: [53.0, -2.0], anchor: "A".html_safe },
+        { position: [53.0, -2.0], anchor: "B".html_safe },
+        { position: [54.0, -3.0], anchor: "C".html_safe }
+      ]
+      result = helper.send(:group_colocated_markers, markers)
+      expect(result.length).to eq(2)
+    end
+  end
+
   describe "#args_for_map" do
     let(:site) { create(:site, theme: "pink") }
     let(:map_points) do
@@ -133,6 +185,26 @@ RSpec.describe MapHelper, type: :helper do
     it "includes marker positions" do
       result = JSON.parse(helper.args_for_map(map_points, site, :single, false))
       expect(result["markers"].first["position"]).to eq([53.4668, -2.2339])
+    end
+
+    it "groups colocated markers into a single marker" do
+      colocated_points = [
+        { lat: 53.4668, lon: -2.2339, name: "Partner A", id: "partner-a" },
+        { lat: 53.4668, lon: -2.2339, name: "Partner B", id: "partner-b" }
+      ]
+      result = JSON.parse(helper.args_for_map(colocated_points, site, nil, false))
+      expect(result["markers"].length).to eq(1)
+      expect(result["markers"].first["anchor"]).to include("Partner A")
+      expect(result["markers"].first["anchor"]).to include("Partner B")
+    end
+
+    it "preserves map--multiple style class for colocated markers" do
+      colocated_points = [
+        { lat: 53.4668, lon: -2.2339, name: "Partner A", id: "partner-a" },
+        { lat: 53.4668, lon: -2.2339, name: "Partner B", id: "partner-b" }
+      ]
+      result = JSON.parse(helper.args_for_map(colocated_points, site, nil, false))
+      expect(result["styleClass"]).to include("map--multiple")
     end
 
     it "filters out nil map points" do


### PR DESCRIPTION
## Summary
- Group colocated map markers into a single marker with a combined popup showing all partners at that location (fixes the zero-area bounding box crash in Leaflet)
- Add defensive JS guard so `fitBounds` on identical coordinates falls back to `setView`
- Show all partners with addresses on the index map regardless of service areas (the old `addresses_only` filter was hiding partners like Battle Scars and Benji on queerleeds)

Closes #3113

## Test plan
- [ ] Visit a site with colocated partners (e.g. queerleeds /partners) and verify the map renders with all markers
- [ ] Click the grouped marker and verify popup shows both partner names as links
- [ ] Verify other sites with unique marker positions still work normally
- [ ] `bundle exec rspec spec/helpers/map_helper_spec.rb spec/components/map_spec.rb`