### PR TITLE
Restore body font weight, fix filter spacing and footer email wrap

### DIFF
--- a/app/assets/stylesheets/components/filters.scss
+++ b/app/assets/stylesheets/components/filters.scss
@@ -73,6 +73,8 @@
 		padding: 0.25rem 0;
 		display: grid;
 		grid-template-columns: auto 1fr;
+		gap: 0.5rem;
+		align-items: center;
 	}
 
 	input {

--- a/app/components/footer.rb
+++ b/app/components/footer.rb
@@ -68,11 +68,11 @@ class Components::Footer < Components::Base
   def render_site_contact_info
     if @site.site_admin.phone&.length&.positive?
       strong { 'T:' }
-      plain " #{@site.site_admin.phone}"
+      plain " #{@site.site_admin.phone}"
       br
     end
     strong { 'E:' }
-    plain ' '
+    plain ' '
     mail_to(@site.site_admin.email)
   end
 

--- a/app/tailwind/public_tailwind.css
+++ b/app/tailwind/public_tailwind.css
@@ -171,7 +171,7 @@ https://tailwindcss.com/docs/theme#default-theme-variable-reference
 @layer base {
 	body {
 		/* app/assets/stylesheets/base/typography.scss */
-		@apply font-sans;
+		@apply font-sans font-regular;
 	}
 	/* app/assets/stylesheets/variables/typography.scss */
 	h1 {


### PR DESCRIPTION
## Summary
- Restore `font-weight: 500` on `body` — was dropped during the SCSS → Tailwind migration ([befe5da](https://github.com/geeksforsocialchange/PlaceCal/commit/befe5daa)), making dev text look lighter than prod
- Add `gap: 0.5rem` + `align-items: center` to `.filters__option` so the event filter radio buttons and labels have proper spacing
- Use a non-breaking space between `E:` and the email link in the site footer so they don't wrap onto separate lines on narrow screens (e.g. queerleeds)

## Test plan
- [ ] Visit any public page — body copy should look medium-weight, matching production
- [ ] Visit `/events` on a site with a "Filter and sort" dropdown — radios and labels should have visible space between them
- [ ] On a site with a long site-admin email (e.g. queerleeds), check the footer renders `E: <email>` on one line where possible