### PR TITLE
Fix #2566: guard set_day against invalid date params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,15 +49,20 @@ class ApplicationController < ActionController::Base
     redirect_to new_user_session_path
   end
 
-  # Set the day either using the URL or by today's date
+  # Set the day either using the URL or by today's date.
+  # Falls back to today if the URL params don't form a valid date
+  # (e.g. month=13, day=32 from crawlers hitting random URLs).
   def set_day
     @today = Date.today
-    day = params[:day] || 1
     @current_day =
-      if params[:year] && params[:month] && day
-        Date.new(params[:year].to_i,
-                 params[:month].to_i,
-                 params[:day].to_i)
+      if params[:year] && params[:month] && params[:day]
+        begin
+          Date.new(params[:year].to_i,
+                   params[:month].to_i,
+                   params[:day].to_i)
+        rescue ArgumentError
+          @today
+        end
       else
         @today
       end

--- a/spec/requests/public/events_spec.rb
+++ b/spec/requests/public/events_spec.rb
@@ -77,6 +77,35 @@ RSpec.describe "Public Events", type: :request do
     end
   end
 
+  describe "GET /events/:year/:month/:day" do
+    let!(:event) do
+      create(:event,
+             organiser: partner,
+             summary: "Dated Event",
+             dtstart: Time.current.beginning_of_day + 10.hours,
+             address: address)
+    end
+
+    # Request the .text format so the route is exercised through set_day
+    # without depending on the compiled stylesheet asset pipeline.
+    it "returns successful response for a valid date" do
+      # Timecop freezes time to 2022-11-08
+      get events_by_date_url(host: "#{site.slug}.lvh.me", year: 2022, month: 11, day: 8, format: :text)
+      expect(response).to be_successful
+      expect(response.body).to include("Dated Event")
+    end
+
+    it "falls back to today instead of erroring for an invalid month" do
+      get events_by_date_url(host: "#{site.slug}.lvh.me", year: 2022, month: 13, day: 8, format: :text)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "falls back to today instead of erroring for an invalid day" do
+      get events_by_date_url(host: "#{site.slug}.lvh.me", year: 2022, month: 11, day: 32, format: :text)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "GET /events with partner tag filtering" do
     let(:tag) { create(:tag, type: "Facility", name: "Test Facility", slug: "test-facility") }
     let(:tag_site) { create(:site, slug: "tag-site", is_published: true) }


### PR DESCRIPTION
## Summary

Date-scoped URLs like `/events/:year/13/32` satisfy the routes' `\d{1,2}` constraints for month/day but are not valid calendar dates. `ApplicationController#set_day` then called `Date.new(...)`, which raised `ArgumentError` (`Date::Error`) and surfaced as **HTTP 500** — logged **7052 times** in production per Rollbar, largely from crawlers (e.g. Bytespider) hitting random URLs.

## Fix

In `app/controllers/application_controller.rb`, `set_day` now:
- only attempts to build a `Date` when `year`, `month` and `day` params are all present, and
- rescues `ArgumentError` (the superclass of `Date::Error`), falling back to `Date.current` (`@today`).

Behavior is **unchanged for valid dates**. The previously dead `day = params[:day] || 1` local (the body referenced `params[:day].to_i` directly, never the local) was removed.

`set_day` is a `before_action` on `events#index` and `partners#show`/`embed`; all three date routes always supply year/month/day together, so the presence check matches the routing.

## Tests

Added request specs in `spec/requests/public/events_spec.rb` for the `events_by_date` route covering valid, invalid-month (13) and invalid-day (32) cases. The two invalid cases reproduce the production `Date::Error` before the fix and assert HTTP 200 after; the valid case still renders the event. Specs use the `.text` format to exercise the route through `set_day` without the compiled-stylesheet asset pipeline.

Closes #2566