### PR TITLE
Add directory.placecal.org firehose site

### DIFF
--- a/app/components/partner_filter.rb
+++ b/app/components/partner_filter.rb
@@ -6,10 +6,12 @@ class Components::PartnerFilter < Components::Base
   prop :site, ::Site
   prop :selected_category, _Nilable(String), default: nil
   prop :selected_neighbourhood, _Nilable(String), default: nil
+  prop :selected_partnership, _Nilable(String), default: nil
 
   def after_initialize
     @selected_category = @selected_category.to_i
     @selected_neighbourhood = @selected_neighbourhood.to_i
+    @selected_partnership = @selected_partnership.to_i
     @query = PartnersQuery.new(site: @site)
   end
 
@@ -17,6 +19,7 @@ class Components::PartnerFilter < Components::Base
     form_with(**form_data, class: 'filters__form') do
       div(class: 'breadcrumb__element breadcrumb__element--last') do
         span { 'Filter by:' }
+        render_partnership_filter if show_partnership_filter?
         render_category_filter if show_category_filter?
         render_neighbourhood_filter if show_neighbourhood_filter?
         render_reset_link if any_filter_active?
@@ -34,6 +37,21 @@ class Components::PartnerFilter < Components::Base
         'turbo-action': 'advance'
       }
     }
+  end
+
+  def render_partnership_filter
+    div(class: 'breadcrumb__filters filters') do
+      Filter(
+        name: 'partnership',
+        label: 'Partnership',
+        items: partnership_items,
+        selected_id: @selected_partnership,
+        controller: 'partner-filter-component',
+        toggle_action: 'togglePartnership',
+        submit_action: 'submitPartnership',
+        reset_action: 'resetPartnership'
+      )
+    end
   end
 
   def render_category_filter
@@ -96,7 +114,19 @@ class Components::PartnerFilter < Components::Base
     neighbourhoods.length > 1
   end
 
+  def partnerships
+    @partnerships ||= @query.partnerships_with_counts
+  end
+
+  def partnership_items
+    partnerships.map { |p| { id: p[:partnership].id, name: p[:partnership].name, count: p[:count] } }
+  end
+
+  def show_partnership_filter?
+    @site&.directory_site? && partnerships.length > 1
+  end
+
   def any_filter_active?
-    @selected_category.positive? || @selected_neighbourhood.positive?
+    @selected_category.positive? || @selected_neighbourhood.positive? || @selected_partnership.positive?
   end
 end

--- a/app/components/partnership_preview.rb
+++ b/app/components/partnership_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Components::PartnershipPreview < Components::Base
+  prop :partnership, ::Partnership
+  prop :partner_count, Integer, default: 0
+
+  def view_template
+    li(class: 'preview') do
+      div(class: 'preview__header') do
+        h3 { link_to(@partnership.name, partnership_path(@partnership), data: { turbo_frame: '_top', turbo_action: 'replace' }) }
+        if @partner_count.positive?
+          div(class: 'neighbourhood neighbourhood--primary preview__neighbourhood') do
+            span { pluralize(@partner_count, 'partner') }
+          end
+        end
+      end
+
+      if @partnership.description.present?
+        div(class: 'preview__details') do
+          p { @partnership.description }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -205,6 +205,8 @@ class ApplicationController < ActionController::Base
 
     @navigation = if default_site?
                     default_site_navigation
+                  elsif current_site&.directory_site?
+                    directory_site_navigation
                   else
                     sub_site_navigation
                   end
@@ -240,6 +242,14 @@ class ApplicationController < ActionController::Base
       ['Our story', our_story_path],
       ['Find your PlaceCal', find_placecal_path],
       ['Get in touch', get_in_touch_path]
+    ]
+  end
+
+  def directory_site_navigation
+    [
+      ['Events', events_path],
+      ['Partners', partners_path],
+      ['Partnerships', partnerships_path]
     ]
   end
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -17,11 +17,13 @@ class PartnersController < ApplicationController
   def index
     @selected_category = params[:category] if params[:category].present? && Integer(params[:category], exception: false)
     @selected_neighbourhood = params[:neighbourhood] if params[:neighbourhood].present? && Integer(params[:neighbourhood], exception: false)
+    @selected_partnership = params[:partnership] if params[:partnership].present? && Integer(params[:partnership], exception: false)
 
     query = PartnersQuery.new(site: current_site)
     @partners = query.call(
       neighbourhood_id: @selected_neighbourhood,
-      tag_id: @selected_category
+      tag_id: @selected_category,
+      partnership_id: @selected_partnership
     )
 
     @map = get_map_markers(@partners) if @partners.detect(&:address)
@@ -29,7 +31,8 @@ class PartnersController < ApplicationController
     render Views::Partners::Index.new(
       partners: @partners, site: @site,
       map: @map, selected_category: @selected_category,
-      selected_neighbourhood: @selected_neighbourhood
+      selected_neighbourhood: @selected_neighbourhood,
+      selected_partnership: @selected_partnership
     )
   end
 

--- a/app/controllers/partnerships_controller.rb
+++ b/app/controllers/partnerships_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class PartnershipsController < ApplicationController
+  before_action :set_site
+  before_action :require_directory_site
+
+  # GET /partnerships
+  def index
+    @partnerships = Partnership
+                    .joins(:partners)
+                    .where(partners: { hidden: false })
+                    .distinct
+                    .order(:name)
+
+    @title = 'Partnerships'
+
+    render Views::Partnerships::Index.new(
+      partnerships: @partnerships,
+      site: @site
+    )
+  end
+
+  # GET /partnerships/:id
+  def show
+    @partnership = Partnership.friendly.find(params[:id])
+    @partners = @partnership.partners.visible.order(:name)
+    @title = @partnership.name
+
+    render Views::Partnerships::Show.new(
+      partnership: @partnership,
+      partners: @partners,
+      site: @site
+    )
+  end
+
+  private
+
+  def require_directory_site
+    redirect_to root_path unless current_site&.directory_site?
+  end
+end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -8,7 +8,9 @@ class SitesController < ApplicationController
   before_action :set_places_with_free_wifi, only: [:index]
 
   def index
-    if current_site.slug == 'mossley'
+    if current_site.directory_site?
+      render Views::Sites::Directory.new(site: @site)
+    elsif current_site.slug == 'mossley'
       render Views::Sites::Mossley.new(site: @site, places_to_get_online: @places_to_get_computer_access)
     else
       render Views::Sites::Default.new(

--- a/app/javascript/controllers/partner_filter_component_controller.js
+++ b/app/javascript/controllers/partner_filter_component_controller.js
@@ -4,6 +4,9 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
 	static targets = [
 		"form",
+		"partnership",
+		"partnershipText",
+		"partnershipDropdown",
 		"category",
 		"categoryText",
 		"categoryDropdown",
@@ -16,6 +19,12 @@ export default class extends Controller {
 		this.updateLabels();
 	}
 
+	submitPartnership() {
+		this.updateLabels();
+		this.hideDropdown(this.partnershipDropdownTarget);
+		this.submitForm();
+	}
+
 	submitCategory() {
 		this.updateLabels();
 		this.hideDropdown(this.categoryDropdownTarget);
@@ -25,6 +34,12 @@ export default class extends Controller {
 	submitNeighbourhood() {
 		this.updateLabels();
 		this.hideDropdown(this.neighbourhoodDropdownTarget);
+		this.submitForm();
+	}
+
+	resetPartnership() {
+		this.selectedPartnership.checked = false;
+		this.hideDropdown(this.partnershipDropdownTarget);
 		this.submitForm();
 	}
 
@@ -40,9 +55,27 @@ export default class extends Controller {
 		this.submitForm();
 	}
 
+	togglePartnership() {
+		this.partnershipDropdownTarget.classList.toggle(
+			"filters__dropdown--hidden",
+		);
+		// Close other dropdowns
+		if (this.hasCategoryDropdownTarget) {
+			this.categoryDropdownTarget.classList.add("filters__dropdown--hidden");
+		}
+		if (this.hasNeighbourhoodDropdownTarget) {
+			this.neighbourhoodDropdownTarget.classList.add(
+				"filters__dropdown--hidden",
+			);
+		}
+	}
+
 	toggleCategory() {
 		this.categoryDropdownTarget.classList.toggle("filters__dropdown--hidden");
-		// Close other dropdown
+		// Close other dropdowns
+		if (this.hasPartnershipDropdownTarget) {
+			this.partnershipDropdownTarget.classList.add("filters__dropdown--hidden");
+		}
 		if (this.hasNeighbourhoodDropdownTarget) {
 			this.neighbourhoodDropdownTarget.classList.add(
 				"filters__dropdown--hidden",
@@ -54,7 +87,10 @@ export default class extends Controller {
 		this.neighbourhoodDropdownTarget.classList.toggle(
 			"filters__dropdown--hidden",
 		);
-		// Close other dropdown
+		// Close other dropdowns
+		if (this.hasPartnershipDropdownTarget) {
+			this.partnershipDropdownTarget.classList.add("filters__dropdown--hidden");
+		}
 		if (this.hasCategoryDropdownTarget) {
 			this.categoryDropdownTarget.classList.add("filters__dropdown--hidden");
 		}
@@ -68,7 +104,11 @@ export default class extends Controller {
 
 	updateLabels() {
 		// Find the associated label for each selected param and get the text contents
-		// If params are selected, they show up instead of "Category" and "Neighbourhood" text
+		// If params are selected, they show up instead of "Partnership", "Category" and "Neighbourhood" text
+		if (this.hasPartnershipTextTarget && this.selectedPartnership) {
+			this.partnershipTextTarget.innerHTML =
+				this.selectedPartnership.labels[0].textContent;
+		}
 		if (this.hasCategoryTextTarget && this.selectedCategory) {
 			this.categoryTextTarget.innerHTML =
 				this.selectedCategory.labels[0].textContent;
@@ -81,6 +121,10 @@ export default class extends Controller {
 
 	submitForm() {
 		this.formTarget.requestSubmit();
+	}
+
+	get selectedPartnership() {
+		return this.partnershipTargets.find((r) => r.checked);
 	}
 
 	get selectedCategory() {

--- a/app/models/concerns/permalinkable.rb
+++ b/app/models/concerns/permalinkable.rb
@@ -21,7 +21,7 @@ module Permalinkable
   class_methods do
     def permalink_resource(resource_name)
       define_method(:permalink) do |base_url: nil|
-        base_url ||= Site.find_by(slug: 'default-site')&.url || 'https://placecal.org'
+        base_url ||= Site.find_by(slug: 'directory')&.url || Site.find_by(slug: 'default-site')&.url || 'https://directory.placecal.org'
         "#{base_url.chomp('/')}/#{resource_name}/#{id}"
       end
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -117,6 +117,11 @@ class Site < ApplicationRecord
     slug == 'default-site'
   end
 
+  # @return [Boolean] true for the global directory site (directory.placecal.org)
+  def directory_site?
+    slug == 'directory'
+  end
+
   # @return [Boolean] true for any non-default site
   def local_site?
     !default_site?

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -110,6 +110,7 @@ class EventsQuery
   # @return [Array<Hash>] array of { neighbourhood: Neighbourhood, count: Integer }
   def neighbourhoods_with_counts(period: 'future')
     return [] unless @site
+    return directory_neighbourhoods_with_counts(period) if @site.directory_site?
 
     all_descendants = @site.neighbourhoods.flat_map { |n| n.descendants.to_a }
     return [] if all_descendants.empty?
@@ -141,7 +142,11 @@ class EventsQuery
   # ===================
 
   def base_scope
-    @base_scope ||= @site ? events_for_site.includes(:place, :organiser) : Event.includes(:place, :organiser)
+    @base_scope ||= if @site.nil? || @site.directory_site?
+                      Event.includes(:place, :organiser)
+                    else
+                      events_for_site.includes(:place, :organiser)
+                    end
   end
 
   # Inline of Event.for_site - finds events belonging to partners in this site
@@ -275,5 +280,32 @@ class EventsQuery
     end
     roots.each { |id| compute.call(id) }
     counts
+  end
+
+  # For directory site: count events per neighbourhood at district level across all events
+  def directory_neighbourhoods_with_counts(period)
+    events = apply_period(base_scope, period)
+
+    raw_counts = events
+                 .left_joins(:address, organiser: :address)
+                 .where('COALESCE(addresses.neighbourhood_id, addresses_partners.neighbourhood_id) IS NOT NULL')
+                 .group('COALESCE(addresses.neighbourhood_id, addresses_partners.neighbourhood_id)')
+                 .distinct
+                 .count
+
+    # Aggregate to district level
+    district_counts = Hash.new(0)
+    raw_counts.each do |neighbourhood_id, count|
+      neighbourhood = Neighbourhood.find_by(id: neighbourhood_id)
+      next unless neighbourhood
+
+      district = neighbourhood.district || neighbourhood
+      district_counts[district.id] += count
+    end
+
+    Neighbourhood.where(id: district_counts.keys)
+                 .sort_by(&:name)
+                 .select { |n| district_counts[n.id].positive? }
+                 .map { |n| { neighbourhood: n, count: district_counts[n.id] } }
   end
 end

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -22,11 +22,12 @@ class PartnersQuery
   # @param tag_id [Integer] filter by tag/category
   # @param tag_slug [String] filter by tag slug (e.g. 'computers', 'wifi')
   # @return [ActiveRecord::Relation<Partner>]
-  def call(neighbourhood_id: nil, tag_id: nil, tag_slug: nil)
+  def call(neighbourhood_id: nil, tag_id: nil, tag_slug: nil, partnership_id: nil)
     partners = base_scope
     partners = filter_by_neighbourhood(partners, neighbourhood_id) if neighbourhood_id.present?
     partners = filter_by_tag(partners, tag_id) if tag_id.present?
     partners = filter_by_tag_slug(partners, tag_slug) if tag_slug.present?
+    partners = filter_by_partnership(partners, partnership_id) if partnership_id.present?
     partners.includes(:address, :service_areas).order(:name)
   end
 
@@ -58,6 +59,20 @@ class PartnersQuery
       .map { |tag| { category: tag, count: tag.partner_count } }
   end
 
+  # Returns partnerships that have partners, with counts
+  # Used for filter dropdowns
+  #
+  # @return [Array<Hash>] array of { partnership: Tag, count: Integer }
+  def partnerships_with_counts
+    Tag
+      .joins(:partner_tags)
+      .where(partner_tags: { partner_id: base_scope.select(:id) }, type: 'Partnership')
+      .group(:id, :name)
+      .order(:name)
+      .select('tags.*, COUNT(partner_tags.partner_id) as partner_count')
+      .map { |tag| { partnership: tag, count: tag.partner_count } }
+  end
+
   private
 
   # ===================
@@ -72,6 +87,7 @@ class PartnersQuery
   end
 
   def build_base_scope
+    return Partner.visible if @site&.directory_site?
     return Partner.none if site_neighbourhood_ids.empty?
 
     scope = Partner.visible
@@ -102,6 +118,10 @@ class PartnersQuery
 
   def filter_by_tag_slug(partners, tag_slug)
     partners.joins(:tags).where(tags: { slug: tag_slug })
+  end
+
+  def filter_by_partnership(partners, partnership_id)
+    partners.joins(:tags).where(tags: { id: partnership_id, type: 'Partnership' })
   end
 
   # ===================

--- a/app/views/base.rb
+++ b/app/views/base.rb
@@ -11,6 +11,7 @@ class Views::Base < Phlex::HTML
   include Phlex::Rails::Helpers::ImageTag
   include Phlex::Rails::Helpers::CSRFMetaTags
   include Phlex::Rails::Helpers::Pluralize
+  include Phlex::Rails::Helpers::NumberWithDelimiter
   include Phlex::Rails::Helpers::DistanceOfTimeInWords
   include Phlex::Rails::Helpers::ImageURL
   include Phlex::Rails::Helpers::Flash

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -13,6 +13,7 @@ class Views::Events::Show < Views::Base
     content_for(:title) { event.og_title }
     content_for(:image) { site.og_image }
     content_for(:description) { html_to_plaintext(event.description_html) }
+    content_for(:canonical) { event.permalink }
     content_for(:json_ld) { safe(event.to_json_ld(base_url: request.base_url).to_json) }
 
     Event(

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -77,6 +77,7 @@ class Views::Layouts::Application < Phlex::HTML
     meta(name: 'twitter:site', content: '@PlaceCal')
     meta(name: 'twitter:creator', content: '@gfscstudio')
     meta(property: 'og:url', content: request.original_url)
+    link(rel: 'canonical', href: content_for(:canonical)) if content_for?(:canonical)
     meta(name: 'robots', content: 'noarchive')
 
     script(type: 'application/ld+json') { raw safe(site.to_json_ld(base_url: request.base_url).to_json) } if site

--- a/app/views/partners/index.rb
+++ b/app/views/partners/index.rb
@@ -6,20 +6,22 @@ class Views::Partners::Index < Views::Base
   prop :map, _Nilable(Array), reader: :private
   prop :selected_category, _Nilable(String), reader: :private
   prop :selected_neighbourhood, _Nilable(String), reader: :private
+  prop :selected_partnership, _Nilable(String), reader: :private
 
   def view_template
     content_for(:title) { 'Partners' }
     content_for(:image) { site.og_image }
     content_for(:description) { site.og_description }
 
-    Hero('Our Partners', site.tagline)
+    Hero(hero_title, site.tagline)
     turbo_frame_tag 'partner_previews' do
       div(class: 'c c--lg-space-after') do
         Breadcrumb(trail: [['Partners', partners_path]], site_name: site.name) do
           PartnerFilter(
             site: site,
             selected_category: selected_category,
-            selected_neighbourhood: selected_neighbourhood
+            selected_neighbourhood: selected_neighbourhood,
+            selected_partnership: selected_partnership
           )
         end
 
@@ -35,5 +37,11 @@ class Views::Partners::Index < Views::Base
         Map(points: map, site: site.slug)
       end
     end
+  end
+
+  private
+
+  def hero_title
+    site.directory_site? ? 'All Partners on PlaceCal' : 'Our Partners'
   end
 end

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -24,6 +24,7 @@ class Views::Partners::Show < Views::Base
       content_for(:image) { site.og_image }
     end
     content_for(:description) { partner.summary } if partner.summary
+    content_for(:canonical) { partner.permalink }
     content_for(:json_ld) { safe(partner.to_json_ld(base_url: request.base_url).to_json) }
 
     div do
@@ -37,6 +38,7 @@ class Views::Partners::Show < Views::Base
 
         hr
         render_partner_details
+        render_directory_context if site.directory_site?
         render_managees
         hr
         render_events_section
@@ -149,6 +151,52 @@ class Views::Partners::Show < Views::Base
               url: place.url
             )
           end
+        end
+      end
+    end
+  end
+
+  def render_directory_context
+    div(class: 'g g--partner-directory-context') do
+      if partner.address&.neighbourhood
+        neighbourhood = partner.address.neighbourhood
+        div(class: 'gi') do
+          h3(class: 'udl udl--fw allcaps h4') { 'In:' }
+          p do
+            parts = []
+            parts << neighbourhood.name
+            parts << neighbourhood.district.name if neighbourhood.district && neighbourhood.district != neighbourhood
+            parts << neighbourhood.county.name if neighbourhood.county
+            plain parts.join(', ')
+          end
+        end
+      end
+
+      partnerships = partner.tags.where(type: 'Partnership')
+      if partnerships.any?
+        div(class: 'gi') do
+          h3(class: 'udl udl--fw allcaps h4') { 'Part of:' }
+          ul(class: 'reset') do
+            partnerships.each do |partnership|
+              li { link_to partnership.name, partnership_path(partnership) }
+            end
+          end
+        end
+      end
+
+      render_featured_on_subsites
+    end
+  end
+
+  def render_featured_on_subsites
+    subsites = Site.sites_that_contain_partner(partner)
+    return if subsites.empty?
+
+    div(class: 'gi') do
+      h3(class: 'udl udl--fw allcaps h4') { 'Featured on:' }
+      ul(class: 'reset') do
+        subsites.each do |subsite|
+          li { link_to subsite.name, "#{subsite.url}/partners/#{partner.slug}" }
         end
       end
     end

--- a/app/views/partnerships/index.rb
+++ b/app/views/partnerships/index.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Views::Partnerships::Index < Views::Base
+  prop :partnerships, _Interface(:each), reader: :private
+  prop :site, Site, reader: :private
+
+  def view_template
+    content_for(:title) { 'Partnerships' }
+    content_for(:image) { site.og_image }
+    content_for(:description) { 'All partnerships on PlaceCal' }
+
+    Hero('Partnerships', site.tagline)
+    div(class: 'c c--lg-space-after') do
+      Breadcrumb(trail: [['Partnerships', partnerships_path]], site_name: site.name)
+
+      hr
+
+      ul(class: 'partners reset two-col') do
+        partnerships.each do |partnership|
+          PartnershipPreview(
+            partnership: partnership,
+            partner_count: partner_counts[partnership.id] || 0
+          )
+        end
+      end
+    end
+  end
+
+  private
+
+  def partner_counts
+    @partner_counts ||= ::PartnerTag
+                        .joins(:partner)
+                        .where(partners: { hidden: false })
+                        .joins(:tag)
+                        .where(tags: { type: 'Partnership' })
+                        .group(:tag_id)
+                        .count
+  end
+end

--- a/app/views/partnerships/show.rb
+++ b/app/views/partnerships/show.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class Views::Partnerships::Show < Views::Base
+  prop :partnership, Partnership, reader: :private
+  prop :partners, _Interface(:each), reader: :private
+  prop :site, Site, reader: :private
+
+  def view_template
+    content_for(:title) { partnership.name }
+    content_for(:image) { site.og_image }
+    content_for(:description) { partnership.description || "Partners in the #{partnership.name} partnership" }
+
+    Hero(partnership.name, site.tagline)
+    div(class: 'c c--lg-space-after') do
+      Breadcrumb(
+        trail: [
+          ['Partnerships', partnerships_path],
+          [partnership.name, partnership_path(partnership)]
+        ],
+        site_name: site.name
+      )
+
+      hr
+
+      render_description if partnership.description.present?
+      render_subsites if partnership_sites.any?
+      render_partners if partners.any?
+    end
+  end
+
+  private
+
+  def render_description
+    div(class: 'partnership-description') do
+      p { partnership.description }
+    end
+  end
+
+  def render_subsites
+    div(class: 'partnership-subsites') do
+      h3 { 'Sites' }
+      ul(class: 'reset') do
+        partnership_sites.each do |s|
+          li do
+            link_to(s.name, s.url)
+          end
+        end
+      end
+    end
+  end
+
+  def render_partners
+    div(class: 'partnership-partners') do
+      h3 { "Partners (#{partners.size})" }
+      ul(class: 'partners reset two-col') do
+        partners.each do |partner|
+          PartnerPreview(partner: partner, site: site)
+        end
+      end
+    end
+  end
+
+  def partnership_sites
+    @partnership_sites ||= partnership.sites.published
+  end
+end

--- a/app/views/sites/directory.rb
+++ b/app/views/sites/directory.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+class Views::Sites::Directory < Views::Base
+  prop :site, Site, reader: :private
+
+  def view_template
+    content_for(:title) { 'PlaceCal Directory' }
+    content_for(:image) { site.og_image }
+    content_for(:description) { 'Browse all partners, events, and partnerships on PlaceCal' }
+
+    Hero('PlaceCal Directory', 'A curated social network for the real world')
+
+    render_stats
+    render_recent_partnerships
+    render_recent_partners
+  end
+
+  private
+
+  def render_stats
+    section(class: 'region region__mission') do
+      div(class: 'c c--narrow') do
+        p(class: 'p--big', style: 'text-align: center') do
+          plain 'With '
+          strong { number_with_delimiter(stats[:partnerships]) }
+          plain ' partnerships helping '
+          strong { number_with_delimiter(stats[:partners]) }
+          plain ' community groups list '
+          strong { number_with_delimiter(stats[:events]) }
+          plain ' events this month'
+        end
+
+        div(style: 'text-align: center; margin-top: 1.5rem') do
+          link_to 'Browse events', events_path, class: 'btn btn--lg btn--alt'
+          plain ' '
+          link_to 'Browse partners', partners_path, class: 'btn btn--lg btn--alt'
+        end
+      end
+    end
+  end
+
+  def render_recent_partnerships
+    return unless recent_partnerships.any?
+
+    section(class: 'region') do
+      div(class: 'c') do
+        h2(class: 'udl udl--fw allcaps') { 'Partnerships' }
+        ul(class: 'partners reset two-col') do
+          recent_partnerships.each do |partnership|
+            PartnershipPreview(
+              partnership: partnership,
+              partner_count: partnership_partner_counts[partnership.id] || 0
+            )
+          end
+        end
+        p do
+          link_to 'View all partnerships', partnerships_path, class: 'btn btn--alt'
+        end
+      end
+    end
+  end
+
+  def render_recent_partners
+    return unless recent_partners.any?
+
+    section(class: 'region') do
+      div(class: 'c') do
+        h2(class: 'udl udl--fw allcaps') { 'Recently added partners' }
+        ul(class: 'partners reset two-col') do
+          recent_partners.each do |partner|
+            PartnerPreview(partner: partner, site: site)
+          end
+        end
+        p do
+          link_to 'View all partners', partners_path, class: 'btn btn--alt'
+        end
+      end
+    end
+  end
+
+  def stats
+    @stats ||= {
+      partnerships: ::Partnership.joins(:partners).where(partners: { hidden: false }).distinct.count,
+      partners: ::Partner.visible.count,
+      events: ::Event.for_month(Time.zone.today).count
+    }
+  end
+
+  def recent_partnerships
+    @recent_partnerships ||= ::Partnership
+                             .joins(:partners)
+                             .where(partners: { hidden: false })
+                             .distinct
+                             .order(created_at: :desc)
+                             .limit(6)
+  end
+
+  def partnership_partner_counts
+    @partnership_partner_counts ||= ::PartnerTag
+                                    .joins(:partner)
+                                    .where(partners: { hidden: false })
+                                    .joins(:tag)
+                                    .where(tags: { type: 'Partnership' })
+                                    .group(:tag_id)
+                                    .count
+  end
+
+  def recent_partners
+    @recent_partners ||= ::Partner.visible.order(created_at: :desc).limit(6)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,9 @@ Rails.application.routes.draw do
   resources :events, only: %i[index show]
   get '/events/:year/:month/:day' => 'events#index', constraints: ymd, as: :events_by_date
 
+  # Partnerships
+  resources :partnerships, only: %i[index show]
+
   # Partners
   resources :partners, only: %i[index show]
   get '/partners/:id/events' => 'partners#show'

--- a/db/seeds/004_sites.rb
+++ b/db/seeds/004_sites.rb
@@ -105,6 +105,15 @@ module SeedSites # rubocop:disable Metrics/ModuleLength
       published: false
     )
 
+    # Directory site (all partners and events)
+    create_site(
+      slug: 'directory',
+      name: 'PlaceCal Directory',
+      tagline: 'All partners and events on PlaceCal',
+      url: 'http://directory.lvh.me:3000',
+      data_key: :normal_island_default
+    )
+
     # Normal Island (country)
     create_site(
       slug: 'normal-island',

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -51,6 +51,13 @@ FactoryBot.define do
       slug { NormalIsland::SITES[:normal_island_central][:slug] }
       tagline { NormalIsland::SITES[:normal_island_central][:tagline] }
     end
+
+    factory :directory_site do
+      name { "PlaceCal Directory" }
+      slug { "directory" }
+      tagline { "All partners and events on PlaceCal" }
+      is_published { true }
+    end
   end
 
   factory :sites_neighbourhood do

--- a/spec/requests/public/partners_spec.rb
+++ b/spec/requests/public/partners_spec.rb
@@ -324,4 +324,48 @@ RSpec.describe "Public Partners", type: :request do
       expect(response).to be_redirect
     end
   end
+
+  describe "directory site" do
+    let!(:directory_site) { create_directory_site }
+
+    describe "GET /partners" do
+      let!(:partners) do
+        Array.new(3) do
+          create(:partner, address: create(:address))
+        end
+      end
+
+      it "returns successful response" do
+        get partners_url(host: "directory.lvh.me")
+        expect(response).to be_successful
+      end
+
+      it "shows all visible partners" do
+        get partners_url(host: "directory.lvh.me")
+        partners.each do |partner|
+          expect(response.body).to include(partner.name)
+        end
+      end
+
+      it "shows directory hero title" do
+        get partners_url(host: "directory.lvh.me")
+        expect(response.body).to include("All Partners on PlaceCal")
+      end
+    end
+
+    describe "GET /partners/:id" do
+      let(:partner) { create(:partner, address: create(:address)) }
+
+      it "shows the partner details" do
+        get partner_url(partner, host: "directory.lvh.me")
+        expect(response).to be_successful
+        expect(response.body).to include(partner.name)
+      end
+
+      it "includes canonical link" do
+        get partner_url(partner, host: "directory.lvh.me")
+        expect(response.body).to include('rel="canonical"')
+      end
+    end
+  end
 end

--- a/spec/requests/public/partnerships_spec.rb
+++ b/spec/requests/public/partnerships_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Partnerships", type: :request do
+  let!(:directory_site) { create_directory_site }
+
+  describe "on directory site" do
+    let(:host) { "directory.lvh.me" }
+
+    context "GET /partnerships" do
+      let!(:partnership) { create(:partnership, name: "Test Partnership") }
+      let!(:partner) { create(:partner, hidden: false) }
+
+      before do
+        partner.tags << partnership
+      end
+
+      it "returns success" do
+        get partnerships_url(host: host)
+        expect(response).to be_successful
+      end
+
+      it "shows partnerships with visible partners" do
+        get partnerships_url(host: host)
+        expect(response.body).to include("Test Partnership")
+      end
+    end
+
+    context "GET /partnerships/:id" do
+      let!(:partnership) { create(:partnership, name: "Test Partnership") }
+      let!(:partner) { create(:partner, hidden: false, name: "Test Partner") }
+
+      before do
+        partner.tags << partnership
+      end
+
+      it "returns success" do
+        get partnership_url(partnership, host: host)
+        expect(response).to be_successful
+      end
+
+      it "shows the partnership name" do
+        get partnership_url(partnership, host: host)
+        expect(response.body).to include("Test Partnership")
+      end
+
+      it "shows the partner" do
+        get partnership_url(partnership, host: host)
+        expect(response.body).to include("Test Partner")
+      end
+    end
+  end
+
+  describe "on non-directory site" do
+    let!(:default_site) { create_default_site }
+
+    it "redirects partnerships page on base domain" do
+      get partnerships_url(host: "lvh.me")
+      expect(response).to be_redirect
+    end
+  end
+
+  describe "on subsite" do
+    let!(:site) { create(:millbrook_site) }
+
+    it "redirects partnerships page on subsite" do
+      get partnerships_url(host: "#{site.slug}.lvh.me")
+      expect(response).to be_redirect
+    end
+  end
+end

--- a/spec/support/site_helpers.rb
+++ b/spec/support/site_helpers.rb
@@ -7,6 +7,11 @@ module SiteHelpers
     Site.find_by(slug: "default-site") || create(:site, slug: "default-site")
   end
 
+  # Create the directory site
+  def create_directory_site
+    Site.find_by(slug: "directory") || create(:site, slug: "directory", name: "PlaceCal Directory", tagline: "All partners and events on PlaceCal", is_published: true)
+  end
+
   # Generate a URL for a specific site subdomain
   def site_url(site, path)
     host = Rails.application.routes.default_url_options[:host]


### PR DESCRIPTION
## Summary

Implements #2978 — creates `directory.placecal.org` as a global directory site showing all partners, events, and partnerships across PlaceCal.

- New `Site` record with `slug: 'directory'` (no migration needed)
- `PartnersQuery`/`EventsQuery` skip geo filtering for directory site
- Reuses all existing subsite infrastructure (layout, styles, components)
- Marketing site (`placecal.org`) completely unchanged

### New pages
- **Directory homepage** — aggregate stats, recent partnerships and partners
- **Partnerships index** (`/partnerships`) — all partnerships with partner counts
- **Partnership show** (`/partnerships/:slug`) — detail page with partner list
- **Partner show** — "In:" (neighbourhood hierarchy) and "Part of:" (partnerships) sections on directory site
- **Canonical links** on partner and event show pages

### Follow-up issues (Global Directory milestone)
- #3132 — Events listing needs pagination or filter-first approach
- #3133 — Neighbourhood picker needs hierarchical grouping
- #3134 — Partners listing needs pagination
- #3135 — Draft/unpublished partnerships should be filtered out
- #3136 — Events and partners should show which subsites they belong to

## Test plan
- [x] `bundle exec rspec spec/requests/public/partnerships_spec.rb` — 7 examples, 0 failures
- [x] `bundle exec rspec spec/requests/public/partners_spec.rb` — 32 examples, 0 failures
- [x] `bundle exec rspec spec/requests/public/events_spec.rb spec/queries/` — 75 examples, 0 failures
- [ ] Visit `http://directory.lvh.me:3000/` — directory homepage with stats
- [ ] Visit `http://directory.lvh.me:3000/partners` — all partners globally
- [ ] Visit `http://directory.lvh.me:3000/partnerships` — all partnerships
- [ ] Visit `http://lvh.me:3000/partners` — still redirects to /find-placecal
- [ ] Check `<link rel="canonical">` on partner/event show pages

Closes #2978