### PR TITLE
Fix #2936: guard missing custom theme stylesheet

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -175,15 +175,18 @@ class Site < ApplicationRecord
     refresh_events_count!
   end
 
-  # @return [String] Sprockets stylesheet path for this site's theme
+  # @return [String, nil] asset pipeline stylesheet path for this site's theme,
+  #   or nil when no stylesheet should be linked. For the :custom theme the
+  #   per-site asset (themes/custom/<slug>.css) may not exist in the pipeline;
+  #   in that case we return nil so the page renders with the default styling
+  #   instead of raising Propshaft::MissingAssetError (see issue #2936).
   def stylesheet_link
     return nil if default_site?
 
-    if theme == :custom
-      "themes/custom/#{slug}"
-    else
-      "themes/#{theme}"
-    end
+    return "themes/#{theme}" unless theme == :custom
+
+    custom_path = "themes/custom/#{slug}"
+    custom_path if asset_present?("#{custom_path}.css")
   end
 
   # @return [String, false] Open Graph image URL, or false
@@ -209,6 +212,17 @@ class Site < ApplicationRecord
         Disallow: /
       TXT
     end
+  end
+
+  private
+
+  # @param logical_path [String] asset logical path, e.g. "themes/custom/foo.css"
+  # @return [Boolean] whether the asset resolves in the pipeline. Uses the same
+  #   resolver that stylesheet_link_tag relies on (Propshaft::Helper#compute_asset_path),
+  #   so the guard matches link behaviour in both development (dynamic) and
+  #   production (static manifest) modes.
+  def asset_present?(logical_path)
+    Rails.application.assets&.resolver&.resolve(logical_path).present?
   end
 
   # ==== Class methods ====

--- a/spec/requests/public/custom_theme_spec.rb
+++ b/spec/requests/public/custom_theme_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression test for issue #2936: a site configured with the "custom" theme
+# whose per-site stylesheet (themes/custom/<slug>.css) does not exist in the
+# asset pipeline must not crash with Propshaft::MissingAssetError. The page
+# should render with the default styling instead.
+RSpec.describe "Custom theme with missing stylesheet", type: :request do
+  let!(:default_site) { create_default_site }
+  let(:ward) { create(:riverside_ward) }
+  let!(:site) do
+    create(:site,
+           slug: "experimentalmusic",
+           theme: "custom",
+           url: "https://experimentalmusic.lvh.me",
+           place_name: "Experimental Music")
+  end
+
+  before do
+    site.neighbourhoods << ward
+  end
+
+  it "does not advertise a custom stylesheet that is missing from the pipeline" do
+    # Guards against accidentally adding the asset in the test environment,
+    # which would make the request specs below pass for the wrong reason.
+    expect(site.stylesheet_link).to be_nil
+  end
+
+  it "renders the site homepage without the missing custom stylesheet" do
+    get "http://experimentalmusic.lvh.me"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("themes/custom/experimentalmusic")
+  end
+
+  it "renders the events index without the missing custom stylesheet" do
+    get "http://experimentalmusic.lvh.me/events"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("themes/custom/experimentalmusic")
+  end
+end


### PR DESCRIPTION
## Problem

When a site is configured with the **custom** theme, `Site#stylesheet_link` returned `themes/custom/<slug>` unconditionally. If no matching CSS asset exists in the pipeline (the reported case had slug `experimentalmusic`), the public layout's `stylesheet_link_tag` raised `Propshaft::MissingAssetError`, producing a **500 on every page** of that site.

Originally surfaced as `ActionView::Template::Error` in `EventsController#index` (incident #168), but the layout is shared, so all pages of an affected site crashed.

> Note: the issue backtrace referenced `sprockets-rails`; the app has since migrated to **Propshaft**. The failure mechanism is identical (`Propshaft::MissingAssetError` from `compute_asset_path`).

## Fix

`Site#stylesheet_link` now verifies the custom theme's CSS asset is present before returning its path. The check uses `Rails.application.assets.resolver.resolve` — the exact resolver `stylesheet_link_tag` uses internally — so the guard agrees with real link behaviour in both development (dynamic resolver) and production (static manifest resolver).

When the asset is absent, `stylesheet_link` returns `nil`; the layout's existing `if site&.stylesheet_link` guard then skips the link, and the page renders with the default base styling instead of crashing. Standard themes (pink/orange/green/blue) are unaffected — they always have built assets and skip the presence check.

## Tests

New request spec `spec/requests/public/custom_theme_spec.rb` for a custom-theme site whose stylesheet is missing:
- homepage returns 200 (not 500)
- events index returns 200 (not 500)
- the missing stylesheet is not linked in the response body

Verified the spec fails on `main` (both requests raise `Propshaft::MissingAssetError`) and passes with this change.

Closes #2936

🤖 Generated with [Claude Code](https://claude.com/claude-code)