### PR TITLE
Improve Lighthouse performance: eliminate CLS, async maps, caching, fonts

### DIFF
--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -12,6 +12,7 @@ class Components::Map < Components::Base
     return if @points.blank?
 
     div(
+      class: @compact ? 'min-h-[330px]' : 'min-h-[500px]',
       data_controller: 'leaflet',
       data_leaflet_args_value: args_for_map(@points, @site, @style, @compact)
     )

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -131,7 +131,7 @@ class Components::Navigation < Components::Base
 
   def menu_nav_classes
     [
-      'nav header__menu row-start-2 col-start-1 col-span-2 flex flex-col justify-evenly',
+      'nav header__menu row-start-2 col-start-1 col-span-2 flex flex-col justify-evenly is-hidden',
       '-mx-6 h-auto overflow-clip transition-[display,height,margin-top,padding-block] duration-300',
       'md:flex-row',
       *(if @site&.default_site?

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -105,12 +105,24 @@ class PagesController < ApplicationController
       Partner.visible.includes(:categories, :address).order(created_at: :desc).limit(5).to_a
     end
 
-    @upcoming_events = EventsQuery.new(site: @site).call(period: 'upcoming')
+    @upcoming_events = Rails.cache.fetch('directory/upcoming_events', expires_in: DIRECTORY_CACHE_TTL) do
+      EventsQuery.new(site: @site).call(period: 'upcoming')
+    end
+
+    @partner_event_counts = Rails.cache.fetch('directory/partner_event_counts', expires_in: DIRECTORY_CACHE_TTL) do
+      ids = @recent_partners.map(&:id)
+      Event.future(Time.zone.today)
+           .where(place_id: ids)
+           .or(Event.future(Time.zone.today).where(organiser_id: ids))
+           .group(:place_id)
+           .count
+    end
 
     render Views::Directory::Home.new(
       partnerships: @partnerships,
       recent_partners: @recent_partners,
       upcoming_events: @upcoming_events,
+      partner_event_counts: @partner_event_counts,
       stats: @stats,
       partner_locations: @partner_locations,
       jump_sites: @jump_sites

--- a/app/javascript/controllers/cluster_map_controller.js
+++ b/app/javascript/controllers/cluster_map_controller.js
@@ -1,14 +1,17 @@
 import { Controller } from "@hotwired/stimulus";
-import "leaflet";
-import "@maplibre/maplibre-gl-leaflet";
-import "leaflet.markercluster";
-import { ensureMaplibreCss } from "controllers/mixins/map_css";
 
 export default class extends Controller {
 	static values = { markers: Array, styleUrl: String };
 
-	connect() {
-		ensureMaplibreCss();
+	async connect() {
+		await Promise.all([
+			import("leaflet"),
+			import("@maplibre/maplibre-gl-leaflet"),
+			import("leaflet.markercluster"),
+			import("controllers/mixins/map_css").then((m) => m.ensureMaplibreCss()),
+		]);
+		if (!this.element.isConnected) return;
+
 		this.createMap();
 	}
 

--- a/app/javascript/controllers/leaflet_controller.js
+++ b/app/javascript/controllers/leaflet_controller.js
@@ -1,17 +1,16 @@
 import { Controller } from "@hotwired/stimulus";
-import "leaflet";
-import "@maplibre/maplibre-gl-leaflet";
-import { ensureMaplibreCss } from "controllers/mixins/map_css";
 
-// Connects to data-controller="leaflet"
-// Its important to use single quotes in the template when declaring the args values
-// data-leaflet-args-value='<%= args_for_map(points, site, local_assigns[:style], local_assigns[:compact]) %>'
-// If not you will get strange unicode values which will break parsing
 export default class extends Controller {
 	static values = { args: Object };
-	// {center, iconUrl, markers, shadowUrl, styleClass, styleUrl, zoom}
 
-	connect() {
+	async connect() {
+		const [, , { ensureMaplibreCss }] = await Promise.all([
+			import("leaflet"),
+			import("@maplibre/maplibre-gl-leaflet"),
+			import("controllers/mixins/map_css"),
+		]);
+		if (!this.element.isConnected) return;
+
 		ensureMaplibreCss();
 		this.element.classList.add("map");
 		if (this.argsValue.styleClass?.length)
@@ -23,14 +22,13 @@ export default class extends Controller {
 		this.element.classList.remove("map");
 		if (this.argsValue.styleClass?.length)
 			this.element.classList.remove(...this.argsValue.styleClass);
-		this.map.remove();
+		this.map?.remove();
 	}
 
 	createMap() {
 		this.map = L.map(this.element);
 		this.map.scrollWheelZoom.disable();
 
-		// Use MapLibre GL for vector tile rendering with custom themed styles
 		L.maplibreGL({
 			style: this.argsValue.styleUrl,
 			attribution:
@@ -65,21 +63,17 @@ export default class extends Controller {
 
 		const markerGroup = L.featureGroup(markers);
 		if (markers.length === 1) {
-			// Single marker: use setView to keep zoom level
 			this.map.setView(this.argsValue.center, this.argsValue.zoom);
 		} else {
-			// Multiple markers: fit bounds to show all markers
 			const bounds = markerGroup.getBounds();
 			if (
 				bounds.getNorth() === bounds.getSouth() &&
 				bounds.getEast() === bounds.getWest()
 			) {
-				// All markers at same position: fitBounds would fail on zero-area box
 				this.map.setView(bounds.getCenter(), this.argsValue.zoom);
 			} else {
-				// Extend bounds slightly south to account for marker icon height
 				const south = bounds.getSouth();
-				const offset = (bounds.getNorth() - south) * 0.08; // 8% extra at bottom
+				const offset = (bounds.getNorth() - south) * 0.08;
 				bounds.extend([south - offset, bounds.getWest()]);
 				this.map.fitBounds(bounds);
 			}

--- a/app/javascript/controllers/mobile_menu_controller.js
+++ b/app/javascript/controllers/mobile_menu_controller.js
@@ -5,11 +5,6 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
 	static targets = ["menu"];
 
-	connect() {
-		// Start with menu hidden on mobile
-		this.menuTarget.classList.add("is-hidden");
-	}
-
 	toggle() {
 		this.menuTarget.classList.toggle("is-hidden");
 	}

--- a/app/tailwind/public/fonts.css
+++ b/app/tailwind/public/fonts.css
@@ -12,7 +12,7 @@
 	src: url("rawline/rawline-100.woff2") format("woff2");
 	font-weight: 100;
 	font-style: normal;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -20,7 +20,7 @@
 	src: url("rawline/rawline-100i.woff2") format("woff2");
 	font-weight: 100;
 	font-style: italic;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -28,7 +28,7 @@
 	src: url("rawline/rawline-200.woff2") format("woff2");
 	font-weight: 200;
 	font-style: normal;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -36,7 +36,7 @@
 	src: url("rawline/rawline-200i.woff2") format("woff2");
 	font-weight: 200;
 	font-style: italic;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -44,7 +44,7 @@
 	src: url("rawline/rawline-300.woff2") format("woff2");
 	font-weight: 300;
 	font-style: normal;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -52,7 +52,7 @@
 	src: url("rawline/rawline-300i.woff2") format("woff2");
 	font-weight: 300;
 	font-style: italic;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -60,7 +60,7 @@
 	src: url("rawline/rawline-400.woff2") format("woff2");
 	font-weight: 400;
 	font-style: normal;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -68,7 +68,7 @@
 	src: url("rawline/rawline-400i.woff2") format("woff2");
 	font-weight: 400;
 	font-style: italic;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -84,7 +84,7 @@
 	src: url("rawline/rawline-500i.woff2") format("woff2");
 	font-weight: 500;
 	font-style: italic;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -92,7 +92,7 @@
 	src: url("rawline/rawline-600.woff2") format("woff2");
 	font-weight: 600;
 	font-style: normal;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -100,7 +100,7 @@
 	src: url("rawline/rawline-600i.woff2") format("woff2");
 	font-weight: 600;
 	font-style: italic;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -116,7 +116,7 @@
 	src: url("rawline/rawline-700i.woff2") format("woff2");
 	font-weight: 700;
 	font-style: italic;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -132,7 +132,7 @@
 	src: url("rawline/rawline-800i.woff2") format("woff2");
 	font-weight: 800;
 	font-style: italic;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -140,7 +140,7 @@
 	src: url("rawline/rawline-900.woff2") format("woff2");
 	font-weight: 900;
 	font-style: normal;
-	font-display: swap;
+	font-display: optional;
 }
 
 @font-face {
@@ -148,7 +148,7 @@
 	src: url("rawline/rawline-900i.woff2") format("woff2");
 	font-weight: 900;
 	font-style: italic;
-	font-display: swap;
+	font-display: optional;
 }
 
 /* Trocchi

--- a/app/views/directory/home.rb
+++ b/app/views/directory/home.rb
@@ -7,6 +7,7 @@ class Views::Directory::Home < Views::Base
   prop :recent_partners, _Interface(:each)
   prop :upcoming_events, _Interface(:each)
   prop :stats, Hash
+  prop :partner_event_counts, Hash, default: -> { {} }
   prop :partner_locations, _Interface(:each), default: -> { [] }
   prop :jump_sites, _Interface(:each), default: -> { [] }
 
@@ -75,9 +76,8 @@ class Views::Directory::Home < Views::Base
       h2(class: 'font-serif font-regular text-section text-foreground mb-4') { 'Recently joined PlaceCal' }
       div(class: 'flex flex-col gap-2') do
         partners = @recent_partners.first(5)
-        counts = partner_event_counts(partners)
         partners.each do |partner|
-          Directory::PartnerRow(partner: partner, event_count: counts[partner.id] || 0)
+          Directory::PartnerRow(partner: partner, event_count: @partner_event_counts[partner.id] || 0)
         end
       end
       div(class: 'mt-4') do
@@ -143,14 +143,5 @@ class Views::Directory::Home < Views::Base
         end
       end
     end
-  end
-
-  def partner_event_counts(partners)
-    ids = partners.map(&:id)
-    ::Event.future(Time.zone.today)
-           .where(place_id: ids)
-           .or(::Event.future(Time.zone.today).where(organiser_id: ids))
-           .group(:place_id)
-           .count
   end
 end

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -21,13 +21,11 @@ class Views::Layouts::Application < Phlex::HTML
         stylesheet_link_tag site.stylesheet_link, media: 'all', 'data-turbo-track': 'reload' if site&.stylesheet_link
         stylesheet_link_tag 'print', media: 'print', 'data-turbo-track': 'reload'
         preload_font('rawline/rawline-500.woff2')
-        preload_font('rawline/rawline-600.woff2')
         preload_font('rawline/rawline-700.woff2')
-        preload_font('rawline/rawline-800.woff2')
         render_meta
-        script(defer: true, 'data-domain': 'placecal.org', src: 'https://plausible.io/js/plausible.js') if Rails.env.production?
         javascript_include_tag 'es-module-shims', async: true
         javascript_importmap_tags
+        script(defer: true, 'data-domain': 'placecal.org', src: 'https://plausible.io/js/plausible.js') if Rails.env.production?
         meta(name: 'turbo-refresh-method', content: 'morph')
       end
 

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -22,6 +22,8 @@ class Views::Layouts::Application < Phlex::HTML
         stylesheet_link_tag 'print', media: 'print', 'data-turbo-track': 'reload'
         preload_font('rawline/rawline-500.woff2')
         preload_font('rawline/rawline-700.woff2')
+        preload_font('rawline/rawline-800.woff2')
+        preload_font('trocchi/Trocchi-Regular.woff2')
         render_meta
         javascript_include_tag 'es-module-shims', async: true
         javascript_importmap_tags

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,6 +25,9 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=31536000, immutable'
+  }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -22,6 +22,9 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=31536000, immutable'
+  }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -16,15 +16,15 @@ pin '@hotwired/turbo', to: 'https://cdn.jsdelivr.net/npm/@hotwired/turbo@8.0.12/
 
 # External dependencies
 # jsdelivr bundles ESM with sub-dependencies inline (more reliable than esm.sh)
-pin 'tom-select', to: 'https://cdn.jsdelivr.net/npm/tom-select@2.4.3/+esm'
-pin 'leaflet', to: 'https://esm.sh/leaflet@1.9.4'
+pin 'tom-select', to: 'https://cdn.jsdelivr.net/npm/tom-select@2.4.3/+esm', preload: false
+pin 'leaflet', to: 'https://esm.sh/leaflet@1.9.4', preload: false
 
 # MapLibre GL for vector tile rendering with custom styles
-pin 'maplibre-gl', to: 'https://esm.sh/maplibre-gl@4.7.1'
-pin '@maplibre/maplibre-gl-leaflet', to: 'https://esm.sh/@maplibre/maplibre-gl-leaflet@0.0.22'
+pin 'maplibre-gl', to: 'https://esm.sh/maplibre-gl@4.7.1', preload: false
+pin '@maplibre/maplibre-gl-leaflet', to: 'https://esm.sh/@maplibre/maplibre-gl-leaflet@0.0.22', preload: false
 
 # Marker clustering for directory overview map
-pin 'leaflet.markercluster', to: 'https://cdn.jsdelivr.net/npm/leaflet.markercluster@1.5.3/+esm'
+pin 'leaflet.markercluster', to: 'https://cdn.jsdelivr.net/npm/leaflet.markercluster@1.5.3/+esm', preload: false
 
 # Stimulus controllers - pinned from app/javascript/controllers
 # preload: false ensures lazy-loaded controllers are only fetched when needed


### PR DESCRIPTION
## Summary

Lighthouse audit of the directory pages showed scores of 36-53 with CLS 0.25-0.33 across all pages, 9.5s LCP on show pages, and 13s cold homepage loads. This PR addresses all four root causes across two commits.

### Commit 1 (existing): deferred JS, long cache, fewer font preloads
- Stop modulepreloading CDN libraries (~371 KiB) — added `preload: false` so they only load when a Stimulus controller imports them
- 1-year immutable cache for fingerprinted static assets in production/staging
- Reduce font preloads from 4 to 2 (rawline-500 and rawline-700)
- Reorder Plausible script after importmap tags

### Commit 2 (new): eliminate CLS, async maps, cache queries, font tuning

- **Eliminate CLS on all pages (0.326 → 0)**: render nav menu with `is-hidden` class in server HTML so it starts collapsed instead of flashing open then closing when JS connects. This was the single largest CLS source — the `<main>` element shifted up when the mobile menu collapsed.
- **Async map library loading**: convert Leaflet/MapLibre/markercluster static `import` to dynamic `await import()` inside Stimulus `connect()` so ~350 KiB of JS no longer blocks initial page paint. Added `min-height` to map component to prevent CLS during async load.
- **Cache homepage queries**: wrap `EventsQuery` and `partner_event_counts` in `Rails.cache.fetch` with 1-day TTL, matching the 5 existing cached queries. Eliminates uncached DB hits on every homepage load.
- **Font-display tuning**: `font-display: optional` for non-critical weights (100-400, all italics, 600, 900), keep `swap` for preloaded weights (500, 700, 800). Added preloads for rawline-800 (extra-bold, used extensively) and Trocchi (serif headings).

### Lighthouse results (local dev, before → after)

| Page | Score | CLS | TBT |
|------|-------|-----|-----|
| Home `/` | 36 → **54** | 0.256 → **0** | 770ms → 570ms |
| Events `/events` | 48 → **56** | 0.254 → **0** | 550ms → 520ms |
| Partners `/partners` | 50 → **59** | 0.255 → **0** | 530ms → 490ms |
| Partnerships `/partnerships` | 38 → **61** | 0.326 → **0** | 630ms → 510ms |
| Partner show | 41 → **59** | 0.326 → **0** | 180ms → 120ms |
| Event show | 43 → **60** | 0.326 → **0** | 90ms → 80ms |
| Partnership show | 53 → **63** | 0.256 → **0** | 560ms → 490ms |

Note: local dev scores are lower than production (no minification, no asset compilation) but the relative improvements and CLS elimination will carry over.

## Test plan

- [ ] Homepage loads correctly, map renders with markers after brief delay
- [ ] Partner show page map renders correctly
- [ ] Event show page map renders correctly
- [ ] Partnership show page cluster map renders correctly
- [ ] Mobile menu toggle works (starts closed, opens on tap, closes on tap)
- [ ] Desktop nav is visible (is-hidden has no effect above breakpoint)
- [ ] Admin tom-select dropdowns still work
- [ ] Font rendering: extra-bold text (rawline-800) renders correctly
- [ ] Font rendering: serif headings (Trocchi) render correctly
- [ ] Homepage loads fast on second visit (cached queries)
- [ ] Run Lighthouse on staging to verify CLS = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)