### PR TITLE
Add missing stimulus target to filter options. Fix edge cases in partner_filter_component_controller.js

### DIFF
--- a/app/components/filter.rb
+++ b/app/components/filter.rb
@@ -49,7 +49,10 @@ class Components::Filter < Components::Base
         @name,
         item[:id],
         selected?(item[:id]),
-        data: { action: submit_action_value },
+        data: {
+          action: submit_action_value,
+          "#{target_key}": target_value
+        },
         class: 'tag__button'
       )
       label_tag(
@@ -93,5 +96,13 @@ class Components::Filter < Components::Base
 
   def reset_action_value
     "click->#{@controller}##{@reset_action}"
+  end
+
+  def target_key
+    "#{@controller}-target"
+  end
+
+  def target_value
+    @name
   end
 end

--- a/app/javascript/controllers/partner_filter_component_controller.js
+++ b/app/javascript/controllers/partner_filter_component_controller.js
@@ -12,82 +12,93 @@ export default class extends Controller {
 		"neighbourhoodDropdown",
 	];
 
+	/** Workaround for Stimulus's lack of typing
+	 * @returns {{
+	 * 		categoryDropdownTarget: HTMLElement | undefined,
+	 * 		categoryTargets: HTMLInputElement[],
+	 * 		categoryTextTarget: HTMLElement | undefined,
+	 * 		formTarget: HTMLFormElement,
+	 * 		neighbourhoodDropdownTarget: HTMLElement | undefined,
+	 * 		neighbourhoodTargets: HTMLInputElement[],
+	 * 		neighbourhoodTextTarget: HTMLElement | undefined,
+	 * }} */
+	get typedThis() {
+		// @ts-ignore
+		return this;
+	}
 	connect() {
 		this.updateLabels();
 	}
 
 	submitCategory() {
 		this.updateLabels();
-		this.hideDropdown(this.categoryDropdownTarget);
+		this.toggleDropdownHidden(this.typedThis.categoryDropdownTarget, true);
 		this.submitForm();
 	}
 
 	submitNeighbourhood() {
 		this.updateLabels();
-		this.hideDropdown(this.neighbourhoodDropdownTarget);
+		this.toggleDropdownHidden(this.typedThis.neighbourhoodDropdownTarget, true);
 		this.submitForm();
 	}
 
 	resetCategory() {
-		this.selectedCategory.checked = false;
-		this.hideDropdown(this.categoryDropdownTarget);
+		if (this.selectedCategory) this.selectedCategory.checked = false;
+		this.toggleDropdownHidden(this.typedThis.categoryDropdownTarget, true);
 		this.submitForm();
 	}
 
 	resetNeighbourhood() {
-		this.selectedNeighbourhood.checked = false;
-		this.hideDropdown(this.neighbourhoodDropdownTarget);
+		if (this.selectedNeighbourhood) this.selectedNeighbourhood.checked = false;
+		this.toggleDropdownHidden(this.typedThis.neighbourhoodDropdownTarget, true);
 		this.submitForm();
 	}
 
 	toggleCategory() {
-		this.categoryDropdownTarget.classList.toggle("filters__dropdown--hidden");
-		// Close other dropdown
-		if (this.hasNeighbourhoodDropdownTarget) {
-			this.neighbourhoodDropdownTarget.classList.add(
-				"filters__dropdown--hidden",
-			);
-		}
+		this.toggleDropdownHidden(this.typedThis.categoryDropdownTarget);
+		this.toggleDropdownHidden(this.typedThis.neighbourhoodDropdownTarget, true);
 	}
 
 	toggleNeighbourhood() {
-		this.neighbourhoodDropdownTarget.classList.toggle(
-			"filters__dropdown--hidden",
-		);
-		// Close other dropdown
-		if (this.hasCategoryDropdownTarget) {
-			this.categoryDropdownTarget.classList.add("filters__dropdown--hidden");
-		}
+		this.toggleDropdownHidden(this.typedThis.neighbourhoodDropdownTarget);
+		this.toggleDropdownHidden(this.typedThis.categoryDropdownTarget, true);
 	}
 
-	hideDropdown(dropdown) {
-		if (dropdown) {
-			dropdown.classList.add("filters__dropdown--hidden");
-		}
+	/** Toggle dropdown hidden state. The optional `hidden` param will force a specific state
+	 * @param {HTMLElement | undefined} dropdown
+	 * @param {boolean | undefined} hidden
+	 */
+	toggleDropdownHidden(dropdown, hidden = undefined) {
+		if (!dropdown) return;
+		if (typeof hidden === "undefined")
+			dropdown.classList.toggle("filters__dropdown--hidden");
+		else dropdown.classList.toggle("filters__dropdown--hidden", hidden);
 	}
 
 	updateLabels() {
 		// Find the associated label for each selected param and get the text contents
 		// If params are selected, they show up instead of "Category" and "Neighbourhood" text
-		if (this.hasCategoryTextTarget && this.selectedCategory) {
-			this.categoryTextTarget.innerHTML =
+		if (this.typedThis.categoryTextTarget && this.selectedCategory?.labels)
+			this.typedThis.categoryTextTarget.innerHTML =
 				this.selectedCategory.labels[0].textContent;
-		}
-		if (this.hasNeighbourhoodTextTarget && this.selectedNeighbourhood) {
-			this.neighbourhoodTextTarget.innerHTML =
+
+		if (
+			this.typedThis.neighbourhoodTextTarget &&
+			this.selectedNeighbourhood?.labels
+		)
+			this.typedThis.neighbourhoodTextTarget.innerHTML =
 				this.selectedNeighbourhood.labels[0].textContent;
-		}
 	}
 
 	submitForm() {
-		this.formTarget.requestSubmit();
+		this.typedThis.formTarget.requestSubmit();
 	}
 
 	get selectedCategory() {
-		return this.categoryTargets.find((r) => r.checked);
+		return this.typedThis.categoryTargets.find((r) => r.checked);
 	}
 
 	get selectedNeighbourhood() {
-		return this.neighbourhoodTargets.find((r) => r.checked);
+		return this.typedThis.neighbourhoodTargets.find((r) => r.checked);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"dependencies": {
 		"@hotwired/turbo-rails": "8",
-		"@tailwindcss/cli": "^4.1.18"
+		"@tailwindcss/cli": "^4.1.18",
+		"@hotwired/stimulus": "^3.2.2"
 	},
 	"devDependencies": {
 		"daisyui": "^5.5.14",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	// this exists so we can have js type checking
+	"compilerOptions": {
+		"checkJs": true,
+		"module": "esnext",
+		"target": "esnext",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true,
+		"strict": true,
+		"noEmit": true
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@hotwired/stimulus@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
+  integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
+
 "@hotwired/turbo-rails@8":
   version "8.0.23"
   resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.23.tgz#7a84ad041cb0f3e5d9ff97d1a1f0291550a93fc9"


### PR DESCRIPTION
The reset buttons at the bottom of the Filter component dropdowns were broken. This fixes them

Part of https://github.com/geeksforsocialchange/PlaceCal/issues/3140

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Firefox and Chromium, ran unit tests