### PR TITLE
Fix #3139: scope admin Tailwind scanning to admin paths only

### DIFF
--- a/app/tailwind/admin_tailwind.css
+++ b/app/tailwind/admin_tailwind.css
@@ -4,21 +4,28 @@
  * Tailwind v4 uses CSS-first configuration.
  */
 
-@import "tailwindcss";
+/* Disable automatic content detection so we only scan admin templates.
+   The public site has its own entrypoint (public_tailwind.css); scanning its
+   pages/components here would generate unused CSS. See #3139.
+*/
+@import "tailwindcss" source(none);
 @plugin "daisyui" {
 	themes:
 		light --default,
 		corporate;
 }
 
-/* Source paths for content detection.
-   TODO(#3163): convert to source(none) then positive admin-only includes.
+/* Admin-only source paths for content detection.
+   Admin templates live under the admin/ subdirs of views/ and components/,
+   plus the admin layout. Datatables, helpers and Stimulus controllers are
+   shared utilities that also emit classes used by the admin UI.
 */
 @source "../../app/datatables/**/*.rb";
 @source "../javascript/**/*.js";
 @source "../helpers/**/*.rb";
-@source "../views/**/*.erb";
-@source "../views/**/*.rb";
+@source "../views/admin/**/*.{erb,rb}";
+@source "../views/layouts/admin/**/*.{erb,rb}";
+@source "../components/admin/**/*.rb";
 
 /* Safelist for dynamically generated icon sizes */
 /* size-3 size-4 size-5 size-6 size-8 size-10 size-12 */


### PR DESCRIPTION
## Summary

`app/tailwind/admin_tailwind.css` previously scanned **all** of `app/views/**`, so the admin build pulled in CSS classes from public pages and components (homepage, directory, partners, news, events, etc.) that the admin interface never uses.

This switches the admin entrypoint to `@import "tailwindcss" source(none)` plus explicit, admin-only `@source` includes — the approach the existing `TODO` called for and the mirror of how `public_tailwind.css` already excludes admin subdirs.

## Changes

- Disable automatic content detection (`source(none)`).
- Scan only admin template trees:
  - `app/views/admin/**/*.{erb,rb}`
  - `app/views/layouts/admin/**/*.{erb,rb}`
  - `app/components/admin/**/*.rb` — **these Phlex components were not scanned before**, so admin component classes (e.g. `btn-clear-filters` from `app/components/admin/datatable.rb`) now build from their actual source rather than incidentally.
- Keep shared sources that emit admin classes: `app/datatables/**`, `app/javascript/**` (Stimulus controllers add classes like `bg-orange-500` dynamically), and `app/helpers/**`.

## Why this is safe

Devise auth pages (login/password/invitations) render in the **public** layout (`Views::Layouts::Application` → `public_tailwind.css`), not the admin layout. Their classes (`container-public`, `text-foreground`, `accent-primary`, …) remain emitted by the public build, which scans `app/views/devise`. They were only incidentally present in the admin build before.

## Verification

- `yarn css-admin` succeeds before and after.
- Output drops **199,795 → 168,207 bytes** (~16% smaller).
- Spot-checked all 274 admin utility classes present in the old build are still present — **zero regressions**; safelisted icon sizes (`size-3`…`size-12`) intact.
- Confirmed public-only classes (`break-inside-avoid`, `decoration-2`, `underline-offset-2`, `scroll-mt-4`, `min-w-35/50`, `min-h-30`, `mb-32`, `opacity-55`) were present before and are now absent.

The built `app/assets/builds/admin_tailwind.css` is gitignored, so only the source entrypoint is committed.

Closes #3139