### PR TITLE
Fix #2144: stop admin sign-in warning persisting onto public pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_by_ip if Rails.env.staging?
   protect_from_forgery with: :exception
+  before_action :discard_stale_auth_flash, unless: :devise_controller?
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_supporters
   before_action :set_navigation
@@ -26,6 +27,21 @@ class ApplicationController < ActionController::Base
 
   def set_appsignal_namespace
     Appsignal::Transaction.current.set_namespace('public')
+  end
+
+  # Devise sets a persistent flash[:alert] (e.g. "You need to sign in...") when
+  # an unauthenticated user is bounced away from /admin. That message is only
+  # relevant on the sign-in page it redirects to. If the user instead navigates
+  # to a public site page, the flash would otherwise persist and be shown
+  # there (see #2144), so drop it.
+  #
+  # Scoped to the public site: admin pages legitimately surface flash[:alert]
+  # (e.g. Admin::PartnersController#user_not_authorized) and Devise controllers,
+  # which render the sign-in warning, are excluded by the before_action filter.
+  def discard_stale_auth_flash
+    return if request.subdomain == Site::ADMIN_SUBDOMAIN
+
+    flash.delete(:alert) if flash[:alert].present?
   end
 
   def user_not_authorized

--- a/spec/requests/admin/authentication_flash_spec.rb
+++ b/spec/requests/admin/authentication_flash_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression test for #2144: the "you need to sign in" flash warning that is
+# shown when an unauthenticated user tries to access /admin must NOT persist
+# onto the next page they visit.
+RSpec.describe "Admin authentication flash", type: :request do
+  let!(:default_site) { create_default_site }
+  let!(:published_site) { create(:site, is_published: true) }
+
+  let(:warning_message) do
+    I18n.t("devise.failure.unauthenticated")
+  end
+
+  describe "unauthenticated access to /admin" do
+    it "redirects to the sign in page" do
+      get "http://#{admin_host}"
+      expect(response).to redirect_to("http://#{admin_host}/users/sign_in")
+    end
+
+    it "sets the warning flash for the redirect target" do
+      get "http://#{admin_host}"
+      expect(flash[:danger] || flash[:alert]).to eq(warning_message)
+    end
+
+    it "does not persist the warning flash onto the next visited page" do
+      # 1. Unauthenticated visit to admin sets the warning flash and redirects.
+      get "http://#{admin_host}"
+      expect(flash[:danger] || flash[:alert]).to eq(warning_message)
+
+      # 2. Instead of following the redirect to the sign-in page, the user
+      #    navigates to a different page (e.g. a public site). The warning
+      #    must not still be present on that request.
+      get "http://#{published_site.slug}.lvh.me/robots.txt"
+      expect(response).to be_successful
+      expect(flash[:danger]).to be_blank
+      expect(flash[:alert]).to be_blank
+    end
+  end
+
+  # The fix must not strip flash[:alert] that admin pages set for themselves
+  # (e.g. a Pundit "Unable to access" message), since admin pages render it.
+  describe "admin pages keep their own alert flash" do
+    let(:citizen) { create(:citizen_user) }
+    let!(:partner) { create(:partner) }
+
+    before { sign_in citizen }
+
+    it "preserves an admin-set alert across an admin request" do
+      # A citizen lacks permission, so Pundit sets flash[:alert] = "Unable to
+      # access" and redirects to the admin partners index.
+      get "http://#{admin_host}/partners/#{partner.id}/edit"
+      expect(flash[:alert]).to eq("Unable to access")
+
+      # The alert must survive to the admin index it redirects to. Request the
+      # JSON datatable variant (it skips the asset-heavy HTML layout).
+      get "http://#{admin_host}/partners",
+          params: { draw: "1", start: "0", length: "25" },
+          headers: { "Accept" => "application/json" }
+      expect(flash[:alert]).to eq("Unable to access")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When an unauthenticated user visits `admin.placecal.org`, Devise's `authenticate_user!` bounces them away and sets a persistent `flash[:alert]` ("You need to sign in or sign up before continuing."). That message is only meant for the sign-in page the user is redirected to, but because it is a *persistent* flash it survived onto the next page the user actually visited (e.g. `norwich.placecal.org`).

Worse, requests that never read the flash during rendering (plain-text endpoints like `/robots.txt`, ICS feeds, and the intermediate auth redirects) don't sweep it, so it could linger across several requests before surfacing on an unrelated page.

## Fix

A `before_action :discard_stale_auth_flash` on `ApplicationController` drops a leftover Devise auth `flash[:alert]` on public-site requests.

- **Devise controllers are excluded** (`unless: :devise_controller?`) so the warning still renders on the sign-in page it is meant for.
- **Admin pages are skipped** (subdomain guard) so admin-set alerts — e.g. Pundit's "Unable to access" from `Admin::PartnersController#user_not_authorized` — are preserved and still shown.

Only Devise's failure redirect produces a bare `:alert` reaching a public page (the app's own public flashes use `:danger`/`:warning`/etc., and Devise controllers convert `:alert` → `:danger` via `Users::AuthCommon#patch_flash`).

## Tests

`spec/requests/admin/authentication_flash_spec.rb` covers:
- the warning is still set on the auth-failure redirect,
- it does **not** persist onto the next public page visited (the bug),
- admin pages keep their own `flash[:alert]` (guards against over-stripping).

Closes #2144
