### PR TITLE
Fix #2991: load NormalIsland module in geocoder; link skip-admin checkbox to its label

### DIFF
--- a/app/views/admin/partners/new.rb
+++ b/app/views/admin/partners/new.rb
@@ -325,10 +325,10 @@ class Views::Admin::Partners::New < Views::Admin::Base
                            "Optionally invite someone to manage this partner. They'll receive an email invitation.")
         div(class: 'space-y-6') do
           div(class: 'flex items-center gap-3 p-4 bg-base-200/50 rounded-xl') do
-            input(type: 'checkbox', class: 'checkbox checkbox-sm',
+            input(type: 'checkbox', id: 'partner_skip_admin', class: 'checkbox checkbox-sm',
                   data: { 'partner-wizard-target': 'skipAdminCheckbox',
                           action: 'change->partner-wizard#toggleAdminFields' })
-            label(class: 'text-sm') { "Skip this step - I'll add admins later" }
+            label(for: 'partner_skip_admin', class: 'text-sm') { "Skip this step - I'll add admins later" }
           end
           div(data: { 'partner-wizard-target': 'adminFields' }) do
             render_admin_details_card(form)

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 if Rails.env.local?
+  # Load the NormalIsland data module (POSTCODES, WARDS, etc.) referenced by
+  # the custom geocoder lookup. Without this the constant is undefined outside
+  # the seed scripts, raising "uninitialized constant NormalIsland" when the
+  # admin partner form geocodes an address.
+  require 'normal_island'
   require 'normal_island/geocoder_lookup'
   Geocoder::Lookup.street_services.unshift(:normal_island)
   Geocoder.configure(lookup: :normal_island, timeout: 5)

--- a/spec/components/admin/partners/new_invite_step_spec.rb
+++ b/spec/components/admin/partners/new_invite_step_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression coverage for issue #2991: the "Skip this step" checkbox in the new
+# partner wizard had no id and its label had no matching `for`, so clicking the
+# label did nothing and the control was inaccessible to screen readers.
+#
+# The full New view depends on `current_user` (in the location step), so this
+# spec renders only the invite step in isolation via a thin subclass. The
+# invite step takes a form argument but does not call any method on it.
+RSpec.describe Views::Admin::Partners::New, type: :component do
+  # Renders just the "Invite a Partner Admin" step so we can assert its markup
+  # without the Devise/asset context the full wizard page requires.
+  let(:invite_step_view) do
+    Class.new(described_class) do
+      def view_template
+        render_step_invite(nil)
+      end
+    end
+  end
+
+  before do
+    render_inline(invite_step_view.new(partner: Partner.new))
+  end
+
+  it "gives the skip-admin checkbox an id" do
+    expect(page).to have_css("input[type='checkbox']#partner_skip_admin")
+  end
+
+  it "links the label to the skip-admin checkbox via matching for" do
+    expect(page).to have_css("label[for='partner_skip_admin']")
+  end
+
+  it "uses the same value for the checkbox id and the label for" do
+    checkbox = page.find("input[type='checkbox'][data-partner-wizard-target='skipAdminCheckbox']")
+    label = page.find("label[for]", text: /Skip this step/)
+
+    expect(checkbox[:id]).to be_present
+    expect(label[:for]).to eq(checkbox[:id])
+  end
+end

--- a/spec/lib/normal_island/geocoder_lookup_spec.rb
+++ b/spec/lib/normal_island/geocoder_lookup_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression coverage for issue #2991: adding/editing a partner using the
+# seeded dev database raised "uninitialized constant NormalIsland" because the
+# geocoder initializer required the custom lookup but never loaded the
+# NormalIsland data module it depends on (POSTCODES, WARDS, ADDRESSES, ...).
+#
+# Note: factories in spec/factories/normal_island load the NormalIsland module
+# at suite boot, so a plain `Geocoder.search` would always pass under RSpec and
+# would NOT catch a regression. We therefore also assert that the geocoder
+# initializer itself loads the module, which is the guarantee the running
+# (factory-free) app relies on.
+RSpec.describe Geocoder::Lookup::NormalIsland do
+  it "loads the NormalIsland data module from the geocoder initializer" do
+    initializer = Rails.root.join("config/initializers/geocoder.rb").read
+
+    expect(initializer).to include("require 'normal_island'")
+  end
+
+  it "resolves the NormalIsland constant when looking up a Normal Island postcode" do
+    expect { described_class.new.search("ZZMB 1RS") }.not_to raise_error
+  end
+
+  it "returns the seeded Normal Island result for a known postcode" do
+    results = described_class.new.search("ZZMB 1RS")
+
+    expect(results.size).to eq(1)
+    expect(results.first.coordinates).to eq([53.5, -1.5])
+    expect(results.first.data["admin_ward"]).to eq("Riverside")
+  end
+end


### PR DESCRIPTION
## Summary

Fixes two defects from #2991 hit when adding/editing partners against the seeded dev DB.

### (a) `uninitialized constant NormalIsland`
`config/initializers/geocoder.rb` required the custom `Geocoder::Lookup::NormalIsland` lookup but never loaded the `NormalIsland` **data** module (`POSTCODES`, `WARDS`, `ADDRESSES`, …) that the lookup references. That module is only `require_relative`'d by the seed scripts (and, in the test suite, by factories), so it was undefined in the running dev/seed app. Geocoding a `ZZ`-prefix postcode during a partner save then raised `uninitialized constant NormalIsland`.

Fix: `require 'normal_island'` in the initializer (before the lookup) so the constant resolves at app boot. As a bonus this also loads the `UKPostcode` Normal Island monkey-patch in dev/test app boot, not just during seeding. The require is idempotent and the patch is prepended exactly once.

### (b) Unlinked checkbox + label (accessibility)
In the new-partner wizard's "Invite a Partner Admin" step (`app/views/admin/partners/new.rb`), the "Skip this step — I'll add admins later" checkbox had no `id` and its label no `for`, so clicking the label did nothing and screen readers couldn't associate them. Added `id="partner_skip_admin"` to the input and a matching `for` on the label.

## Tests
- `spec/lib/normal_island/geocoder_lookup_spec.rb` — asserts the geocoder initializer loads `normal_island` (regression guard, since factories otherwise mask the constant in-suite) and that a Normal Island postcode lookup resolves without `NameError` and returns the seeded result.
- `spec/components/admin/partners/new_invite_step_spec.rb` — renders the wizard's invite step in isolation and asserts the checkbox has an `id` and its label a matching `for`.

Both specs were confirmed to fail before the change and pass after. Targeted specs green; rubocop clean on changed files.

## Notes / out of scope
- I did **not** chase the "Address is invalid" / "postcode could not be mapped to a neighbourhood" validation messages, nor the "Partner Name too short" transient error — per the issue these may be expected; they need separate investigation.
- The "Skip this step…" label text is a hardcoded string (an i18n violation per project rules) but it is pre-existing and unrelated to either defect, so I left it untouched to keep this change focused.

Closes #2991