### PR TITLE
Fix #2463: Hide homepage-only URLs (e.g. /find-placecal) from site subdomains

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
+  # Actions that belong only to the main placecal.org homepage. They must not be
+  # reachable on a sub-site subdomain, where they don't belong (see #2463).
+  HOMEPAGE_ONLY_ACTIONS = %i[
+    find_placecal our_story community_groups metropolitan_areas
+    vcses housing_providers social_prescribers culture_tourism
+  ].freeze
+
   before_action :set_primary_neighbourhood, only: [:site]
   before_action :set_site
+  before_action :require_default_site, only: HOMEPAGE_ONLY_ACTIONS
 
   def home
     if default_site?
@@ -74,6 +82,17 @@ class PagesController < ApplicationController
   DIRECTORY_CACHE_TTL = 1.day
 
   private
+
+  # Homepage-only actions are not valid on sub-sites. When such an action is
+  # requested on a real, non-default site, redirect to that site's root rather
+  # than letting the page render where it doesn't belong (see #2463).
+  # (SitemapsController#require_default_site does the same for its routes but
+  # returns 404; here we redirect because these pages have a sub-site equivalent.)
+  def require_default_site
+    return if current_site.nil? || default_site?
+
+    redirect_to root_path # site root on the current (sub-site) host
+  end
 
   def render_directory_home
     @stats = Rails.cache.fetch('directory/stats', expires_in: DIRECTORY_CACHE_TTL) do

--- a/spec/requests/public/pages_spec.rb
+++ b/spec/requests/public/pages_spec.rb
@@ -101,6 +101,27 @@ RSpec.describe "Public Pages", type: :request do
       get "/find-placecal", headers: { "Host" => "lvh.me" }
       expect(response).to be_successful
     end
+
+    context "on a non-default site" do
+      it "redirects to the site root instead of rendering the homepage page" do
+        get "/find-placecal", headers: { "Host" => "#{site.slug}.lvh.me" }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "homepage-only pages on a non-default site" do
+    # These pages belong only to the main placecal.org homepage and must not be
+    # reachable on a sub-site subdomain (see #2463).
+    %w[
+      /find-placecal /our-story /community-groups /metropolitan-areas
+      /vcses /housing-providers /social-prescribers /culture-tourism
+    ].each do |path|
+      it "redirects #{path} to the site root" do
+        get path, headers: { "Host" => "#{site.slug}.lvh.me" }
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 
   describe "GET /community-groups" do


### PR DESCRIPTION
## What

Homepage-only pages such as \`/find-placecal\` were reachable on any site subdomain (e.g. \`exeter.placecal-staging.org/find-placecal\`), where they don't belong. As noted in the issue, this let main-homepage URLs be "spoofed" as part of areas/partnerships they aren't part of — the routing didn't match where these pages legitimately exist.

## How

Added a \`before_action\` guard in \`PagesController\` scoped to exactly the homepage-only actions:

\`\`\`
find_placecal, our_story, community_groups, metropolitan_areas,
vcses, housing_providers, social_prescribers, culture_tourism
\`\`\`

On a non-default site (i.e. \`current_site\` present and not the default site) the guard redirects to the site root; on the default site these pages render as before. The guard reuses the existing \`default_site?\` helper and mirrors the naming of the existing \`SitemapsController#require_default_site\` convention (that one returns 404; here we redirect, since these requests land on a real sub-site with its own root).

Actions deliberately **not** guarded:
- \`home\` — serves both the default directory home and per-site homepages
- \`privacy\`, \`terms_of_use\` — render \`Views::Directory::*\`, valid per-site
- \`robots\` — per-site robots.txt

## Tests

Added request specs in \`spec/requests/public/pages_spec.rb\`: on a non-default host every homepage-only path redirects to the site root; on the default host \`/find-placecal\` still returns 200 (existing test retained).

Verified before/after: the 8 new non-default-site redirect specs fail without the guard and pass with it. (Other pre-existing failures in that file are unrelated environmental asset-build errors — missing \`public_tailwind\`/\`application.css\` — affecting all render-path tests regardless of this change.)

Closes #2463