### PR TITLE
Fix #2912: Enable event matching by default and fix toggle label emphasis

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -23,7 +23,7 @@ class Partner < ApplicationRecord
   attribute :calendar_email,          :string                      # nullable
   attribute :calendar_name,           :string                      # nullable
   attribute :calendar_phone,          :string                      # nullable
-  attribute :can_be_assigned_events,  :boolean, default: false     # NOT NULL
+  attribute :can_be_assigned_events,  :boolean, default: true      # NOT NULL
   attribute :description,             :text                        # nullable
   attribute :description_html,        :string                      # nullable, populated by HtmlRenderCache
   attribute :facebook_link,           :string                      # nullable

--- a/app/views/admin/partners/form_tab_settings.rb
+++ b/app/views/admin/partners/form_tab_settings.rb
@@ -73,12 +73,16 @@ class Views::Admin::Partners::FormTabSettings < Views::Admin::Base
           plain is_enabled ? t('admin.partners.event_matching.enabled') : t('admin.partners.event_matching.disabled')
         end
         div(class: 'flex items-center gap-3') do
-          span(class: 'label-text text-sm font-medium text-gray-600') { t('admin.labels.disabled') }
+          span(class: event_matching_label_class(active: !is_enabled), id: 'event-matching-label-disabled') do
+            t('admin.labels.disabled')
+          end
           raw form.check_box(:can_be_assigned_events,
                              class: 'toggle toggle-success',
                              id: 'partner_can_be_assigned_events',
                              onchange: 'updateEventMatchingTitle(this.checked)')
-          span(class: 'label-text text-sm font-medium text-success') { t('admin.labels.enabled') }
+          span(class: event_matching_label_class(active: is_enabled, success: true), id: 'event-matching-label-enabled') do
+            t('admin.labels.enabled')
+          end
         end
       end
 
@@ -86,6 +90,18 @@ class Views::Admin::Partners::FormTabSettings < Views::Admin::Base
 
       render_event_matching_benefits
     end
+  end
+
+  # The label matching the toggle's current position is prominent; the other is faded.
+  # The active "enabled" label uses the success colour; otherwise it is neutral.
+  def event_matching_label_class(active:, success: false)
+    emphasis =
+      if active
+        success ? 'text-success' : 'text-base-content'
+      else
+        'text-base-content/40'
+      end
+    "label-text text-sm font-medium #{emphasis}"
   end
 
   def render_event_matching_benefits
@@ -114,6 +130,14 @@ class Views::Admin::Partners::FormTabSettings < Views::Admin::Base
         function updateEventMatchingTitle(isEnabled) {
           const title = document.getElementById('event-matching-title');
           title.textContent = isEnabled ? '#{t('admin.partners.event_matching.enabled')}' : '#{t('admin.partners.event_matching.disabled')}';
+
+          const faded = 'text-base-content/40';
+          const enabledLabel = document.getElementById('event-matching-label-enabled');
+          const disabledLabel = document.getElementById('event-matching-label-disabled');
+          enabledLabel.classList.toggle('text-success', isEnabled);
+          enabledLabel.classList.toggle(faded, !isEnabled);
+          disabledLabel.classList.toggle('text-base-content', !isEnabled);
+          disabledLabel.classList.toggle(faded, isEnabled);
         }
       JS
     end

--- a/db/migrate/20260528120000_change_can_be_assigned_events_default_to_true.rb
+++ b/db/migrate/20260528120000_change_can_be_assigned_events_default_to_true.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Enable event matching by default for new partners.
+# See issue #2912: when creating a new partner, event matching should be
+# enabled by default rather than disabled.
+class ChangeCanBeAssignedEventsDefaultToTrue < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :partners, :can_be_assigned_events, from: false, to: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_172023) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -221,7 +221,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_172023) do
     t.string "calendar_email"
     t.string "calendar_name"
     t.string "calendar_phone"
-    t.boolean "can_be_assigned_events", default: false, null: false
+    t.boolean "can_be_assigned_events", default: true, null: false
     t.datetime "created_at", precision: nil, null: false
     t.text "description"
     t.string "description_html"

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Partner, type: :model do
     it { is_expected.to have_many(:articles).through(:article_partners) }
   end
 
+  describe "defaults" do
+    it "enables event matching by default" do
+      expect(described_class.new.can_be_assigned_events).to be true
+    end
+  end
+
   describe "validations" do
     # shoulda-matchers needs an existing record for uniqueness validation
     subject { create(:partner) }

--- a/spec/views/admin/partners/form_tab_settings_spec.rb
+++ b/spec/views/admin/partners/form_tab_settings_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Views::Admin::Partners::FormTabSettings, type: :phlex do
+  # Renders the settings tab inside a SimpleForm form so the toggle's
+  # form helpers resolve, returning a Capybara node for the markup.
+  def render_settings(partner)
+    component = described_class
+    wrapper = Class.new(Views::Admin::Base) do
+      define_method(:initialize) { |p| @partner = p }
+      define_method(:view_template) do
+        simple_form_for(@partner, url: "/x") do |form|
+          render component.new(form: form)
+        end
+      end
+    end
+
+    html = wrapper.new(partner).render_in(view_context)
+    Capybara::Node::Simple.new(html)
+  end
+
+  # The component calls policy(partner) for the URL/slug section; stub it so the
+  # spec does not depend on an authenticated user.
+  let(:view_context) do
+    controller = ApplicationController.new
+    controller.request = ActionDispatch::TestRequest.create
+    context = controller.view_context
+    permissive_policy = Struct.new(:record) do
+      def permitted_attributes = %i[slug]
+      def destroy? = false
+    end
+    context.define_singleton_method(:policy) { |record| permissive_policy.new(record) }
+    context
+  end
+
+  context "when event matching is enabled" do
+    let(:partner) { Partner.new(name: "Test", can_be_assigned_events: true) }
+
+    it "checks the toggle" do
+      page = render_settings(partner)
+      expect(page).to have_css("input#partner_can_be_assigned_events[checked]")
+    end
+
+    it "renders the enabled label prominently and the disabled label faded" do
+      page = render_settings(partner)
+      expect(page).to have_css("#event-matching-label-enabled.text-success")
+      expect(page).to have_css("#event-matching-label-disabled.text-base-content\\/40")
+    end
+  end
+
+  context "when event matching is disabled" do
+    let(:partner) { Partner.new(name: "Test", can_be_assigned_events: false) }
+
+    it "leaves the toggle unchecked" do
+      page = render_settings(partner)
+      expect(page).to have_no_css("input#partner_can_be_assigned_events[checked]")
+    end
+
+    it "renders the disabled label prominently and the enabled label faded" do
+      page = render_settings(partner)
+      expect(page).to have_css("#event-matching-label-disabled.text-base-content")
+      expect(page).to have_css("#event-matching-label-enabled.text-base-content\\/40")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the two partner settings issues reported in #2912.

### 1. Event matching enabled by default

New partners now have event matching enabled by default. Adds a migration changing the `partners.can_be_assigned_events` column default from `false` to `true`, and updates the model attribute default + annotation to match.

### 2. Toggle label emphasis follows the toggle state

In the Settings tab event-matching card, the "Disabled" / "Enabled" labels flanking the toggle were statically coloured, so even when matching was disabled the prominent green "Enabled" label remained — making the control read backwards. The label matching the toggle's current position is now prominent and the other is faded, both on initial server render and when the toggle is flipped (via the existing `onchange` handler).

## Tests

- Model spec: `Partner.new.can_be_assigned_events` is `true`.
- Component spec (`spec/views/admin/partners/form_tab_settings_spec.rb`): asserts the active label is prominent and the inactive one faded, for both enabled and disabled states. Both assertions fail on the pre-fix code and pass after.

Closes #2912