### PR TITLE
Add XML sitemap generation

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+class SitemapsController < ApplicationController
+  CACHE_TTL = 1.day
+  MAX_URLS_PER_SITEMAP = 50_000
+  BASE = 'https://placecal.org'
+
+  before_action :set_site
+  before_action :require_default_site
+
+  def index
+    render xml: cached_xml('sitemap/index') { build_index }
+  end
+
+  def partners
+    render xml: cached_xml('sitemap/partners') { build_partners }
+  end
+
+  def events
+    render xml: cached_xml('sitemap/events') { build_events }
+  end
+
+  def partnerships
+    render xml: cached_xml('sitemap/partnerships') { build_partnerships }
+  end
+
+  def pages
+    render xml: cached_xml('sitemap/pages') { build_pages }
+  end
+
+  private
+
+  def require_default_site
+    head :not_found unless default_site?
+  end
+
+  def cached_xml(key, &)
+    expires_in CACHE_TTL, public: true
+    Rails.cache.fetch(key, expires_in: CACHE_TTL, &)
+  end
+
+  def build_index
+    xml = +''
+    xml << '<?xml version="1.0" encoding="UTF-8"?>'
+    xml << '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    %w[partners events partnerships pages].each do |section|
+      xml << "<sitemap><loc>#{BASE}/sitemap/#{section}.xml</loc></sitemap>"
+    end
+    xml << '</sitemapindex>'
+  end
+
+  def build_partners
+    urls = Partner.visible.pluck(:slug, :updated_at).map do |slug, updated_at|
+      url_entry("#{BASE}/partners/#{slug}", updated_at)
+    end
+    wrap_urlset(urls)
+  end
+
+  def build_events
+    urls = Event.where(dtstart: 3.months.ago..)
+                .limit(MAX_URLS_PER_SITEMAP)
+                .pluck(:id, :updated_at)
+                .map { |id, updated_at| url_entry("#{BASE}/events/#{id}", updated_at) }
+    wrap_urlset(urls)
+  end
+
+  def build_partnerships
+    urls = []
+    urls << url_entry("#{BASE}/partnerships")
+
+    Site.published.where.not(slug: 'default-site').pluck(:slug, :url, :updated_at).each do |slug, site_url, updated_at|
+      urls << url_entry("#{BASE}/partnerships/#{slug}", updated_at)
+      urls << url_entry(site_url.chomp('/'), updated_at)
+    end
+
+    wrap_urlset(urls)
+  end
+
+  def build_pages
+    urls = []
+
+    urls << url_entry(BASE)
+    urls << url_entry("#{BASE}/partners")
+    urls << url_entry("#{BASE}/events")
+    urls << url_entry("#{BASE}/find-placecal")
+
+    %w[privacy our-story terms-of-use get-in-touch
+       community-groups metropolitan-areas vcses
+       housing-providers social-prescribers culture-tourism].each do |page|
+      urls << url_entry("#{BASE}/#{page}")
+    end
+
+    Article.published.pluck(:slug, :updated_at).each do |slug, updated_at|
+      urls << url_entry("#{BASE}/news/#{slug}", updated_at)
+    end
+
+    Collection.pluck(:id, :route, :updated_at).each do |id, route, updated_at|
+      path = route.presence || "collections/#{id}"
+      urls << url_entry("#{BASE}/#{path}", updated_at)
+    end
+
+    wrap_urlset(urls)
+  end
+
+  def url_entry(loc, lastmod = nil)
+    entry = "<url><loc>#{CGI.escapeHTML(loc)}</loc>"
+    entry << "<lastmod>#{lastmod.strftime('%Y-%m-%d')}</lastmod>" if lastmod
+    entry << '</url>'
+  end
+
+  def wrap_urlset(urls)
+    xml = +'<?xml version="1.0" encoding="UTF-8"?>'
+    xml << '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    urls.each { |u| xml << u }
+    xml << '</urlset>'
+  end
+end

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -5,6 +5,9 @@ class SitemapsController < ApplicationController
   MAX_URLS_PER_SITEMAP = 50_000
   BASE = 'https://placecal.org'
 
+  skip_before_action :set_supporters
+  skip_before_action :set_navigation
+
   before_action :set_site
   before_action :require_default_site
 
@@ -58,6 +61,7 @@ class SitemapsController < ApplicationController
 
   def build_events
     urls = Event.where(dtstart: 3.months.ago..)
+                .order(dtstart: :desc)
                 .limit(MAX_URLS_PER_SITEMAP)
                 .pluck(:id, :updated_at)
                 .map { |id, updated_at| url_entry("#{BASE}/events/#{id}", updated_at) }
@@ -92,11 +96,6 @@ class SitemapsController < ApplicationController
 
     Article.published.pluck(:slug, :updated_at).each do |slug, updated_at|
       urls << url_entry("#{BASE}/news/#{slug}", updated_at)
-    end
-
-    Collection.pluck(:id, :route, :updated_at).each do |id, route, updated_at|
-      path = route.presence || "collections/#{id}"
-      urls << url_entry("#{BASE}/#{path}", updated_at)
     end
 
     wrap_urlset(urls)

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -86,11 +86,8 @@ class SitemapsController < ApplicationController
     urls << url_entry(BASE)
     urls << url_entry("#{BASE}/partners")
     urls << url_entry("#{BASE}/events")
-    urls << url_entry("#{BASE}/find-placecal")
 
-    %w[privacy our-story terms-of-use get-in-touch
-       community-groups metropolitan-areas vcses
-       housing-providers social-prescribers culture-tourism].each do |page|
+    %w[privacy terms-of-use get-in-touch].each do |page|
       urls << url_entry("#{BASE}/#{page}")
     end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -201,7 +201,7 @@ class Site < ApplicationRecord
     config = File.read(Rails.root.join("config/robots/#{self.class.robots_config_filename}"))
 
     if is_published?
-      config
+      "#{config}\nSitemap: https://placecal.org/sitemap.xml\n"
     else
       <<~TXT
         #{config}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,11 @@
 
 # config/routes.rb
 Rails.application.routes.draw do
-  # Health check for Kamal proxy
+  # ============================================================
+  # Infrastructure
+  # ============================================================
   get 'up', to: proc { [200, {}, ['OK']] }
 
-  # User login stuff
   devise_for :users,
              controllers: {
                invitations: 'users/invitations',
@@ -13,22 +14,9 @@ Rails.application.routes.draw do
                passwords: 'users/passwords'
              }
 
-  # Static pages (also listed in SitemapsController#build_pages — update both)
-  get 'get-in-touch', to: 'joins#new'
-  post 'get-in-touch', to: 'joins#create'
-  get 'privacy', to: 'pages#privacy'
-  get 'terms-of-use', to: 'pages#terms_of_use'
-
-  # Deprecated: moving to join.placecal.org
-  get 'find-placecal', to: 'pages#find_placecal'
-  get 'our-story', to: 'pages#our_story'
-  get 'community-groups', to: 'pages#community_groups'
-  get 'metropolitan-areas', to: 'pages#metropolitan_areas'
-  get 'vcses', to: 'pages#vcses'
-  get 'housing-providers', to: 'pages#housing_providers'
-  get 'social-prescribers', to: 'pages#social_prescribers'
-  get 'culture-tourism', to: 'pages#culture_tourism'
-
+  # ============================================================
+  # Admin (admin.lvh.me / admin.placecal.org)
+  # ============================================================
   scope module: :admin, as: :admin, constraints: { subdomain: 'admin' } do
     resources :articles, except: [:show]
     resources :calendars do
@@ -73,6 +61,11 @@ Rails.application.routes.draw do
     root 'pages#home'
   end
 
+  # ============================================================
+  # Public site
+  # ============================================================
+
+  # Local site homepages must match before the default root
   constraints(Sites::Local) do
     get '/' => 'sites#index'
   end
@@ -92,11 +85,21 @@ Rails.application.routes.draw do
   resources :partnerships, only: %i[index show]
   get '/partners/:id/events' => 'partners#show'
   get '/partners/:id/events/:year/:month/:day' => 'partners#show', constraints: ymd
-  get '/places' => 'partners#index' # Removing separate Places view for now.
+  get '/places' => 'partners#index'
   get '/partners/:id/embed' => 'places#embed'
 
   # News
   resources :news, only: %i[index show]
+
+  # Static pages (also listed in SitemapsController#build_pages — update both)
+  get 'get-in-touch', to: 'joins#new'
+  post 'get-in-touch', to: 'joins#create'
+  get 'privacy', to: 'pages#privacy'
+  get 'terms-of-use', to: 'pages#terms_of_use'
+
+  # ============================================================
+  # Legacy & deprecated
+  # ============================================================
 
   # Legacy routes from when some Partners were Places
   get '/places/:id' => 'partners#show'
@@ -104,12 +107,24 @@ Rails.application.routes.draw do
   get '/places/:id/events/:year/:month/:day' => 'partners#show', constraints: ymd
   get '/places/:id/embed' => 'places#embed'
 
-  # Collections (deprecated)
+  # Deprecated: moving to join.placecal.org
+  get 'find-placecal', to: 'pages#find_placecal'
+  get 'our-story', to: 'pages#our_story'
+  get 'community-groups', to: 'pages#community_groups'
+  get 'metropolitan-areas', to: 'pages#metropolitan_areas'
+  get 'vcses', to: 'pages#vcses'
+  get 'housing-providers', to: 'pages#housing_providers'
+  get 'social-prescribers', to: 'pages#social_prescribers'
+  get 'culture-tourism', to: 'pages#culture_tourism'
+
+  # Deprecated: collections
   resources :collections, only: %i[show]
   get 'winter2017', to: 'collections#show', id: 1
   get 'winter2018', to: 'collections#show', id: 2
 
-  # SEO
+  # ============================================================
+  # Technical (SEO, API, dev tools)
+  # ============================================================
   get '/robots.txt' => 'pages#robots'
   get '/sitemap.xml' => 'sitemaps#index', defaults: { format: :xml }
   get '/sitemap/partners.xml' => 'sitemaps#partners', defaults: { format: :xml }
@@ -117,7 +132,6 @@ Rails.application.routes.draw do
   get '/sitemap/partnerships.xml' => 'sitemaps#partnerships', defaults: { format: :xml }
   get '/sitemap/pages.xml' => 'sitemaps#pages', defaults: { format: :xml }
 
-  # API
   get '/api/v1/graphql', to: 'graphql#execute'
   post '/api/v1/graphql', to: 'graphql#execute'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,11 @@ Rails.application.routes.draw do
   get 'winter2018', to: 'collections#show', id: 2
 
   get '/robots.txt' => 'pages#robots'
+  get '/sitemap.xml' => 'sitemaps#index', defaults: { format: :xml }
+  get '/sitemap/partners.xml' => 'sitemaps#partners', defaults: { format: :xml }
+  get '/sitemap/events.xml' => 'sitemaps#events', defaults: { format: :xml }
+  get '/sitemap/partnerships.xml' => 'sitemaps#partnerships', defaults: { format: :xml }
+  get '/sitemap/pages.xml' => 'sitemaps#pages', defaults: { format: :xml }
 
   get '/api/v1/graphql', to: 'graphql#execute'
   post '/api/v1/graphql', to: 'graphql#execute'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,10 +42,10 @@ Rails.application.routes.draw do
         delete :clear_address
       end
     end
-    resources :tags
     resources :partnerships
     resources :sites
     resources :supporters
+    resources :tags
     resources :users, except: [:show] do
       collection do
         get :lookup_email
@@ -54,9 +54,10 @@ Rails.application.routes.draw do
         patch :update_profile
       end
     end
-    get 'profile', to: 'users#profile', as: :profile
-    get 'jobs', to: 'jobs#index', as: :jobs
+
     get 'icons', to: 'pages#icons', as: :icons
+    get 'jobs', to: 'jobs#index', as: :jobs
+    get 'profile', to: 'users#profile', as: :profile
 
     root 'pages#home'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,14 +13,15 @@ Rails.application.routes.draw do
                passwords: 'users/passwords'
              }
 
-  # Static pages
+  # Static pages (also listed in SitemapsController#build_pages — update both)
   get 'get-in-touch', to: 'joins#new'
   post 'get-in-touch', to: 'joins#create'
   get 'privacy', to: 'pages#privacy'
-  get 'find-placecal', to: 'pages#find_placecal'
-  get 'our-story', to: 'pages#our_story'
   get 'terms-of-use', to: 'pages#terms_of_use'
 
+  # Deprecated: moving to join.placecal.org
+  get 'find-placecal', to: 'pages#find_placecal'
+  get 'our-story', to: 'pages#our_story'
   get 'community-groups', to: 'pages#community_groups'
   get 'metropolitan-areas', to: 'pages#metropolitan_areas'
   get 'vcses', to: 'pages#vcses'
@@ -94,22 +95,21 @@ Rails.application.routes.draw do
   get '/places' => 'partners#index' # Removing separate Places view for now.
   get '/partners/:id/embed' => 'places#embed'
 
-  # news
+  # News
   resources :news, only: %i[index show]
 
-  # Legacy routes from when some Partners were Places. Don't let Google down...
+  # Legacy routes from when some Partners were Places
   get '/places/:id' => 'partners#show'
   get '/places/:id/events' => 'partners#show'
   get '/places/:id/events/:year/:month/:day' => 'partners#show', constraints: ymd
   get '/places/:id/embed' => 'places#embed'
 
-  # Collections
+  # Collections (deprecated)
   resources :collections, only: %i[show]
-
-  # Named routes
   get 'winter2017', to: 'collections#show', id: 1
   get 'winter2018', to: 'collections#show', id: 2
 
+  # SEO
   get '/robots.txt' => 'pages#robots'
   get '/sitemap.xml' => 'sitemaps#index', defaults: { format: :xml }
   get '/sitemap/partners.xml' => 'sitemaps#partners', defaults: { format: :xml }
@@ -117,6 +117,7 @@ Rails.application.routes.draw do
   get '/sitemap/partnerships.xml' => 'sitemaps#partnerships', defaults: { format: :xml }
   get '/sitemap/pages.xml' => 'sitemaps#pages', defaults: { format: :xml }
 
+  # API
   get '/api/v1/graphql', to: 'graphql#execute'
   post '/api/v1/graphql', to: 'graphql#execute'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,9 +54,9 @@ Rails.application.routes.draw do
         patch :update_profile
       end
     end
-    get 'profile' => 'users#profile', as: :profile
-    get 'jobs' => 'jobs#index', as: :jobs
-    get 'icons' => 'pages#icons', as: :icons
+    get 'profile', to: 'users#profile', as: :profile
+    get 'jobs', to: 'jobs#index', as: :jobs
+    get 'icons', to: 'pages#icons', as: :icons
 
     root 'pages#home'
   end
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
 
   # Local site homepages must match before the default root
   constraints(Sites::Local) do
-    get '/' => 'sites#index'
+    get '/', to: 'sites#index'
   end
 
   root 'pages#home'
@@ -78,15 +78,15 @@ Rails.application.routes.draw do
 
   # Events
   resources :events, only: %i[index show]
-  get '/events/:year/:month/:day' => 'events#index', constraints: ymd, as: :events_by_date
+  get '/events/:year/:month/:day', to: 'events#index', constraints: ymd, as: :events_by_date
 
   # Partners
   resources :partners, only: %i[index show]
   resources :partnerships, only: %i[index show]
-  get '/partners/:id/events' => 'partners#show'
-  get '/partners/:id/events/:year/:month/:day' => 'partners#show', constraints: ymd
-  get '/places' => 'partners#index'
-  get '/partners/:id/embed' => 'places#embed'
+  get '/partners/:id/events', to: 'partners#show'
+  get '/partners/:id/events/:year/:month/:day', to: 'partners#show', constraints: ymd
+  get '/places', to: 'partners#index'
+  get '/partners/:id/embed', to: 'places#embed'
 
   # News
   resources :news, only: %i[index show]
@@ -102,10 +102,10 @@ Rails.application.routes.draw do
   # ============================================================
 
   # Legacy routes from when some Partners were Places
-  get '/places/:id' => 'partners#show'
-  get '/places/:id/events' => 'partners#show'
-  get '/places/:id/events/:year/:month/:day' => 'partners#show', constraints: ymd
-  get '/places/:id/embed' => 'places#embed'
+  get '/places/:id', to: 'partners#show'
+  get '/places/:id/events', to: 'partners#show'
+  get '/places/:id/events/:year/:month/:day', to: 'partners#show', constraints: ymd
+  get '/places/:id/embed', to: 'places#embed'
 
   # Deprecated: moving to join.placecal.org
   get 'find-placecal', to: 'pages#find_placecal'
@@ -125,12 +125,12 @@ Rails.application.routes.draw do
   # ============================================================
   # Technical (SEO, API, dev tools)
   # ============================================================
-  get '/robots.txt' => 'pages#robots'
-  get '/sitemap.xml' => 'sitemaps#index', defaults: { format: :xml }
-  get '/sitemap/partners.xml' => 'sitemaps#partners', defaults: { format: :xml }
-  get '/sitemap/events.xml' => 'sitemaps#events', defaults: { format: :xml }
-  get '/sitemap/partnerships.xml' => 'sitemaps#partnerships', defaults: { format: :xml }
-  get '/sitemap/pages.xml' => 'sitemaps#pages', defaults: { format: :xml }
+  get '/robots.txt', to: 'pages#robots'
+  get '/sitemap.xml', to: 'sitemaps#index', defaults: { format: :xml }
+  get '/sitemap/partners.xml', to: 'sitemaps#partners', defaults: { format: :xml }
+  get '/sitemap/events.xml', to: 'sitemaps#events', defaults: { format: :xml }
+  get '/sitemap/partnerships.xml', to: 'sitemaps#partnerships', defaults: { format: :xml }
+  get '/sitemap/pages.xml', to: 'sitemaps#pages', defaults: { format: :xml }
 
   get '/api/v1/graphql', to: 'graphql#execute'
   post '/api/v1/graphql', to: 'graphql#execute'

--- a/spec/requests/public/sitemaps_spec.rb
+++ b/spec/requests/public/sitemaps_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Public Sitemaps", type: :request do
+  let!(:default_site) { create(:default_site) }
+  let!(:local_site) { create(:site, slug: "mossley", is_published: true, url: "https://mossley.placecal.org/") }
+
+  describe "on the default site" do
+    let(:host) { "lvh.me" }
+
+    describe "GET /sitemap.xml" do
+      it "returns a sitemap index with sub-sitemaps" do
+        get "/sitemap.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.content_type).to include("xml")
+        expect(response.body).to include("sitemapindex")
+        %w[partners events partnerships pages].each do |section|
+          expect(response.body).to include("https://placecal.org/sitemap/#{section}.xml")
+        end
+      end
+    end
+
+    describe "GET /sitemap/partners.xml" do
+      let!(:partner) { create(:partner, slug: "test-partner") }
+
+      it "includes visible partners" do
+        get "/sitemap/partners.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.body).to include("https://placecal.org/partners/test-partner")
+      end
+
+      it "excludes hidden partners" do
+        admin = create(:root)
+        partner.update!(hidden: true, hidden_reason: "test", hidden_blame_id: admin.id)
+        get "/sitemap/partners.xml", headers: { "Host" => host }
+        expect(response.body).not_to include("test-partner")
+      end
+    end
+
+    describe "GET /sitemap/events.xml" do
+      let!(:recent_event) { create(:event, dtstart: 1.week.from_now, dtend: 1.week.from_now + 1.hour) }
+      let!(:old_event) { create(:event, dtstart: 6.months.ago, dtend: 6.months.ago + 1.hour) }
+
+      it "includes recent events" do
+        get "/sitemap/events.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.body).to include("https://placecal.org/events/#{recent_event.id}")
+      end
+
+      it "excludes events older than 3 months" do
+        get "/sitemap/events.xml", headers: { "Host" => host }
+        expect(response.body).not_to include("events/#{old_event.id}")
+      end
+    end
+
+    describe "GET /sitemap/partnerships.xml" do
+      it "includes partnerships index and published sites" do
+        get "/sitemap/partnerships.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.body).to include("https://placecal.org/partnerships")
+        expect(response.body).to include("https://placecal.org/partnerships/mossley")
+        expect(response.body).to include("https://mossley.placecal.org")
+      end
+    end
+
+    describe "GET /sitemap/pages.xml" do
+      it "includes static pages" do
+        get "/sitemap/pages.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.body).to include("https://placecal.org")
+        expect(response.body).to include("https://placecal.org/partners")
+        expect(response.body).to include("https://placecal.org/events")
+        expect(response.body).to include("https://placecal.org/privacy")
+        expect(response.body).to include("https://placecal.org/find-placecal")
+      end
+    end
+  end
+
+  describe "on a local site" do
+    it "returns 404" do
+      get "/sitemap.xml", headers: { "Host" => "mossley.lvh.me" }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "robots.txt" do
+    it "includes sitemap directive for published sites" do
+      get "/robots.txt", headers: { "Host" => "mossley.lvh.me" }
+      expect(response.body).to include("Sitemap: https://placecal.org/sitemap.xml")
+    end
+  end
+end

--- a/spec/requests/public/sitemaps_spec.rb
+++ b/spec/requests/public/sitemaps_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Public Sitemaps", type: :request do
         expect(response.body).to include("https://placecal.org/partners")
         expect(response.body).to include("https://placecal.org/events")
         expect(response.body).to include("https://placecal.org/privacy")
-        expect(response.body).to include("https://placecal.org/find-placecal")
+        expect(response.body).not_to include("find-placecal")
       end
     end
   end


### PR DESCRIPTION
## Summary

- Adds `SitemapsController` with a sitemap index and 4 sub-sitemaps: partners, events, partnerships (including published site homepage URLs), and pages (static pages, articles)
- Only served on the default site (`placecal.org`) — local subsites return 404
- Updates `robots.txt` for all published sites with `Sitemap: https://placecal.org/sitemap.xml`
- Follows Google guidelines: no `changefreq`/`priority` (ignored by Google), `lastmod` only where accurate, canonical URLs, 50k URL limit
- Cleans up `routes.rb`: reorders into logical sections, adds comments, modernises `=>` to `to:` syntax, alphabetises admin resources
- Marks deprecated audience pages (our-story, community-groups, etc.) and collections

## Routes cleanup

Routes are reordered into sections: Infrastructure → Admin → Public site → Legacy/deprecated → Technical (SEO, API). All 197 route patterns verified identical before and after via sorted diff.

## Test plan

- [ ] `curl https://placecal.org/sitemap.xml` returns sitemap index with 4 sub-sitemap refs
- [ ] Each sub-sitemap returns valid XML with correct URLs
- [ ] Local subsite sitemaps return 404
- [ ] `robots.txt` on published sites includes `Sitemap:` directive
- [ ] `bundle exec rspec spec/requests/public/` — 115 examples, 0 failures

Closes #3120

🤖 Generated with [Claude Code](https://claude.com/claude-code)