### PR TITLE
Fix #2358: retain user-set slug on validation failure

### DIFF
--- a/app/models/concerns/slug_retainable.rb
+++ b/app/models/concerns/slug_retainable.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Keeps a user-entered slug on the in-memory record when validation fails.
+#
+# FriendlyId installs an `after_validation :unset_slug_if_invalid` callback that
+# reverts the slug back to its previous value whenever the slug attribute itself
+# is invalid (for example a duplicate slug). On a form round-trip that means the
+# value the user typed is silently replaced with the old slug, so when the form
+# is re-rendered after a failed save the user's input appears to have been lost
+# (see issue #2358).
+#
+# We never persist on a failed validation, so reverting the slug only affects the
+# unsaved object that gets handed back to the view. Suppressing the revert lets
+# the form show what the user actually entered alongside the validation error.
+#
+# The override is prepended, so it shadows FriendlyId's `Slugged#unset_slug_if_invalid`
+# regardless of whether `friendly_id ... use: :slugged` runs before or after this
+# concern is included.
+module SlugRetainable
+  extend ActiveSupport::Concern
+
+  module Override
+    private
+
+    # Override FriendlyId's revert behaviour: retain the user-entered slug so it
+    # is preserved across a validation-failure re-render.
+    def unset_slug_if_invalid
+      # no-op: keep the submitted slug for the form round-trip
+    end
+  end
+
+  included do
+    prepend Override
+  end
+end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -7,6 +7,7 @@ class Partner < ApplicationRecord
   include Permalinkable
   extend FriendlyId
   include HtmlRenderCache
+  include SlugRetainable
 
   # ==== Constants ====
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -6,6 +6,7 @@ class Site < ApplicationRecord
   extend Enumerize
   include HtmlRenderCache
   include SiteJsonLd
+  include SlugRetainable
 
   # ==== Constants ====
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,6 +4,7 @@ class Tag < ApplicationRecord
   # ==== Includes / Extends ====
   extend FriendlyId
   extend Enumerize
+  include SlugRetainable
 
   # ==== Constants ====
 

--- a/spec/models/concerns/slug_retainable_spec.rb
+++ b/spec/models/concerns/slug_retainable_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression coverage for issue #2358: a user-entered custom slug must survive a
+# validation-failure round-trip so the re-rendered form shows what was typed,
+# instead of FriendlyId silently reverting it to the previous slug.
+RSpec.describe SlugRetainable do
+  shared_examples "retains a user-entered slug on validation failure" do
+    it "keeps the submitted slug when only the slug is invalid (duplicate)" do
+      create(factory, name: "Already Taken Name", slug: "taken-slug")
+      record = create(factory, name: "Some Existing Name")
+
+      saved = record.update(slug: "taken-slug")
+
+      expect(saved).to be(false)
+      expect(record.errors[:slug]).to be_present
+      expect(record.slug).to eq("taken-slug")
+    end
+
+    it "keeps the submitted slug when another field is also invalid" do
+      create(factory, name: "Already Taken Name", slug: "taken-slug")
+      record = create(factory, name: "Some Existing Name")
+
+      record.update(slug: "taken-slug", name: invalid_name)
+
+      expect(record.slug).to eq("taken-slug")
+    end
+
+    it "persists a valid custom slug as before" do
+      record = create(factory, name: "Some Existing Name")
+
+      expect(record.update(slug: "fresh-custom-slug")).to be(true)
+      expect(record.reload.slug).to eq("fresh-custom-slug")
+    end
+  end
+
+  describe "Partner" do
+    let(:factory) { :partner }
+    # too short to satisfy the name length validation
+    let(:invalid_name) { "x" }
+
+    include_examples "retains a user-entered slug on validation failure"
+
+    it "still auto-generates a slug from the name when none is given" do
+      # guards against the override accidentally disabling slug generation
+      partner = create(:partner, name: "Brand New Thing")
+
+      expect(partner.slug).to eq("brand-new-thing")
+    end
+  end
+
+  describe "Site" do
+    let(:factory) { :site }
+    let(:invalid_name) { "" }
+
+    include_examples "retains a user-entered slug on validation failure"
+  end
+
+  describe "Tag" do
+    let(:factory) { :tag }
+    let(:invalid_name) { "" }
+
+    include_examples "retains a user-entered slug on validation failure"
+  end
+end

--- a/spec/requests/admin/partners_spec.rb
+++ b/spec/requests/admin/partners_spec.rb
@@ -291,6 +291,34 @@ RSpec.describe "Admin::Partners", type: :request do
       end
     end
 
+    context "custom slug with a validation failure (#2358)" do
+      let(:user) { create(:root_user) }
+      let!(:other_partner) { create(:partner, slug: "taken-slug") }
+      let(:partner) { create(:riverside_partner) }
+
+      before { sign_in user }
+
+      it "re-renders the form with the slug the user entered, not the original" do
+        original_slug = partner.slug
+
+        partner_params = {
+          name: partner.name,
+          slug: "taken-slug", # already used => slug validation fails
+          address_attributes: {
+            street_address: partner.address.street_address,
+            postcode: partner.address.postcode
+          }
+        }
+
+        put admin_partner_url(partner, host: admin_host), params: { partner: partner_params }
+
+        expect(response).not_to be_redirect
+        expect(response.body).to include('value="taken-slug"')
+        expect(response.body).not_to include("value=\"#{original_slug}\"")
+        expect(partner.reload.slug).to eq(original_slug)
+      end
+    end
+
     context "neighbourhood admin address restriction" do
       let(:ward) { create(:riverside_ward) }
       let(:user) { create(:neighbourhood_admin, neighbourhood: ward) }


### PR DESCRIPTION
## What

Fixes a bug where a user-provided custom slug is lost when saving a record fails validation. When a user enters a custom slug and the save is rejected (most commonly because the slug is a duplicate, but also alongside other invalid fields), the form is re-rendered showing the *old* slug instead of what the user typed.

## Root cause

FriendlyId registers an `after_validation :unset_slug_if_invalid` callback. Whenever there's an error on the slug attribute *and* the slug changed, it reverts the in-memory slug back to its previous value. Because the admin controllers re-render the form with that same in-memory object after a failed save, the user's input was silently discarded.

This affects every model with a user-editable slug: **Partner**, **Site**, and **Tag** (all use `friendly_id :name, use: :slugged` plus a `validates :slug, uniqueness`). Article uses `slug_candidates` and doesn't expose the slug for editing, so it's unaffected in practice.

## Fix

A small `SlugRetainable` concern prepends a no-op override of `unset_slug_if_invalid`, so the entered slug survives the validation-failure round-trip and is shown back to the user alongside the error. It's `prepend`ed, so it shadows FriendlyId's method regardless of include order.

Nothing is persisted on a failed validation, so this only affects the unsaved object handed to the view. Valid saves still persist custom slugs, and blank-slug auto-generation from the name is unchanged.

## Tests

- `spec/models/concerns/slug_retainable_spec.rb` — for Partner, Site and Tag: the submitted slug is retained when the slug is a duplicate, and when another field is also invalid; a valid custom slug still persists; Partner still auto-generates a slug from the name when none is given.
- `spec/requests/admin/partners_spec.rb` — end-to-end: a root user submits a duplicate slug, the form re-renders with `value="taken-slug"` (what they typed) rather than the original slug.

Both fail before the fix and pass after.

Closes #2358