### PR TITLE
Fix #2393: show full neighbourhood names in admin ward pickers

### DIFF
--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -19,7 +19,7 @@ module PartnersHelper
       .order(:name)
       .all
       .collect do |ward|
-        name = ward.contextual_name
+        name = ward.contextual_fullname
         name += " - #{ward.release_date.year}/#{ward.release_date.month}" if ward.legacy_neighbourhood?
 
         { name: name, id: ward.id }

--- a/app/helpers/sites_helper.rb
+++ b/app/helpers/sites_helper.rb
@@ -10,7 +10,7 @@ module SitesHelper
       .order(:name)
       .all
       .collect do |ward|
-        name = ward.contextual_name
+        name = ward.contextual_fullname
         name += " - #{ward.release_date.year}/#{ward.release_date.month}" if ward.legacy_neighbourhood?
 
         { name: name, id: ward.id }

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -45,9 +45,9 @@ module UsersHelper
       .all
       .collect do |ward|
         if ward.legacy_neighbourhood?
-          ["#{ward.contextual_name} - #{ward.release_date.year}/#{ward.release_date.month}", ward.id]
+          ["#{ward.contextual_fullname} - #{ward.release_date.year}/#{ward.release_date.month}", ward.id]
         else
-          [ward.contextual_name, ward.id]
+          [ward.contextual_fullname, ward.id]
         end
       end
   end

--- a/app/models/neighbourhood.rb
+++ b/app/models/neighbourhood.rb
@@ -162,6 +162,18 @@ class Neighbourhood < ApplicationRecord
     "#{shortname} (#{unit&.titleize})"
   end
 
+  # As {#contextual_name} but always uses the full {#fullname} rather than the
+  # abbreviation. Used by the admin neighbourhood pickers so editors see the
+  # full ward name (see issue #2393). Public-facing views keep abbreviations.
+  # @return [String] full name with parent and unit, e.g. "Hulme, Manchester (Ward)"
+  def contextual_fullname
+    # "Wardname, Countryname (Region)"
+    return "#{fullname}, #{parent_name} (#{unit.titleize})" if parent_name
+
+    # "Wardname (Region)"
+    "#{fullname} (#{unit&.titleize})"
+  end
+
   # @return [String] full name, falling back to abbreviation or "[not set]"
   def fullname
     if name.present?

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -76,6 +76,24 @@ RSpec.describe UsersHelper, type: :helper do
     end
   end
 
+  describe "#options_for_user_neighbourhoods" do
+    let!(:ward) { create(:riverside_ward, name: "Riverside Ward", name_abbr: "Rvrsde") }
+    let(:for_user) { create(:user) }
+
+    before do
+      allow(helper).to receive(:policy_scope) do |_scope|
+        Pundit.policy_scope!(root, Neighbourhood)
+      end
+    end
+
+    it "labels options with the full neighbourhood name, not the abbreviation" do
+      labels = helper.options_for_user_neighbourhoods(for_user).map(&:first)
+
+      expect(labels).to include(a_string_including("Riverside Ward"))
+      expect(labels).not_to include(a_string_including("Rvrsde"))
+    end
+  end
+
   describe "#permitted_options_for_partners" do
     context "as neighbourhood admin" do
       before do

--- a/spec/models/neighbourhood_spec.rb
+++ b/spec/models/neighbourhood_spec.rb
@@ -115,6 +115,28 @@ RSpec.describe Neighbourhood, type: :model do
     end
   end
 
+  describe "#contextual_fullname" do
+    let(:ward) { create(:riverside_ward, name_abbr: "Rvrsde") }
+
+    it "includes parent name and unit type" do
+      # NOTE: parent_name is set on update via callback
+      ward.update!(parent_name: ward.parent.name)
+      expect(ward.contextual_fullname).to include("Riverside")
+      expect(ward.contextual_fullname).to include("Ward")
+    end
+
+    it "uses the full name rather than the abbreviation" do
+      ward.update!(parent_name: ward.parent.name)
+      expect(ward.contextual_fullname).to include(ward.name)
+      expect(ward.contextual_fullname).not_to include("Rvrsde")
+    end
+
+    it "falls back to the unit when there is no parent" do
+      neighbourhood = build(:neighbourhood, name: "Full Name", name_abbr: "Abbr", unit: "ward", parent_name: nil)
+      expect(neighbourhood.contextual_fullname).to eq("Full Name (Ward)")
+    end
+  end
+
   describe "#legacy_neighbourhood?" do
     it "returns true for neighbourhoods with old release dates" do
       neighbourhood = build(:neighbourhood, release_date: DateTime.new(2020, 1))


### PR DESCRIPTION
## What & why

Admin neighbourhood/ward pickers were showing the **abbreviated** name (`name_abbr`) instead of the full ward name. This caused confusion — e.g. "Greater Manchester" appeared as "Gtr Mcr" and some users thought counties were missing from the dataset (see #2380).

Per the issue discussion, the fix is to use the **full name in the admin interface** and keep abbreviations on the public frontend (that redesign is tracked separately in #2879).

## Changes

- Add `Neighbourhood#contextual_fullname`, mirroring the existing `#contextual_name` but using `#fullname` (full `name`) instead of `#shortname` (`name_abbr`).
- Switch the three admin picker helpers to it:
  - `PartnersHelper#options_for_service_area_neighbourhoods`
  - `SitesHelper#options_for_sites_neighbourhoods`
  - `UsersHelper#options_for_user_neighbourhoods`
- Public-facing code (`partner_card.rb`, datatables, hierarchy badges) is **deliberately untouched** — it keeps using `shortname`/`contextual_name`.

## Tests

- Model spec for `#contextual_fullname` (full name vs abbreviation, parent and no-parent branches).
- Helper spec for `UsersHelper#options_for_user_neighbourhoods` asserting the rendered picker label uses the full name and not the abbreviation. Verified it fails before the change and passes after.

Closes #2393