### PR TITLE
Fix #3084: let admins add themselves as partner admins

### DIFF
--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
 module PartnersHelper
-  # Returns users as [display_name, id] pairs for partner admin assignment
-  # Excludes users already assigned to the partner
+  # Returns users as [display_name, id] pairs for partner admin assignment.
+  #
+  # Excludes users already assigned to the partner, but always keeps the
+  # current user selectable (unless they are already an admin) so that, for
+  # example, a neighbourhood admin can add themselves as a partner admin.
+  # See https://github.com/geeksforsocialchange/PlaceCal/issues/3084
   def options_for_partner_users(partner)
     existing_ids = partner.user_ids
-    User.where.not(id: existing_ids)
+    selectable_ids = User.where.not(id: existing_ids).pluck(:id)
+    selectable_ids |= [current_user.id] if current_user && existing_ids.exclude?(current_user.id)
+
+    User.where(id: selectable_ids)
         .order(:email)
         .map { |u| [u.email, u.id] }
   end

--- a/spec/helpers/partners_helper_spec.rb
+++ b/spec/helpers/partners_helper_spec.rb
@@ -42,6 +42,50 @@ RSpec.describe PartnersHelper, type: :helper do
     end
   end
 
+  describe "#options_for_partner_users" do
+    let(:neighbourhood_admin) { create(:neighbourhood_admin) }
+
+    before do
+      allow(helper).to receive(:current_user).and_return(neighbourhood_admin)
+    end
+
+    it "includes the current user so they can add themselves as an admin" do
+      options = helper.options_for_partner_users(partner)
+      ids = options.map(&:last)
+
+      expect(ids).to include(neighbourhood_admin.id)
+    end
+
+    it "excludes users already assigned to the partner" do
+      other_user = create(:user)
+      partner.users << other_user
+
+      options = helper.options_for_partner_users(partner)
+      ids = options.map(&:last)
+
+      expect(ids).not_to include(other_user.id)
+    end
+
+    it "excludes the current user when they are already an admin of the partner" do
+      partner.users << neighbourhood_admin
+
+      options = helper.options_for_partner_users(partner)
+      ids = options.map(&:last)
+
+      expect(ids).not_to include(neighbourhood_admin.id)
+    end
+
+    it "returns [email, id] pairs ordered by email" do
+      create(:user, email: "zzz@placecal.org")
+      create(:user, email: "aaa@placecal.org")
+
+      options = helper.options_for_partner_users(partner)
+      emails = options.map(&:first)
+
+      expect(emails).to eq(emails.sort)
+    end
+  end
+
   describe "#options_for_partner_partnerships" do
     let(:partnership_admin) { create(:neighbourhood_admin) }
     let(:partnership_tag) { create(:partnership) }


### PR DESCRIPTION
## Summary

Neighbourhood/site admins could not add themselves as a partner admin from the partner **Admins** tab — their own account did not appear in the "add existing admin" selector (issue #3084).

The selector is populated by `PartnersHelper#options_for_partner_users`, which excludes users already assigned to the partner but gave no guarantee that the current user appears as a selectable option. This change makes the helper **always include the current user** (unless they are already an admin of that partner), while preserving the existing-admin exclusion.

## Changes

- `app/helpers/partners_helper.rb` — `options_for_partner_users` now unions the current user into the selectable set (guarded so an already-assigned current user is still excluded, and nil-safe). DB-level email ordering is preserved.
- `spec/helpers/partners_helper_spec.rb` — new `#options_for_partner_users` helper specs:
  - current user (neighbourhood admin) appears so they can self-assign
  - users already assigned to the partner are excluded
  - the current user is excluded when already an admin
  - results are `[email, id]` pairs ordered by email

## Verification

- New spec fails against a deliberately-broken helper that excludes `current_user` (reproducing the bug) and passes with the fix.
- `bundle exec rspec spec/helpers/partners_helper_spec.rb` → 11 examples, 0 failures.
- RuboCop clean on both changed files.

Closes #3084