### PR TITLE
Fix #3100: handle calendar importer network timeouts gracefully

### DIFF
--- a/app/jobs/calendar_importer/parsers/base.rb
+++ b/app/jobs/calendar_importer/parsers/base.rb
@@ -115,6 +115,12 @@ module CalendarImporter::Parsers
       raise InaccessibleFeed, "The source URL could not be resolved (#{e})"
     rescue SocketError => e
       raise InaccessibleFeed, "There was a socket error (#{e})"
+    rescue Net::ReadTimeout, Net::OpenTimeout, OpenSSL::SSL::SSLError => e
+      # Slow/unreachable feeds and TLS negotiation failures are expected when
+      # scraping third-party sources. Treat them as an unreachable source rather
+      # than letting them bubble up as unhandled exceptions (see issue #3100).
+      Rails.logger.warn("Calendar source unreachable for #{url}: #{e.class} (#{e.message})")
+      raise InaccessibleFeed, I18n.t('admin.calendars.wizard.source.unreachable')
     end
 
     def self.parse_ld_json(url)

--- a/app/jobs/calendar_importer_job.rb
+++ b/app/jobs/calendar_importer_job.rb
@@ -13,6 +13,20 @@ class CalendarImporterJob < ApplicationJob
     report_bad_source_error exception.message
   end
 
+  # Network timeouts and TLS failures are expected when scraping third-party
+  # feeds that are slow or temporarily down. Treat them as an unreachable
+  # source instead of letting them surface as unhandled exceptions (see issue
+  # #3100). Most HTTP fetches funnel through Parsers::Base.read_http_source,
+  # which already maps these to InaccessibleFeed; this backstop covers parsers
+  # that make HTTP requests by other means (e.g. API and POST-based parsers).
+  rescue_from Net::ReadTimeout, Net::OpenTimeout, OpenSSL::SSL::SSLError do |exception|
+    Rails.logger.warn(
+      "Calendar source unreachable for calendar #{@calendar_id}: " \
+      "#{exception.class} (#{exception.message})"
+    )
+    report_bad_source_error I18n.t('admin.calendars.wizard.source.unreachable')
+  end
+
   rescue_from InvalidResponse do |exception|
     report_error exception, 'Calendar URL returned un-parsable data'
   end

--- a/app/jobs/calendar_importer_job.rb
+++ b/app/jobs/calendar_importer_job.rb
@@ -19,7 +19,11 @@ class CalendarImporterJob < ApplicationJob
   # #3100). Most HTTP fetches funnel through Parsers::Base.read_http_source,
   # which already maps these to InaccessibleFeed; this backstop covers parsers
   # that make HTTP requests by other means (e.g. API and POST-based parsers).
-  rescue_from Net::ReadTimeout, Net::OpenTimeout, OpenSSL::SSL::SSLError do |exception|
+  # RestClient::Exceptions::Timeout (the parent of RestClient's Read/OpenTimeout)
+  # covers the Eventbrite parser, which fetches via RestClient/EventbriteSDK —
+  # its timeout errors are not subclasses of Net::ReadTimeout/Net::OpenTimeout.
+  rescue_from Net::ReadTimeout, Net::OpenTimeout, OpenSSL::SSL::SSLError,
+              RestClient::Exceptions::Timeout do |exception|
     Rails.logger.warn(
       "Calendar source unreachable for calendar #{@calendar_id}: " \
       "#{exception.class} (#{exception.message})"

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -310,6 +310,7 @@ en:
           forbidden: "This URL returned a 403 (forbidden). The site may be blocking automated access. Please check the URL is correct and that the feed is publicly accessible."
           not_found: "This URL returned a 404 (not found). Please check the URL is correct and that the feed or page has not been removed or set to private."
           unreadable: "The source URL could not be read (code=%{code})"
+          unreachable: "The source could not be reached (it timed out or refused a secure connection). It may be temporarily down — please check the URL and try again later."
         organiser:
           title: "Organiser"
           description: "Which partner organises these events, and what should we call this calendar?"

--- a/spec/jobs/calendar_importer_job_spec.rb
+++ b/spec/jobs/calendar_importer_job_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CalendarImporterJob do
+  # perform_now runs the full ActiveJob pipeline so that rescue_from handlers
+  # (which catch and record the error) fire — calling #perform directly would
+  # bypass them.
+  subject(:perform_import) do
+    described_class.perform_now(calendar.id, Time.zone.today, true)
+  end
+
+  # Use the factory's unique source sequence so the spec is independent of any
+  # leftover calendar rows in the shared test database.
+  let(:calendar) do
+    create(:calendar, importer_mode: "ical")
+      .tap { |c| c.update!(calendar_state: "in_queue") }
+  end
+
+  # Issue #3100: network timeouts and TLS failures while scraping third-party
+  # feeds should mark the source as unreachable rather than surfacing as
+  # unhandled exceptions in error tracking.
+  describe "network/source-unreachable errors" do
+    context "when the HTTP fetch times out (via read_http_source)" do
+      before do
+        stub_request(:get, calendar.source).to_raise(Net::ReadTimeout)
+      end
+
+      it "does not raise" do
+        expect { perform_import }.not_to raise_error
+      end
+
+      it "marks the calendar as a bad (unreachable) source" do
+        perform_import
+
+        expect(calendar.reload.calendar_state).to eq("bad_source")
+        expect(calendar.critical_error)
+          .to eq(I18n.t("admin.calendars.wizard.source.unreachable"))
+      end
+
+      it "logs a warning describing the unreachable source" do
+        allow(Rails.logger).to receive(:warn).and_call_original
+
+        perform_import
+
+        expect(Rails.logger).to have_received(:warn).with(/unreachable/i).at_least(:once)
+      end
+    end
+
+    context "when a connection times out (Net::OpenTimeout)" do
+      before do
+        stub_request(:get, calendar.source).to_raise(Net::OpenTimeout)
+      end
+
+      it "does not raise and marks the source unreachable" do
+        expect { perform_import }.not_to raise_error
+        expect(calendar.reload.calendar_state).to eq("bad_source")
+      end
+    end
+
+    context "when a TLS negotiation fails (OpenSSL::SSL::SSLError)" do
+      before do
+        stub_request(:get, calendar.source).to_raise(OpenSSL::SSL::SSLError)
+      end
+
+      it "does not raise and marks the source unreachable" do
+        expect { perform_import }.not_to raise_error
+        expect(calendar.reload.calendar_state).to eq("bad_source")
+      end
+    end
+
+    context "when a timeout escapes a parser that bypasses read_http_source" do
+      # API/POST-based parsers (TicketSource, ResidentAdvisor, Eventbrite) make
+      # HTTP requests outside read_http_source, so the timeout reaches the job
+      # directly. The job-level rescue_from is the backstop for these.
+      before do
+        task = instance_double(CalendarImporter::CalendarImporterTask)
+        allow(CalendarImporter::CalendarImporterTask).to receive(:new).and_return(task)
+        allow(task).to receive(:run).and_raise(Net::ReadTimeout)
+      end
+
+      it "does not raise and marks the source unreachable" do
+        expect { perform_import }.not_to raise_error
+
+        expect(calendar.reload.calendar_state).to eq("bad_source")
+        expect(calendar.critical_error)
+          .to eq(I18n.t("admin.calendars.wizard.source.unreachable"))
+      end
+    end
+  end
+
+  describe "non-network errors" do
+    it "does not swallow unrelated StandardError exceptions" do
+      task = instance_double(CalendarImporter::CalendarImporterTask)
+      allow(CalendarImporter::CalendarImporterTask).to receive(:new).and_return(task)
+      allow(task).to receive(:run).and_raise(KeyError, "boom")
+
+      expect { perform_import }.to raise_error(KeyError, /boom/)
+    end
+  end
+end

--- a/spec/jobs/calendar_importer_job_spec.rb
+++ b/spec/jobs/calendar_importer_job_spec.rb
@@ -87,6 +87,32 @@ RSpec.describe CalendarImporterJob do
           .to eq(I18n.t("admin.calendars.wizard.source.unreachable"))
       end
     end
+
+    context "when the Eventbrite parser's RestClient fetch times out" do
+      # Eventbrite imports via RestClient (EventbriteSDK), not read_http_source,
+      # so its timeouts are RestClient::Exceptions::ReadTimeout — not Net:: errors
+      # — and propagate through the importer task to this job-level backstop (#3100).
+      let(:calendar) do
+        create(:eventbrite_calendar, importer_mode: "eventbrite")
+          .tap { |c| c.update!(calendar_state: "in_queue") }
+      end
+
+      before do
+        # The Eventbrite source page is reachable (validate_feed! passes)...
+        stub_request(:get, calendar.source).to_return(status: 200, body: "ok")
+        # ...but the Eventbrite API fetch (RestClient via EventbriteSDK) times out.
+        allow(EventbriteSDK::Organizer).to receive(:retrieve)
+          .and_raise(RestClient::Exceptions::ReadTimeout)
+      end
+
+      it "does not raise and marks the source unreachable" do
+        expect { perform_import }.not_to raise_error
+
+        expect(calendar.reload.calendar_state).to eq("bad_source")
+        expect(calendar.critical_error)
+          .to eq(I18n.t("admin.calendars.wizard.source.unreachable"))
+      end
+    end
   end
 
   describe "non-network errors" do


### PR DESCRIPTION
## Summary

`Net::ReadTimeout`, `Net::OpenTimeout`, and `OpenSSL::SSL::SSLError` from slow or unreachable external calendar feeds were surfacing as unhandled exceptions in AppSignal (incidents #214, #266, #274). These are expected for a system that scrapes third-party feeds, so they create noise rather than signalling a real bug.

This implements the issue's recommended **Option 1**: catch the timeout/TLS errors and mark the calendar as "source unreachable" using the importer's existing error-recording mechanism, instead of raising to the error tracker.

## Changes

- **`Parsers::Base.read_http_source`** — rescue the three error classes and convert them to the existing `InaccessibleFeed` exception (the established "source unreachable" path), mirroring the existing `SocketError` handling. This is the single HTTP chokepoint used by most parsers and by admin wizard source validation, so both benefit.
- **`CalendarImporterJob`** — add a `rescue_from` backstop for the same three classes, covering parsers that fetch HTTP by other means (API-based parsers via `ApiBase`, and ResidentAdvisor's `HTTParty.post`). Routes through the existing `report_bad_source_error` → `flag_bad_source!`.
- Both paths log a warning and mark the calendar `bad_source`, so admins can see which feeds are unreachable.
- New i18n key `admin.calendars.wizard.source.unreachable` for the user-facing message (no hardcoded strings).
- **Non-network exceptions are not swallowed** (verified by a spec asserting an unrelated `KeyError` still propagates).

## Testing

New `spec/jobs/calendar_importer_job_spec.rb` (type: `:job`, fully transactional, all HTTP stubbed via WebMock):
- stubbing the HTTP fetch to raise `Net::ReadTimeout` / `Net::OpenTimeout` / `OpenSSL::SSL::SSLError` → job does not raise and the calendar is marked `bad_source` with the unreachable message;
- a timeout escaping a parser that bypasses `read_http_source` is caught by the job-level backstop;
- a logged warning is asserted;
- a non-network `StandardError` still propagates.

The spec fails before this change (all 6 timeout cases raise) and passes after. Existing `parser_base_spec`, `calendar_importer_spec`, and `calendar_importer_task_spec` still pass.

> Note: a follow-up is worth doing for the Eventbrite parser, which uses `RestClient` (timeouts wrapped in `RestClient::Exceptions::*`, not `Net::*`) and so isn't covered here — out of scope for the three error classes named in this issue.

Closes #3100

🤖 Generated with [Claude Code](https://claude.com/claude-code)