### PR TITLE
Fix #2567: set default site when current_site is nil

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -192,8 +192,21 @@ class ApplicationController < ActionController::Base
     @calendar = Calendar.find(params[:id])
   end
 
+  # Assigns @site for site-scoped public controllers (events, partners, etc.).
+  #
+  # current_site is deliberately nil on the admin subdomain (it provides a
+  # global, site-less view). Public resource pages such as /events/:id are not
+  # behind a subdomain constraint, so crawlers can reach them on the admin
+  # subdomain where current_site is nil — which previously blew up the
+  # Site-typed Phlex view props (issue #2567). Fall back to the default site so
+  # those pages render the directory view instead of raising. When current_site
+  # has already issued a redirect (e.g. an unknown subdomain) we leave @site nil
+  # and let that redirect halt the request.
   def set_site
     @site = current_site
+    return if @site || response.redirect?
+
+    @site = Site.find_by(slug: 'default-site') || Site.new
   end
 
   def redirect_from_default_site

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -198,15 +198,15 @@ class ApplicationController < ActionController::Base
   # global, site-less view). Public resource pages such as /events/:id are not
   # behind a subdomain constraint, so crawlers can reach them on the admin
   # subdomain where current_site is nil — which previously blew up the
-  # Site-typed Phlex view props (issue #2567). Fall back to the default site so
-  # those pages render the directory view instead of raising. When current_site
-  # has already issued a redirect (e.g. an unknown subdomain) we leave @site nil
-  # and let that redirect halt the request.
+  # Site-typed Phlex view props (issue #2567). Fall back to the directory site
+  # (placecal.org) so those pages render the directory view instead of raising.
+  # When current_site has already issued a redirect (e.g. an unknown subdomain)
+  # we leave @site nil and let that redirect halt the request.
   def set_site
     @site = current_site
     return if @site || response.redirect?
 
-    @site = Site.find_by(slug: 'default-site') || Site.new
+    @site = Site.directory
   end
 
   def redirect_from_default_site

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -214,6 +214,14 @@ class Site < ApplicationRecord
   # ==== Class methods ====
 
   class << self
+    # The default "directory" site (placecal.org) that aggregates every partner
+    # and event. Used as the fallback for requests that resolve to no site of
+    # their own (e.g. the admin subdomain reaching a public resource page).
+    # @return [Site, nil]
+    def directory
+      find_by(slug: 'default-site')
+    end
+
     # Selects the robots.txt template based on ALLOW_AI_SEARCH_BOTS env var.
     # In production, defaults to allowing search-AI bots (permissive template).
     # Set ALLOW_AI_SEARCH_BOTS=false to block all AI bots (strict template).

--- a/spec/requests/public/events_spec.rb
+++ b/spec/requests/public/events_spec.rb
@@ -233,4 +233,27 @@ RSpec.describe "Public Events", type: :request do
       expect(response).to be_successful
     end
   end
+
+  # Regression test for #2567: current_site is deliberately nil on the admin
+  # subdomain (it has no Site of its own). Public event pages are not behind a
+  # subdomain constraint, so crawlers reach them at admin.placecal.org where the
+  # nil site previously raised Literal::TypeError on the Site-typed view props.
+  # set_site now falls back to the default site so these pages render instead.
+  describe "admin subdomain (no current_site)" do
+    let!(:default_site) { create_default_site }
+    let!(:event) do
+      create(:event, organiser: partner, summary: "Admin Event",
+                     dtstart: 1.day.from_now, address: address)
+    end
+
+    it "renders the event index without raising" do
+      get events_url(host: "admin.lvh.me")
+      expect(response).to be_successful
+    end
+
+    it "renders an event show page without raising" do
+      get event_url(event, host: "admin.lvh.me")
+      expect(response).to be_successful
+    end
+  end
 end


### PR DESCRIPTION
## What

`current_site` is deliberately `nil` on the admin subdomain (it provides a global, site-less view; see `app/controllers/application_controller.rb`). Public resource pages such as `/events` and `/events/:id` are **not** behind a subdomain constraint, so crawlers (e.g. Bytespider) reach them at `admin.placecal.org`. There the `nil` site flowed into the non-nilable `Site`-typed Phlex view props (`Views::Events::Index`, `Views::Events::Show`) and raised `Literal::TypeError` — the Rollbar error in this issue.

## Fix

`set_site` now falls back to the default site when `current_site` is `nil` and no redirect is already in flight:

```ruby
def set_site
  @site = current_site
  return if @site || response.redirect?

  @site = Site.find_by(slug: 'default-site') || Site.new
end
```

This is the single shared seam used by all site-scoped public controllers (events, partners, news, partnerships, collections, pages), so it fixes the root nil-deref uniformly rather than guarding each view.

- **Site present (normal traffic):** unchanged — `current_site` returns the site and we return early.
- **Unknown subdomain:** unchanged — `current_site` already issues a redirect to the base domain; we detect `response.redirect?` and leave `@site` nil so that redirect halts the request.
- **Admin subdomain / no resolvable site:** previously crashed; now renders the default (directory) site view.

`current_site` itself is untouched, preserving its documented "nil on admin" contract used by `default_site?`, navigation, etc. The admin interface and Devise views do not use `@site`, so they are unaffected (verified by the existing devise request specs).

## Tests

Added request specs in `spec/requests/public/events_spec.rb` for the no-current-site (admin subdomain) path on both the events index and an event show page. These fail with `Literal::TypeError` before the change and pass after. Existing public-controller and devise request specs continue to pass.

Closes #2567