### PR TITLE
Fix #3058: Guard My Permissions icon mapping for neighbourhood admins

### DIFF
--- a/spec/components/admin/users/profile_tab_permissions_spec.rb
+++ b/spec/components/admin/users/profile_tab_permissions_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression guard for #3058 ("My Permissions" icons scrambled for neighbourhood
+# admins). Each permission card hardcodes its own icon, so this spec pins the
+# icon-to-card mapping and the rendering order so they cannot drift apart.
+RSpec.describe Views::Admin::Users::ProfileTabPermissions, type: :component do
+  # Canonical SVG path data for each permission icon, read straight from the
+  # icon set so the spec keeps passing if the icon artwork is updated while
+  # still catching a wrong icon being wired to the wrong card.
+  def icon_path(name)
+    entry = SvgIconsHelper::ICONS[name]
+    entry.is_a?(Hash) ? entry[:path] : entry
+  end
+
+  def profile_label(key)
+    I18n.t("admin.users.profile.#{key}")
+  end
+
+  # The <path> d= value of every icon rendered inside a permission card header,
+  # in document (top-to-bottom) order.
+  def rendered_header_icon_paths
+    page.all("div.bg-base-200\\/50 > div.flex.items-center svg > path").map { |p| p["d"] }
+  end
+
+  def render_for(user)
+    allow_any_instance_of(ApplicationController)
+      .to receive(:current_user).and_return(user)
+
+    template = ActionView::Base.empty
+    form = ActionView::Helpers::FormBuilder.new(:user, user, template, {})
+    render_inline(described_class.new(form: form))
+  end
+
+  context "with a neighbourhood admin who admins all resource types" do
+    let(:user) do
+      create(:neighbourhood_admin).tap do |u|
+        u.partners << create(:partner)
+        u.tags << create(:partnership)
+        u.sites << create(:site)
+        u.reload
+      end
+    end
+
+    before { render_for(user) }
+
+    it "renders one card per assigned resource type, in order" do
+      titles = page.all("div.bg-base-200\\/50 h4").map(&:text)
+      expect(titles).to eq(
+        [
+          profile_label("your_partners"),
+          profile_label("your_neighbourhoods"),
+          profile_label("your_partnerships"),
+          profile_label("your_sites")
+        ]
+      )
+    end
+
+    it "shows each card's icon next to its matching heading, in order" do
+      expect(rendered_header_icon_paths).to eq(
+        [
+          icon_path(:partner),
+          icon_path(:map_pin),
+          icon_path(:partnership),
+          icon_path(:site)
+        ]
+      )
+    end
+  end
+
+  context "with a neighbourhood admin who only has a neighbourhood" do
+    let(:user) { create(:neighbourhood_admin) }
+
+    before { render_for(user) }
+
+    it "renders only the neighbourhoods card with the map pin icon" do
+      titles = page.all("div.bg-base-200\\/50 h4").map(&:text)
+      expect(titles).to eq([profile_label("your_neighbourhoods")])
+      expect(rendered_header_icon_paths).to eq([icon_path(:map_pin)])
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a component spec for `Views::Admin::Users::ProfileTabPermissions` (the "Your Profile → My Permissions" tab) that pins the icon-to-card mapping and the card ordering for neighbourhood admins.

Closes #3058

## Background / investigation

The issue (reported 2026-03-18) says the permission icons display **scrambled / out of order** for neighbourhood admins.

I could not reproduce a scramble in the **current** code. I verified the rendered output four ways:

- **Component render** (`render_inline`) for a neighbourhood admin with partners, neighbourhoods, partnerships and sites.
- **Full request stack** (`GET /admin/profile` through controller + layout) — cards render in order Partners → Neighbourhoods → Partnerships → Sites, each with the correct icon path and colour.
- **Raw HTTP response body** — the filled partner/partnership icons emit correct camelCase `viewBox="0 0 36 36"` (5×) alongside `0 0 24 24` (21×); no malformed/lowercased `viewbox`.
- **Direct SVG → PNG render** of the partner and partnership icons (with and without `fill-rule="evenodd"`) — both render correctly; no fill-rule corruption.

Each card hardcodes its own icon (there is no index/zip array mapping that could drift), so there is no scramble mechanism in the present code. The original problem was most likely resolved by the admin Phlex migration and the later custom-icon work (`dc0918af`, 2026-04-15), which postdates the report.

Rather than invent a change against a bug that isn't present, this PR adds a **regression guard** so the mapping/order can't silently break in future. The spec was confirmed to have teeth: temporarily wiring the partnerships card to the `:map_pin` icon makes the "icons in correct order" example fail.

## Spec design

- Reads canonical SVG paths from `SvgIconsHelper::ICONS`, so it keeps passing if icon artwork is updated but still catches a wrong icon wired to a card.
- Asserts only the **header** icons via a direct-child selector (`div.bg-base-200/50 > div.flex.items-center svg > path`), which excludes the badge-list item icons (verified: 4 header matches out of 8 total SVGs).
- Covers two cases: a neighbourhood admin with all four resource types, and one with only a neighbourhood.

## Note for maintainer

Pixel-level visual confirmation is out of scope for autonomous specs — **please eyeball the rendered "My Permissions" tab** for a neighbourhood admin to confirm the icons look right in the browser, in case the reported scramble was environment/asset-cache specific.

## Testing

```
bundle exec rspec spec/components/admin/users/profile_tab_permissions_spec.rb
# 3 examples, 0 failures
```
RuboCop clean.