### PR TITLE
Fix homepage map not loading due to leaflet.markercluster global L dependency

### DIFF
--- a/app/javascript/controllers/cluster_map_controller.js
+++ b/app/javascript/controllers/cluster_map_controller.js
@@ -4,12 +4,13 @@ export default class extends Controller {
 	static values = { markers: Array, styleUrl: String };
 
 	async connect() {
-		await Promise.all([
+		const [leafletMod] = await Promise.all([
 			import("leaflet"),
 			import("@maplibre/maplibre-gl-leaflet"),
-			import("leaflet.markercluster"),
 			import("controllers/mixins/map_css").then((m) => m.ensureMaplibreCss()),
 		]);
+		window.L = leafletMod.default || leafletMod;
+		await import("leaflet.markercluster");
 		if (!this.element.isConnected) return;
 
 		this.createMap();


### PR DESCRIPTION
## Summary

- Fix the homepage cluster map failing to load with `ReferenceError: L is not defined`
- The jsdelivr ESM bundle of `leaflet.markercluster@1.5.3` references `window.L` at module evaluation time, but when imported in parallel with Leaflet via `Promise.all`, the markercluster module could execute before Leaflet had set `window.L`
- Import Leaflet first, assign `window.L` from the module, then import markercluster sequentially

## Test plan

- [ ] Load homepage at desktop width — map should render with clustered partner markers
- [ ] Zoom in on the map — vector tiles (OpenFreeMap) should render
- [ ] Hard refresh several times — map should load reliably (no intermittent failures)
- [ ] Check browser console for errors — should be clean
- [ ] Check partnership show pages that also use `cluster-map` controller