### PR TITLE
Fix #2959: auto-populate slug from name when creating a Site

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -91,6 +91,13 @@ class Site < ApplicationRecord
     "#{id}: #{name}"
   end
 
+  # @return [Boolean] whether FriendlyId should generate a new slug
+  # Regenerates from the name whenever the slug is blank (e.g. left empty on
+  # the new-site form), mirroring Partner so the slug auto-populates on create.
+  def should_generate_new_friendly_id?
+    slug.blank?
+  end
+
   # @return [Array<Neighbourhood>] all neighbourhoods in this site's subtrees
   def owned_neighbourhoods
     neighbourhoods.map(&:subtree).flatten

--- a/app/views/admin/sites/form_tab_settings.rb
+++ b/app/views/admin/sites/form_tab_settings.rb
@@ -48,16 +48,13 @@ class Views::Admin::Sites::FormTabSettings < Views::Admin::Base
       end
 
       fieldset(class: 'fieldset') do
-        legend(class: 'fieldset-legend') do
-          plain attr_label(:site, :slug)
-          whitespace
-          span(class: 'text-error') { t('admin.labels.required') }
-        end
+        legend(class: 'fieldset-legend') { plain attr_label(:site, :slug) }
         if policy(site).permitted_attributes.include?(:slug)
           raw form.input_field(:slug, class: 'input input-bordered w-full font-mono text-sm')
         else
           raw form.input_field(:slug, class: 'input input-bordered w-full font-mono text-sm bg-base-200', disabled: true)
         end
+        p(class: 'fieldset-label') { t('admin.hints.leave_blank_to_autogenerate') }
       end
     end
   end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -14,7 +14,11 @@ RSpec.describe Site, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_presence_of(:slug) }
+
+    # NOTE: slug presence is enforced at the model and database level, but a
+    # blank slug is auto-generated from the name before validation (see
+    # #should_generate_new_friendly_id? and the "FriendlyId" specs below), so
+    # validate_presence_of(:slug) cannot be asserted via shoulda-matchers.
 
     # NOTE: FriendlyId handles slug uniqueness at the database level
     # No explicit validates_uniqueness_of on slug in the model
@@ -41,6 +45,33 @@ RSpec.describe Site, type: :model do
     it "uses slug for URL" do
       site = create(:site, name: "Test Site", slug: "test-site")
       expect(site.to_param).to eq("test-site")
+    end
+
+    it "auto-populates the slug from the name on create when slug is left blank" do
+      site = create(:site, name: "My Brand New Site", slug: "")
+      expect(site.slug).to eq("my-brand-new-site")
+    end
+
+    it "auto-populates the slug from the name on create when no slug is given" do
+      site = build(:site, name: "Another New Site")
+      site.slug = nil
+      site.save!
+      expect(site.slug).to eq("another-new-site")
+    end
+
+    it "keeps an explicitly provided slug on create" do
+      site = create(:site, name: "Named Site", slug: "my-custom-slug")
+      expect(site.slug).to eq("my-custom-slug")
+    end
+
+    describe "#should_generate_new_friendly_id?" do
+      it "is true when the slug is blank" do
+        expect(build(:site, slug: "").should_generate_new_friendly_id?).to be(true)
+      end
+
+      it "is false when the slug is present" do
+        expect(build(:site, slug: "present").should_generate_new_friendly_id?).to be(false)
+      end
     end
   end
 

--- a/spec/requests/admin/sites_spec.rb
+++ b/spec/requests/admin/sites_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe "Admin::Sites", type: :request do
         expect(response).to be_successful
         expect(response.body).to include("<title>New Site | PlaceCal Admin</title>")
       end
+
+      it "tells the user the slug auto-generates from the name when left blank" do
+        get new_admin_site_url(host: admin_host)
+        expect(response).to be_successful
+        expect(response.body).to include("Leave blank to auto-generate from name")
+      end
     end
   end
 
@@ -132,6 +138,24 @@ RSpec.describe "Admin::Sites", type: :request do
   end
 
   describe "POST /admin/sites" do
+    context "with a blank slug" do
+      before { sign_in root_user }
+
+      it "auto-generates the slug from the name" do
+        new_site_params = {
+          name: "My Brand New Site",
+          url: "https://brand-new.placecal.org",
+          slug: ""
+        }
+
+        expect do
+          post admin_sites_url(host: admin_host), params: { site: new_site_params }
+        end.to change(Site, :count).by(1)
+
+        expect(Site.last.slug).to eq("my-brand-new-site")
+      end
+    end
+
     context "with bad image uploads" do
       before { sign_in root_user }
 


### PR DESCRIPTION
Closes #2959

New sites did not get a slug auto-generated from their name the way partners do. This mirrors `Partner#should_generate_new_friendly_id?` so a blank slug is generated from the name on create, and the admin site form reuses the existing leave-blank-to-autogenerate hint (no hardcoded strings).

- `app/models/site.rb` — generate slug from name when blank
- `app/views/admin/sites/form_tab_settings.rb` — autogenerate hint on the slug field
- `spec/models/site_spec.rb`, `spec/requests/admin/sites_spec.rb` — specs

The model `slug` presence validation and DB NOT NULL remain as backstops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)