### PR TITLE
Fix meta description tag to use name instead of property

### DIFF
--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -78,7 +78,7 @@ class Views::Layouts::Application < Phlex::HTML
     link(rel: 'apple-touch-icon', href: image_url('apple-touch-icon.png'))
     meta(name: 'viewport', content: 'width=device-width, initial-scale=1')
 
-    meta(property: 'description', content: description_text)
+    meta(name: 'description', content: description_text)
     meta(property: 'og:description', content: description_text)
 
     if content_for?(:image)


### PR DESCRIPTION
## Summary

- The HTML `<meta>` description was using `property="description"` (Open Graph syntax) instead of `name="description"` (standard HTML). Search engines and Lighthouse look for `name="description"` — the `property` form was invisible to them.

Fixes the "Document does not have a meta description" Lighthouse SEO audit. The OG description tag (`property="og:description"`) is unchanged.

## Test plan

- [x] Verify `<meta name="description" content="...">` appears in page source
- [ ] Re-run Lighthouse SEO audit on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)