### PR TITLE
Add A-Z pagination to partners index

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,6 +54,7 @@
 @import "components/neighbourhood_home_card_component";
 @import "components/opening_times";
 @import "components/partner_preview_component.scss";
+@import "components/partners_paginator_component";
 @import "components/partnership_card_component";
 @import "components/turbo_loading";
 @import "components/pull_quote_component";

--- a/app/assets/stylesheets/components/partners_paginator_component.scss
+++ b/app/assets/stylesheets/components/partners_paginator_component.scss
@@ -1,0 +1,42 @@
+@import "../variables_mixins";
+
+.partners-paginator {
+	margin-bottom: 1.5rem;
+	margin-top: 0.5rem;
+}
+
+.partners-paginator__pages {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	justify-content: center;
+}
+
+.partners-paginator__page {
+	padding: 0.375rem 0.75rem;
+	font-size: 0.875rem;
+	text-decoration: none;
+	border: 1px solid $base-rules;
+	border-radius: 3px;
+	color: $base-text;
+
+	&:hover {
+		background-color: $base-rules;
+	}
+
+	&--current {
+		background-color: $base-tertiary;
+		color: white;
+		border-color: $base-tertiary;
+		padding: 0.375rem 0.75rem;
+		border-radius: 3px;
+	}
+}
+
+.partners-letter-heading {
+	margin-top: 1.5rem;
+	margin-bottom: 0.5rem;
+	padding-bottom: 0.25rem;
+	border-bottom: 2px solid $base-rules;
+	font-size: 1.5rem;
+}

--- a/app/components/partners_paginator.rb
+++ b/app/components/partners_paginator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Components::PartnersPaginator < Components::Base
+  prop :page_letter_ranges, Array
+  prop :current_page, Integer
+  prop :filter_params, Hash, default: -> { {} }
+
+  def view_template
+    nav(class: 'partners-paginator', aria_label: 'Partner pagination') do
+      render_page_nav
+    end
+  end
+
+  private
+
+  def render_page_nav
+    div(class: 'partners-paginator__pages') do
+      @page_letter_ranges.each do |range|
+        label = page_label(range)
+        if range[:page] == @current_page
+          strong(class: 'partners-paginator__page partners-paginator__page--current') { label }
+        else
+          link_to(
+            label,
+            partners_path(**@filter_params, page: range[:page]),
+            class: 'partners-paginator__page',
+            data: { turbo_frame: 'partner_previews' }
+          )
+        end
+      end
+    end
+  end
+
+  def page_label(range)
+    if range[:first_label] == range[:last_label]
+      range[:first_label]
+    else
+      "#{range[:first_label]} – #{range[:last_label]}"
+    end
+  end
+end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -17,19 +17,26 @@ class PartnersController < ApplicationController
   def index
     @selected_category = params[:category] if params[:category].present? && Integer(params[:category], exception: false)
     @selected_neighbourhood = params[:neighbourhood] if params[:neighbourhood].present? && Integer(params[:neighbourhood], exception: false)
+    @page = (params[:page] || 1).to_i
 
     query = PartnersQuery.new(site: current_site)
     @partners = query.call(
       neighbourhood_id: @selected_neighbourhood,
-      tag_id: @selected_category
+      tag_id: @selected_category,
+      page: @page
     )
 
     @map = get_map_markers(@partners) if @partners.detect(&:address)
+    @filter_params = { category: @selected_category, neighbourhood: @selected_neighbourhood }.compact
 
     render Views::Partners::Index.new(
       partners: @partners, site: @site,
       map: @map, selected_category: @selected_category,
-      selected_neighbourhood: @selected_neighbourhood
+      selected_neighbourhood: @selected_neighbourhood,
+      page: @page,
+      total_pages: query.total_pages,
+      page_letter_ranges: query.page_letter_ranges,
+      filter_params: @filter_params
     )
   end
 

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -11,23 +11,61 @@
 #     tag_id: 456
 #   )
 #
+# @example With pagination
+#   query = PartnersQuery.new(site: current_site)
+#   partners = query.call(page: 2)
+#   query.total_pages    # => 5
+#   query.page_letter_ranges # => [{ page: 1, first_label: "A", last_label: "C" }, ...]
+#
 class PartnersQuery
+  PER_PAGE = 50
+
   def initialize(site:)
     @site = site
   end
+
+  attr_reader :total_pages, :total_count
 
   # Main entry point - returns partners filtered and sorted
   #
   # @param neighbourhood_id [Integer] filter by neighbourhood (address or service area)
   # @param tag_id [Integer] filter by tag/category
   # @param tag_slug [String] filter by tag slug (e.g. 'computers', 'wifi')
+  # @param page [Integer] page number (1-indexed), nil for no pagination
+  # @param per_page [Integer] number of results per page
   # @return [ActiveRecord::Relation<Partner>]
-  def call(neighbourhood_id: nil, tag_id: nil, tag_slug: nil)
+  def call(neighbourhood_id: nil, tag_id: nil, tag_slug: nil, page: nil, per_page: PER_PAGE)
     partners = base_scope
     partners = filter_by_neighbourhood(partners, neighbourhood_id) if neighbourhood_id.present?
     partners = filter_by_tag(partners, tag_id) if tag_id.present?
     partners = filter_by_tag_slug(partners, tag_slug) if tag_slug.present?
-    partners.includes(:address, :service_areas).order(:name)
+    @filtered_scope = partners.includes(:address, :service_areas).order(:name)
+
+    if page
+      @total_count = @filtered_scope.count
+      @total_pages = [(@total_count.to_f / per_page).ceil, 1].max
+      page = page.clamp(1, @total_pages)
+      @filtered_scope.offset((page - 1) * per_page).limit(per_page)
+    else
+      @total_count = nil
+      @total_pages = 1
+      @filtered_scope
+    end
+  end
+
+  # Returns letter-range labels for each page of the filtered results
+  # Uses two-char prefixes when a letter spans a page boundary
+  #
+  # @param per_page [Integer] results per page
+  # @return [Array<Hash>] array of { page:, first_label:, last_label: }
+  def page_letter_ranges(per_page: PER_PAGE)
+    names = filtered_scope_names
+    return [] if names.empty?
+
+    ranges = names.each_slice(per_page).with_index.map do |slice, i|
+      { page: i + 1, first_label: slice.first, last_label: slice.last }
+    end
+    compute_labels(ranges)
   end
 
   # Returns neighbourhoods that have partners, with counts
@@ -121,5 +159,45 @@ class PartnersQuery
 
   def site_tag_ids
     @site_tag_ids ||= @site.tags.pluck(:id)
+  end
+
+  # ===================
+  # Pagination Helpers
+  # ===================
+
+  def filtered_scope_names
+    @filtered_scope_names ||= (@filtered_scope || base_scope.order(:name)).pluck(:name)
+  end
+
+  # Compute display labels for page ranges. Uses single letter when unambiguous,
+  # two-char prefix when a letter spans a page boundary (e.g. "Ce" vs "Cl")
+  def compute_labels(ranges)
+    ranges.each_with_index do |r, i|
+      prev_last = i.positive? ? ranges[i - 1][:last_label] : nil
+      next_first = i < ranges.length - 1 ? ranges[i + 1][:first_label] : nil
+
+      first_name = r[:first_label]
+      last_name = r[:last_label]
+
+      r[:first_label] = smart_label(first_name, prev_last, :start)
+      r[:last_label] = smart_label(last_name, next_first, :end)
+    end
+    ranges
+  end
+
+  # Generate a label for a page boundary name.
+  # Uses single letter if unambiguous, two-char prefix if the same letter
+  # appears on both sides of the boundary.
+  def smart_label(name, adjacent_name, _position)
+    letter = name[0].upcase
+    return letter unless adjacent_name
+
+    adjacent_letter = adjacent_name[0].upcase
+    if letter == adjacent_letter
+      # Same letter on both sides of boundary — use two-char prefix
+      name[0..1].capitalize
+    else
+      letter
+    end
   end
 end

--- a/app/views/partners/index.rb
+++ b/app/views/partners/index.rb
@@ -6,6 +6,10 @@ class Views::Partners::Index < Views::Base
   prop :map, _Nilable(Array), reader: :private
   prop :selected_category, _Nilable(String), reader: :private
   prop :selected_neighbourhood, _Nilable(String), reader: :private
+  prop :page, Integer, default: 1, reader: :private
+  prop :total_pages, Integer, default: 1, reader: :private
+  prop :page_letter_ranges, Array, default: -> { [] }, reader: :private
+  prop :filter_params, Hash, default: -> { {} }, reader: :private
 
   def view_template
     content_for(:title) { 'Partners' }
@@ -25,14 +29,38 @@ class Views::Partners::Index < Views::Base
 
         hr
 
-        ul(class: 'partners reset two-col', id: 'partners') do
-          partners.each do |partner|
-            PartnerPreview(partner: partner, site: site)
-          end
-        end
+        render_paginator if show_paginator?
+        render_letter_grouped_partners
+        render_paginator if show_paginator?
       end
       div(id: 'map') do
         Map(points: map, site: site.slug)
+      end
+    end
+  end
+
+  private
+
+  def show_paginator?
+    total_pages > 1
+  end
+
+  def render_paginator
+    PartnersPaginator(
+      page_letter_ranges: page_letter_ranges,
+      current_page: page,
+      filter_params: filter_params
+    )
+  end
+
+  def render_letter_grouped_partners
+    grouped = partners.group_by { |p| p.name[0].upcase }
+    grouped.each do |letter, letter_partners|
+      h3(id: "letter-#{letter}", class: 'partners-letter-heading') { letter }
+      ul(class: 'partners reset two-col', id: "partners-#{letter}") do
+        letter_partners.each do |partner|
+          PartnerPreview(partner: partner, site: site)
+        end
       end
     end
   end

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -109,6 +109,83 @@ RSpec.describe PartnersQuery do
     end
   end
 
+  describe "#call with pagination" do
+    let!(:partners) do
+      ("A".."E").map do |letter|
+        address = create(:address, neighbourhood: neighbourhood)
+        create(:partner, name: "#{letter} Partner", address: address)
+      end
+    end
+
+    it "returns only the requested page of results" do
+      results = described_class.new(site: site).call(page: 1, per_page: 2)
+      expect(results.map(&:name)).to eq(["A Partner", "B Partner"])
+    end
+
+    it "returns the second page" do
+      results = described_class.new(site: site).call(page: 2, per_page: 2)
+      expect(results.map(&:name)).to eq(["C Partner", "D Partner"])
+    end
+
+    it "returns the last page with remaining items" do
+      results = described_class.new(site: site).call(page: 3, per_page: 2)
+      expect(results.map(&:name)).to eq(["E Partner"])
+    end
+
+    it "sets total_pages" do
+      query = described_class.new(site: site)
+      query.call(page: 1, per_page: 2)
+      expect(query.total_pages).to eq(3)
+    end
+
+    it "sets total_count" do
+      query = described_class.new(site: site)
+      query.call(page: 1, per_page: 2)
+      expect(query.total_count).to eq(5)
+    end
+
+    it "clamps page to valid range" do
+      results = described_class.new(site: site).call(page: 999, per_page: 2)
+      # Should clamp to last page
+      expect(results.map(&:name)).to eq(["E Partner"])
+    end
+
+    it "returns all results when page is nil" do
+      results = described_class.new(site: site).call
+      expect(results.count).to eq(5)
+    end
+  end
+
+  describe "#page_letter_ranges" do
+    let!(:partners) do
+      %w[Alpha Bravo Charlie Delta Epsilon].each do |name|
+        address = create(:address, neighbourhood: neighbourhood)
+        create(:partner, name: name, address: address)
+      end
+    end
+
+    it "returns letter ranges for each page" do
+      query = described_class.new(site: site)
+      query.call(page: 1, per_page: 2)
+      ranges = query.page_letter_ranges(per_page: 2)
+
+      expect(ranges.length).to eq(3)
+      expect(ranges[0][:page]).to eq(1)
+      expect(ranges[0][:first_label]).to eq("A")
+    end
+
+    it "uses two-char prefix when letter spans boundary" do
+      # With per_page: 3, page 1 = Alpha, Bravo, Charlie; page 2 = Delta, Epsilon
+      query = described_class.new(site: site)
+      query.call(page: 1, per_page: 3)
+      ranges = query.page_letter_ranges(per_page: 3)
+
+      expect(ranges.length).to eq(2)
+      expect(ranges[0][:last_label]).to eq("C")
+      expect(ranges[1][:first_label]).to eq("D")
+    end
+  end
+
   describe "#neighbourhoods_with_counts" do
     let!(:partner1) do
       address = create(:address, neighbourhood: neighbourhood)


### PR DESCRIPTION
## Summary

Adds alphabetical pagination to the partners index with 50 partners per page. The paginator shows letter-range labels computed from the actual data (e.g. **A – Ma** | Ma – Th | Th – Z). When a letter spans a page boundary, two-character prefixes provide clarity (e.g. "Ce" vs "Cl").

- Partners grouped under letter headings within each page
- Sites with fewer than 50 partners don't show a paginator
- Pagination works with existing category and neighbourhood filters
- Navigation via Turbo Frames (no full page reload)
- Filter params preserved across page changes

Closes #3134

## Test plan
- [x] `bundle exec rspec spec/queries/partners_query_spec.rb` — 20 examples, 0 failures
- [x] `bundle exec rspec spec/requests/public/partners_spec.rb` — 27 examples, 0 failures
- [x] Verified on Manchester (3 pages: A–Ma, Ma–Th, Th–Z)
- [x] Verified on Mossley (1 partner, no paginator shown)
- [ ] Check page navigation via Turbo works without full reload
- [ ] Check filters + pagination reset to page 1