### PR TITLE
Fix #2500: Cover and tidy site-admin listing on user edit page

### DIFF
--- a/app/views/admin/users/form_tab_roles.rb
+++ b/app/views/admin/users/form_tab_roles.rb
@@ -74,7 +74,7 @@ class Views::Admin::Users::FormTabRoles < Views::Admin::Base
     FormCard(
       icon: :site,
       title: Site.model_name.human(count: 2),
-      description: t('admin.users.fields.sites_hint', default: 'Sites where this user is assigned as admin')
+      description: t('admin.users.fields.sites_hint')
     ) do
       sites = user.sites.order(:name)
       if sites.any?

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -49,6 +49,26 @@ RSpec.describe "Admin::Users", type: :request do
         expect(response).to be_successful
         expect(response.body).to include(target_user.email)
       end
+
+      context "when the target user is a site admin" do
+        let!(:site) { create(:site, name: "Riverside Calendar", site_admin: target_user) }
+
+        it "lists the sites the user administers" do
+          get edit_admin_user_url(target_user, host: admin_host)
+          expect(response).to be_successful
+          expect(response.body).to include(site.name)
+        end
+      end
+
+      context "when the target user administers no sites" do
+        it "renders without error and shows the empty state" do
+          get edit_admin_user_url(target_user, host: admin_host)
+          expect(response).to be_successful
+          expect(response.body).to include(
+            I18n.t("admin.empty.none_assigned", items: Site.model_name.human(count: 2).downcase)
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What & why

Closes #2500.

> As a root admin, when I see that someone is a site_admin, I need to be able to see which sites they admin for so I have oversight on their scope in the system.

The user **edit** page (`/admin/users/:id/edit` → Permissions tab) already renders a "Sites" card listing every site the user administers (`user.sites`, i.e. sites where they are `site_admin`), each linking to the site's edit page, with an empty state when there are none. See `Views::Admin::Users::FormTabRoles#render_sites_card`.

This was, however, **untested**, so the behaviour requested in #2500 could regress silently. This PR locks it in and tidies a small i18n wart in the same code path.

## Changes

- **`spec/requests/admin/users_spec.rb`** — add request specs under `GET /admin/users/:id/edit` (as a root user):
  - a `site_admin` user's administered site names appear on the page;
  - a user with **no** sites renders successfully and shows the localized empty state (no error).
- **`app/views/admin/users/form_tab_roles.rb`** — drop the redundant `default:` fallback on `t('admin.users.fields.sites_hint')`; the key already exists in `config/locales/admin.en.yml` with an identical value, so output is unchanged.

## Verification

- Targeted request specs pass (`spec/requests/admin/users_spec.rb`: 22 examples, 0 failures).
- Confirmed the new "lists the sites" spec **fails** when site-name rendering is temporarily removed, and passes once restored — proving it actually guards the feature.
- RuboCop clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)