### PR TITLE
Fix GHCR pull failure when non-PAT-owner triggers deploy

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -231,7 +231,7 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.KAMAL_REGISTRY_PASSWORD }}
 
       - uses: ruby/setup-ruby@v1
@@ -250,7 +250,7 @@ jobs:
           kamal deploy -d ${{ steps.dest.outputs.destination }}
         env:
           # Kamal builds + pushes the Docker image to GHCR, then deploys to server
-          KAMAL_REGISTRY_USERNAME: ${{ github.actor }}
+          KAMAL_REGISTRY_USERNAME: ${{ github.repository_owner }}
           KAMAL_REGISTRY_PASSWORD: ${{ secrets.KAMAL_REGISTRY_PASSWORD }}
           # Server host (destination files use ERB to read these)
           STAGING_HOST: ${{ steps.dest.outputs.destination == 'staging' && secrets.STAGING_HOST || '' }}


### PR DESCRIPTION
## Summary

- Use `${{ github.repository_owner }}` (= `geeksforsocialchange`) instead of `${{ github.actor }}` for the GHCR docker login username, in both the runner-side login and the `KAMAL_REGISTRY_USERNAME` passed to `kamal deploy`.

## Why

The PAT in `secrets.KAMAL_REGISTRY_PASSWORD` belongs to `kimadactyl`. When `github.actor` matches the PAT owner the docker login resolves to that user's permissions and pulling works. When the actor is anyone else — notably `renovate[bot]` — login still succeeds, but GHCR scopes the access token to the actor's permissions; the bot can't read the org's private package, so `docker pull` on the staging server returns **404 not found** and Kamal aborts the deploy.

This is what broke [run 25827320984](https://github.com/geeksforsocialchange/PlaceCal/actions/runs/25827320984) (renovate-merged commit `427fa428`, lint-staged v17). The earlier deploy at `f63f4e34` succeeded because `kimadactyl` merged it.

Using the org name as the username decouples the docker login identity from whoever triggered the workflow; GHCR uses the PAT owner's identity for authorisation, and the pull works regardless of the merger.

## Test plan

- [x] Workflow YAML still parses (only two single-line text changes).
- [ ] Merge this PR; confirm the resulting `Test and maybe deploy` run on `main` completes the deploy job successfully (`Finished all in ...` with no error).
- [ ] On the next renovate-merged PR after this lands, confirm the deploy job also passes — this proves the original failure mode is gone.

## Notes

- Staging is currently on the pre-`427fa428` image (the failed pull never replaced the running container). It will roll forward on the next successful `main` deploy; no manual recovery needed.