### PR TITLE
Fix filter reset buttons, tag filtering, neighbourhood counts, and layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,6 @@ This file configures AI coding assistants for PlaceCal. Review the context file 
 - **Never claim a fix worked until you've actually verified it** - Take a screenshot, look at it carefully, and compare before/after.
 - **When the user says something is wrong, believe them** - Trust the user over your assumptions.
 - **Debug properly** - If a fix doesn't work, investigate why rather than assuming it did.
-- **Do NOT use preview tools for verification** - The preview browser cannot resolve `lvh.me` subdomains, which this app requires for site-scoped routing. Use `curl` against the dev server instead, or ask the user to check in their browser.
 
 ## Development URLs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file configures AI coding assistants for PlaceCal. Review the context file 
 - **Never claim a fix worked until you've actually verified it** - Take a screenshot, look at it carefully, and compare before/after.
 - **When the user says something is wrong, believe them** - Trust the user over your assumptions.
 - **Debug properly** - If a fix doesn't work, investigate why rather than assuming it did.
+- **Do NOT use preview tools for verification** - The preview browser cannot resolve `lvh.me` subdomains, which this app requires for site-scoped routing. Use `curl` against the dev server instead, or ask the user to check in their browser.
 
 ## Development URLs
 

--- a/app/assets/stylesheets/components/breadcrumb_component.scss
+++ b/app/assets/stylesheets/components/breadcrumb_component.scss
@@ -9,7 +9,7 @@
 	margin: 0.5rem 0 0;
 
 	@include for-tablet-portrait-up {
-		margin: 1rem 0 0;
+		margin: 1rem 0;
 	}
 
 	~ hr {
@@ -48,8 +48,9 @@
 		}
 
 		svg {
-			width: 1rem;
-			height: 1rem;
+			width: 1em;
+			height: 1em;
+			flex-shrink: 0;
 			color: $base-primary;
 		}
 

--- a/app/assets/stylesheets/components/breadcrumb_component.scss
+++ b/app/assets/stylesheets/components/breadcrumb_component.scss
@@ -6,7 +6,15 @@
 	@include justify-content(flex-start);
 
 	font-size: $small-font-size;
-	margin: 1rem 0;
+	margin: 0.5rem 0 0;
+
+	@include for-tablet-portrait-up {
+		margin: 1rem 0 0;
+	}
+
+	~ hr {
+		margin-top: 0.25rem;
+	}
 
 	.btn {
 		border-bottom-color: var(--base-primary);
@@ -22,7 +30,7 @@
 	}
 
 	@include for-phone-only {
-		&__tagline {
+		&__element:has(.breadcrumb__tagline) {
 			display: none;
 		}
 	}
@@ -48,12 +56,17 @@
 		&--last {
 			display: flex;
 			flex-direction: row;
-			gap: 1rem;
-			justify-content: flex-end;
+			flex-wrap: wrap;
+			align-items: center;
+			gap: 0.5rem 1rem;
+			justify-content: flex-start;
 			margin-right: 0;
+			width: 100%;
 
-			@include flex(1 1 auto);
-			@include for-tablet-portrait-up {
+			@include for-desktop-up {
+				width: auto;
+				@include flex(1 1 auto);
+				justify-content: flex-end;
 				text-align: right;
 			}
 		}
@@ -62,6 +75,7 @@
 	&__filters {
 		display: flex;
 		flex-direction: row;
+		align-items: center;
 		gap: 1rem;
 		justify-content: flex-end;
 	}

--- a/app/assets/stylesheets/components/filters.scss
+++ b/app/assets/stylesheets/components/filters.scss
@@ -57,17 +57,12 @@
 		padding: 0.8rem;
 		position: absolute;
 		top: 2rem;
+		left: 0;
 		z-index: 500;
 		text-align: left;
 		white-space: nowrap;
-
-		&--category {
-			left: -1rem;
-		}
-
-		&--neighbourhood {
-			right: -3rem;
-		}
+		max-width: calc(100vw - 2rem);
+		overflow-x: auto;
 
 		&--hidden {
 			display: none;

--- a/app/components/filter.rb
+++ b/app/components/filter.rb
@@ -49,7 +49,10 @@ class Components::Filter < Components::Base
         @name,
         item[:id],
         selected?(item[:id]),
-        data: { action: submit_action_value },
+        data: {
+          action: submit_action_value,
+          "#{@controller}-target": @name
+        },
         class: 'tag__button'
       )
       label_tag(

--- a/app/components/partner_filter.rb
+++ b/app/components/partner_filter.rb
@@ -73,7 +73,11 @@ class Components::PartnerFilter < Components::Base
   end
 
   def categories
-    @categories ||= @query.categories_with_counts
+    @categories ||= if @selected_neighbourhood.positive?
+                      @query.categories_with_counts(scope: @query.call(neighbourhood_id: @selected_neighbourhood))
+                    else
+                      @query.categories_with_counts
+                    end
   end
 
   def category_items
@@ -85,7 +89,11 @@ class Components::PartnerFilter < Components::Base
   end
 
   def neighbourhoods
-    @neighbourhoods ||= @query.neighbourhoods_with_counts
+    @neighbourhoods ||= if @selected_category.positive?
+                          @query.neighbourhoods_with_counts(scope: @query.call(tag_id: @selected_category))
+                        else
+                          @query.neighbourhoods_with_counts
+                        end
   end
 
   def neighbourhood_items

--- a/app/javascript/controllers/event_filter_controller.js
+++ b/app/javascript/controllers/event_filter_controller.js
@@ -1,36 +1,45 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-	static targets = ["form", "neighbourhoodDropdown", "neighbourhoodText"];
+	static targets = [
+		"neighbourhood",
+		"neighbourhoodDropdown",
+		"neighbourhoodText",
+	];
 
 	toggleNeighbourhood() {
-		this.neighbourhoodDropdownTarget.classList.toggle(
-			"filters__dropdown--hidden",
-		);
+		this.toggleDropdownHidden(this.neighbourhoodDropdownTarget);
 	}
 
-	submitNeighbourhood(event) {
-		// Find the parent form and submit it
-		const form = event.target.closest("form");
-		if (form) {
-			form.requestSubmit();
+	submitNeighbourhood() {
+		this.updateLabel();
+		this.toggleDropdownHidden(this.neighbourhoodDropdownTarget, true);
+		const form = this.element.querySelector("form");
+		if (form) form.requestSubmit();
+	}
+
+	resetNeighbourhood() {
+		if (this.selectedNeighbourhood) this.selectedNeighbourhood.checked = false;
+		this.toggleDropdownHidden(this.neighbourhoodDropdownTarget, true);
+
+		const url = new URL(window.location.href);
+		url.searchParams.delete("neighbourhood");
+		Turbo.visit(url.toString(), { action: "advance" });
+	}
+
+	toggleDropdownHidden(dropdown, hidden) {
+		if (!dropdown) return;
+		dropdown.classList.toggle("filters__dropdown--hidden", hidden);
+	}
+
+	updateLabel() {
+		if (this.hasNeighbourhoodTextTarget && this.selectedNeighbourhood?.labels) {
+			this.neighbourhoodTextTarget.innerHTML =
+				this.selectedNeighbourhood.labels[0].textContent;
 		}
 	}
 
-	resetNeighbourhood(event) {
-		event.preventDefault();
-		// Find all neighbourhood radio buttons and uncheck them
-		const form = event.target.closest("form");
-		if (form) {
-			const radios = form.querySelectorAll('input[name="neighbourhood"]');
-			radios.forEach((radio) => (radio.checked = false));
-
-			// Remove the neighbourhood param by creating a new URL without it
-			const url = new URL(window.location.href);
-			url.searchParams.delete("neighbourhood");
-
-			// Navigate using Turbo
-			Turbo.visit(url.toString(), { action: "advance" });
-		}
+	get selectedNeighbourhood() {
+		return this.neighbourhoodTargets.find((r) => r.checked);
 	}
 }

--- a/app/javascript/controllers/partner_filter_component_controller.js
+++ b/app/javascript/controllers/partner_filter_component_controller.js
@@ -18,62 +18,53 @@ export default class extends Controller {
 
 	submitCategory() {
 		this.updateLabels();
-		this.hideDropdown(this.categoryDropdownTarget);
+		this.toggleDropdownHidden(this.categoryDropdownTarget, true);
 		this.submitForm();
 	}
 
 	submitNeighbourhood() {
 		this.updateLabels();
-		this.hideDropdown(this.neighbourhoodDropdownTarget);
+		this.toggleDropdownHidden(this.neighbourhoodDropdownTarget, true);
 		this.submitForm();
 	}
 
 	resetCategory() {
-		this.selectedCategory.checked = false;
-		this.hideDropdown(this.categoryDropdownTarget);
+		if (this.selectedCategory) this.selectedCategory.checked = false;
+		this.toggleDropdownHidden(this.categoryDropdownTarget, true);
 		this.submitForm();
 	}
 
 	resetNeighbourhood() {
-		this.selectedNeighbourhood.checked = false;
-		this.hideDropdown(this.neighbourhoodDropdownTarget);
+		if (this.selectedNeighbourhood) this.selectedNeighbourhood.checked = false;
+		this.toggleDropdownHidden(this.neighbourhoodDropdownTarget, true);
 		this.submitForm();
 	}
 
 	toggleCategory() {
-		this.categoryDropdownTarget.classList.toggle("filters__dropdown--hidden");
-		// Close other dropdown
+		this.toggleDropdownHidden(this.categoryDropdownTarget);
 		if (this.hasNeighbourhoodDropdownTarget) {
-			this.neighbourhoodDropdownTarget.classList.add(
-				"filters__dropdown--hidden",
-			);
+			this.toggleDropdownHidden(this.neighbourhoodDropdownTarget, true);
 		}
 	}
 
 	toggleNeighbourhood() {
-		this.neighbourhoodDropdownTarget.classList.toggle(
-			"filters__dropdown--hidden",
-		);
-		// Close other dropdown
+		this.toggleDropdownHidden(this.neighbourhoodDropdownTarget);
 		if (this.hasCategoryDropdownTarget) {
-			this.categoryDropdownTarget.classList.add("filters__dropdown--hidden");
+			this.toggleDropdownHidden(this.categoryDropdownTarget, true);
 		}
 	}
 
-	hideDropdown(dropdown) {
-		if (dropdown) {
-			dropdown.classList.add("filters__dropdown--hidden");
-		}
+	toggleDropdownHidden(dropdown, hidden) {
+		if (!dropdown) return;
+		dropdown.classList.toggle("filters__dropdown--hidden", hidden);
 	}
 
 	updateLabels() {
-		// Find the associated label for each selected param and get the text contents
-		// If params are selected, they show up instead of "Category" and "Neighbourhood" text
-		if (this.hasCategoryTextTarget && this.selectedCategory) {
+		if (this.hasCategoryTextTarget && this.selectedCategory?.labels) {
 			this.categoryTextTarget.innerHTML =
 				this.selectedCategory.labels[0].textContent;
 		}
-		if (this.hasNeighbourhoodTextTarget && this.selectedNeighbourhood) {
+		if (this.hasNeighbourhoodTextTarget && this.selectedNeighbourhood?.labels) {
 			this.neighbourhoodTextTarget.innerHTML =
 				this.selectedNeighbourhood.labels[0].textContent;
 		}

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -34,24 +34,42 @@ class PartnersQuery
   # Used for filter dropdowns
   #
   # @return [Array<Hash>] array of { neighbourhood: Neighbourhood, count: Integer }
-  def neighbourhoods_with_counts
-    Neighbourhood
-      .joins(addresses: :partners)
-      .where(partners: { id: base_scope.select(:id) })
-      .group(:id, :name)
-      .order(:name)
-      .select('neighbourhoods.*, COUNT(DISTINCT partners.id) as partner_count')
-      .map { |n| { neighbourhood: n, count: n.partner_count } }
+  def neighbourhoods_with_counts(scope: nil)
+    partner_ids = (scope || base_scope).reorder(nil).select(:id)
+
+    pairs = ActiveRecord::Base.connection.select_all(<<~SQL) # rubocop:disable Rails/SquishedSQLHeredocs
+      SELECT neighbourhood_id, partner_id FROM (
+        SELECT a.neighbourhood_id, p.id AS partner_id
+        FROM partners p
+        INNER JOIN addresses a ON a.id = p.address_id
+        WHERE p.id IN (#{partner_ids.to_sql})
+          AND a.neighbourhood_id IS NOT NULL
+        UNION
+        SELECT sa.neighbourhood_id, sa.partner_id
+        FROM service_areas sa
+        WHERE sa.partner_id IN (#{partner_ids.to_sql})
+          AND sa.neighbourhood_id IS NOT NULL
+      ) AS combined
+    SQL
+
+    counts = pairs.group_by { |r| r['neighbourhood_id'] }
+                  .transform_values { |rows| rows.map { |r| r['partner_id'] }.uniq.length }
+
+    return [] if counts.empty?
+
+    Neighbourhood.where(id: counts.keys).order(:name).map do |n|
+      { neighbourhood: n, count: counts[n.id] }
+    end
   end
 
   # Returns categories/tags that have partners, with counts
   # Used for filter dropdowns
   #
   # @return [Array<Hash>] array of { category: Tag, count: Integer }
-  def categories_with_counts
+  def categories_with_counts(scope: nil)
     Tag
       .joins(:partner_tags)
-      .where(partner_tags: { partner_id: base_scope.select(:id) }, type: 'Category')
+      .where(partner_tags: { partner_id: (scope || base_scope).reorder(nil).select(:id) }, type: 'Category')
       .group(:id, :name)
       .order(:name)
       .select('tags.*, COUNT(partner_tags.partner_id) as partner_count')

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -97,11 +97,11 @@ class PartnersQuery
   end
 
   def filter_by_tag(partners, tag_id)
-    partners.joins(:tags).where(tags: { id: tag_id })
+    partners.where(id: PartnerTag.where(tag_id: tag_id).select(:partner_id))
   end
 
   def filter_by_tag_slug(partners, tag_slug)
-    partners.joins(:tags).where(tags: { slug: tag_slug })
+    partners.where(id: PartnerTag.joins(:tag).where(tags: { slug: tag_slug }).select(:partner_id))
   end
 
   # ===================

--- a/spec/components/event_filter_component_spec.rb
+++ b/spec/components/event_filter_component_spec.rb
@@ -219,6 +219,64 @@ RSpec.describe Components::EventFilter, type: :component do
     end
   end
 
+  describe "neighbourhood filter" do
+    let(:district) { create(:neighbourhood, name: "Test District", unit: "district") }
+    let(:future_attrs) { base_attrs.merge(period: "future") }
+    let(:ward1) { create(:neighbourhood, name: "Hillcrest", unit: "ward", parent: district) }
+    let(:ward2) { create(:neighbourhood, name: "Valleyview", unit: "ward", parent: district) }
+    let(:site) do
+      s = create(:site)
+      create(:sites_neighbourhood, site: s, neighbourhood: district)
+      s
+    end
+    let(:address1) { create(:address, neighbourhood: ward1) }
+    let(:address2) { create(:address, neighbourhood: ward2) }
+    let(:partner1) do
+      p = create(:partner, address: address1)
+      p.service_areas << create(:service_area, neighbourhood: ward1)
+      p
+    end
+    let(:partner2) do
+      p = create(:partner, address: address2)
+      p.service_areas << create(:service_area, neighbourhood: ward2)
+      p
+    end
+
+    before do
+      create_list(:future_event, 3, organiser: partner1, address: address1)
+      create_list(:future_event, 2, organiser: partner2, address: address2)
+    end
+
+    it "shows neighbourhood filter when multiple neighbourhoods have events" do
+      render_inline(described_class.new(**future_attrs, site: site))
+
+      expect(page).to have_selector("button span.filters__link", text: "Neighbourhood")
+    end
+
+    it "shows selected neighbourhood name when a neighbourhood is selected" do
+      render_inline(described_class.new(**future_attrs, site: site, selected_neighbourhood: ward1.id.to_s))
+
+      expect(page).to have_selector("button span.filters__link", text: ward1.name)
+    end
+
+    it "does not show neighbourhood filter when only one neighbourhood has events" do
+      other_district = create(:neighbourhood, name: "Other District", unit: "district")
+      single_ward = create(:neighbourhood, name: "Only Ward", unit: "ward", parent: other_district)
+      single_address = create(:address, neighbourhood: single_ward)
+      single_partner = create(:partner, address: single_address)
+      single_partner.service_areas << create(:service_area, neighbourhood: single_ward)
+
+      single_site = create(:site)
+      create(:sites_neighbourhood, site: single_site, neighbourhood: other_district)
+
+      create_list(:future_event, 3, organiser: single_partner, address: single_address)
+
+      render_inline(described_class.new(**future_attrs, site: single_site))
+
+      expect(page).not_to have_selector("button span.filters__link", text: "Neighbourhood")
+    end
+  end
+
   describe "with different parameter values" do
     context "with week period" do
       let(:attrs) { base_attrs.merge(period: "week") }

--- a/spec/components/partner_filter_component_spec.rb
+++ b/spec/components/partner_filter_component_spec.rb
@@ -100,5 +100,65 @@ RSpec.describe Components::PartnerFilter, type: :component do
       # When a neighbourhood is selected, it shows the neighbourhood name instead of "Neighbourhood"
       expect(page).to have_selector("button span.filters__link", text: neighbourhood1.name)
     end
+
+    it "shows reset link when a filter is active" do
+      render_inline(described_class.new(
+                      site: site,
+                      selected_category: nil,
+                      selected_neighbourhood: neighbourhood1.id.to_s
+                    ))
+
+      expect(page).to have_link("Reset filters")
+    end
+
+    it "does not show reset link when no filters are active" do
+      render_inline(described_class.new(
+                      site: site,
+                      selected_category: nil,
+                      selected_neighbourhood: nil
+                    ))
+
+      expect(page).not_to have_link("Reset filters")
+    end
+  end
+
+  describe "cross-filtering" do
+    let(:neighbourhood1) { create(:neighbourhood) }
+    let(:neighbourhood2) { create(:neighbourhood) }
+    let(:site) { create(:site, neighbourhoods: [neighbourhood1, neighbourhood2]) }
+    let(:category1) { create(:category_tag) }
+    let(:category2) { create(:category_tag) }
+
+    let!(:partner_n1_c1) do
+      partner = create(:partner, address: create(:address, neighbourhood: neighbourhood1))
+      partner.categories << category1
+      partner
+    end
+
+    let!(:partner_n2_c2) do
+      partner = create(:partner, address: create(:address, neighbourhood: neighbourhood2))
+      partner.categories << category2
+      partner
+    end
+
+    it "shows only relevant neighbourhoods when a category is selected" do
+      render_inline(described_class.new(
+                      site: site,
+                      selected_category: category1.id.to_s,
+                      selected_neighbourhood: nil
+                    ))
+
+      expect(page).not_to have_selector("button span.filters__link", text: "Neighbourhood")
+    end
+
+    it "shows only relevant categories when a neighbourhood is selected" do
+      render_inline(described_class.new(
+                      site: site,
+                      selected_category: nil,
+                      selected_neighbourhood: neighbourhood1.id.to_s
+                    ))
+
+      expect(page).not_to have_selector("button span.filters__link", text: "Category")
+    end
   end
 end

--- a/spec/datatables/calendar_datatable_spec.rb
+++ b/spec/datatables/calendar_datatable_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe CalendarDatatable do
     end
 
     context "has_events filter" do
-      before { create(:event, calendar: calendar1, summary: "Unique Event For Filters Test") }
+      before { create(:event, calendar: calendar1, organiser: partner1, summary: "Unique Event For Filters Test") }
 
       it "filters calendars with events" do
         datatable = create_datatable("filter" => { "has_events" => "yes" })

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -138,6 +138,53 @@ RSpec.describe PartnersQuery do
       names = results.map { |r| r[:neighbourhood].name }
       expect(names).to eq(names.sort)
     end
+
+    context "with service-area-only partners" do
+      let!(:service_area_partner) do
+        partner = build(:partner, address: nil)
+        partner.service_area_neighbourhoods << other_neighbourhood
+        partner.save!
+        partner
+      end
+
+      it "includes service-area partners in counts" do
+        results = described_class.new(site: site).neighbourhoods_with_counts
+
+        other_result = results.find { |r| r[:neighbourhood].id == other_neighbourhood.id }
+        expect(other_result[:count]).to eq(2)
+      end
+    end
+
+    context "when partner has address and service area in same neighbourhood" do
+      before do
+        partner1.service_area_neighbourhoods << neighbourhood
+      end
+
+      it "does not double-count the partner" do
+        results = described_class.new(site: site).neighbourhoods_with_counts
+
+        neighbourhood_result = results.find { |r| r[:neighbourhood].id == neighbourhood.id }
+        expect(neighbourhood_result[:count]).to eq(2)
+      end
+    end
+
+    context "with scope parameter (cross-filtering)" do
+      let!(:category) { create(:category, name: "Filtered") }
+
+      before do
+        partner1.tags << category
+      end
+
+      it "counts only partners matching the scoped query" do
+        query = described_class.new(site: site)
+        scoped = query.call(tag_id: category.id)
+        results = query.neighbourhoods_with_counts(scope: scoped)
+
+        expect(results.length).to eq(1)
+        neighbourhood_result = results.find { |r| r[:neighbourhood].id == neighbourhood.id }
+        expect(neighbourhood_result[:count]).to eq(1)
+      end
+    end
   end
 
   describe "#categories_with_counts" do
@@ -180,6 +227,58 @@ RSpec.describe PartnersQuery do
 
       names = results.map { |r| r[:category].name }
       expect(names).to eq(names.sort)
+    end
+
+    context "with scope parameter (cross-filtering)" do
+      it "counts only partners in the scoped neighbourhood" do
+        query = described_class.new(site: site)
+        scoped = query.call(neighbourhood_id: neighbourhood.id)
+        results = query.categories_with_counts(scope: scoped)
+
+        category1_result = results.find { |r| r[:category].id == category1.id }
+        expect(category1_result[:count]).to eq(2)
+
+        expect(results.map { |r| r[:category].id }).not_to include(category2.id) unless
+          partner3.address.neighbourhood_id == neighbourhood.id
+      end
+    end
+  end
+
+  describe "tag filtering on site with site-level tags" do
+    let(:site_tag) { create(:tag) }
+    let!(:partner_both_tags) do
+      address = create(:address, neighbourhood: neighbourhood)
+      partner = create(:partner, address: address)
+      partner.tags << site_tag
+      partner.tags << filter_tag
+      partner
+    end
+    let!(:partner_site_tag_only) do
+      address = create(:address, neighbourhood: neighbourhood)
+      partner = create(:partner, address: address)
+      partner.tags << site_tag
+      partner
+    end
+    let(:filter_tag) { create(:tag) }
+    let(:site_with_tags) { create(:site) }
+
+    before do
+      site_with_tags.neighbourhoods << neighbourhood
+      site_with_tags.tags << site_tag
+      site_with_tags.tags << filter_tag
+    end
+
+    it "filters by tag without conflicting with site tag scope" do
+      results = described_class.new(site: site_with_tags).call(tag_id: filter_tag.id)
+
+      expect(results).to include(partner_both_tags)
+      expect(results).not_to include(partner_site_tag_only)
+    end
+
+    it "returns all site-scoped partners without tag filter" do
+      results = described_class.new(site: site_with_tags).call
+
+      expect(results).to include(partner_both_tags, partner_site_tag_only)
     end
   end
 end


### PR DESCRIPTION
## Summary

Rescues the bug fix from #3141 (fixes #3140) and fixes several additional filter issues discovered during testing.

- **Fix filter reset button crash** — clicking "Reset" no longer throws `TypeError: can't access property "checked"`. Added null guards and Stimulus target attributes to radio buttons so the controller can find them.
- **Fix tag filtering on sites with site-level tags** — changed from `.joins(:tags).where(tags: { id: })` to a subquery to avoid conflicting WHERE clauses when `base_scope` already joins tags for site scoping.
- **Fix neighbourhood counts to include service areas** — rewrote `neighbourhoods_with_counts` to use a UNION of address-based and service-area-based lookups, with deduplication to prevent double-counting.
- **Add cross-filtering** — selecting a category now updates the neighbourhood dropdown to only show neighbourhoods with partners in that category (and vice versa).
- **Fix filter bar layout** — left-align on mobile, right-align on desktop. Remove excess bottom margin on mobile. Fix filter dropdown going off-viewport on mobile.
- **Fix event filter controller** — updated to use Stimulus targets with null guards, matching the partner filter fix.

## Files changed

- `app/components/filter.rb` — add Stimulus target data attribute to radio buttons
- `app/components/partner_filter.rb` — add cross-filtering logic
- `app/queries/partners_query.rb` — fix tag filtering (subquery), fix neighbourhood counts (UNION), add `scope:` param for cross-filtering
- `app/javascript/controllers/partner_filter_component_controller.js` — null guards, `toggleDropdownHidden` helper, optional chaining
- `app/javascript/controllers/event_filter_controller.js` — updated to use Stimulus targets with null guards
- `app/assets/stylesheets/components/breadcrumb_component.scss` — responsive layout fixes
- `app/assets/stylesheets/components/filters.scss` — dropdown viewport containment

## Test plan

- [x] Existing specs pass
- [x] New specs: partner filter — service-area neighbourhood counts, no double-counting, cross-filtering, tag filtering on tagged sites, reset link visibility
- [x] New specs: event filter — neighbourhood filter visibility with multiple/single neighbourhoods, selected neighbourhood name display
- [x] Manual: click category/neighbourhood filter → Reset → no JS error
- [x] Manual: select a category → neighbourhood dropdown updates (and vice versa)
- [x] Manual: filter dropdown stays within viewport on mobile