### PR TITLE
Fix #2138: clearer validation for duplicate service-area neighbourhoods

### DIFF
--- a/app/models/service_area.rb
+++ b/app/models/service_area.rb
@@ -9,7 +9,14 @@ class ServiceArea < ApplicationRecord
   belongs_to :partner
 
   # ==== Validations ====
-  validates :partner, uniqueness: { scope: :neighbourhood }
+  # A partner cannot have the same neighbourhood added as a service area
+  # more than once. Validating neighbourhood_id (rather than partner)
+  # attaches the error to the neighbourhood, giving a clearer message.
+  validates :neighbourhood_id,
+            uniqueness: {
+              scope: :partner_id,
+              message: 'cannot be added more than once as a service area'
+            }
 
   # ==== Callbacks ====
   after_commit :invalidate_neighbourhood_partners_count!

--- a/spec/models/service_area_spec.rb
+++ b/spec/models/service_area_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ServiceArea do
+  let(:partner) { create(:partner) }
+  let(:neighbourhood) { create(:riverside_ward) }
+
+  describe "validations" do
+    it "is valid with a partner and neighbourhood" do
+      service_area = build(:service_area, partner: partner, neighbourhood: neighbourhood)
+
+      expect(service_area).to be_valid
+    end
+
+    it "is invalid when the same neighbourhood is added twice for the same partner" do
+      create(:service_area, partner: partner, neighbourhood: neighbourhood)
+      duplicate = build(:service_area, partner: partner, neighbourhood: neighbourhood)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:neighbourhood_id])
+        .to include("cannot be added more than once as a service area")
+    end
+
+    it "is valid when a partner has two different neighbourhoods" do
+      other_neighbourhood = create(:oldtown_ward)
+      create(:service_area, partner: partner, neighbourhood: neighbourhood)
+      second = build(:service_area, partner: partner, neighbourhood: other_neighbourhood)
+
+      expect(second).to be_valid
+    end
+
+    it "allows the same neighbourhood for two different partners" do
+      other_partner = create(:partner)
+      create(:service_area, partner: partner, neighbourhood: neighbourhood)
+      other = build(:service_area, partner: other_partner, neighbourhood: neighbourhood)
+
+      expect(other).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
Closes #2138

A partner could appear to add the same neighbourhood twice as a service area, surfacing a confusing error. The (partner, neighbourhood) pair was already guarded by a uniqueness validation, but the error attached to `:partner` with a generic message. This re-scopes the check to `:neighbourhood_id` with an explicit message so the duplicate is clearly attributed and surfaced, matching the `SitesNeighbourhood` sibling convention.

- `app/models/service_area.rb` — re-scoped uniqueness validation + clear message
- `spec/models/service_area_spec.rb` — model specs (duplicate invalid; different neighbourhood / different partner valid)

Note: this refines an already-present save-time guard, focused on clearer messaging; form-level UX (blocking duplicate selection before submit) could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)