### PR TITLE
Fix Renovate bundler update failures (rangeStrategy) and invalid manager rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,13 +19,17 @@
 	},
 	"packageRules": [
 		{
+			"matchManagers": ["bundler"],
+			"rangeStrategy": "update-lockfile"
+		},
+		{
 			"matchDatasources": ["docker"],
 			"matchPackageNames": ["postgres"],
 			"matchCurrentVersion": "13.4",
 			"allowedVersions": "13.4"
 		},
 		{
-			"matchManagers": ["npm", "rubygems"],
+			"matchDatasources": ["npm", "rubygems"],
 			"minimumReleaseAge": "7 days"
 		},
 		{


### PR DESCRIPTION
## Problem

Renovate has been failing on this repo with a persistent repository problem on the Mend dashboard:

> ⚠️ WARN: Error updating branch: update failure

Two **bundler** branches fail on every run:

- `renovate/pin-dependencies` — pinning `axe-core-rspec` (`'~> 4.8'` → `4.11.3`)
- `renovate/ruby-on-rails-packages` — pinning `rails` (`'~> 8.0'` → `8.1.3`)

## Root cause

`renovate.json` sets `"rangeStrategy": "pin"` globally. That's fine for npm (those updates succeed), but for the **bundler** manager it tries to rewrite the Gemfile's pessimistic constraints (e.g. `gem 'rails', '~> 8.0'`) into exact versions *inside the Gemfile*. Renovate's bundler manager can't do that replacement — it logs `Value is not updated` → `Error updating branch: update failure`. Because the failure happens at the file-update stage (before any `bundle lock`), the branches never get created and the dashboard stays red.

## Fix

Override `rangeStrategy` to `update-lockfile` for the **bundler** manager only. For a Rails *application*, the idiomatic approach is to keep loose constraints in the `Gemfile` and let `Gemfile.lock` carry the exact pinned versions. `update-lockfile` updates the lockfile and only edits the `Gemfile` when a new version falls outside the existing range. `pin` still applies to npm and every other manager, so nothing else changes.

## Bonus fix

While validating, `renovate-config-validator` flagged a second, pre-existing error: the `minimumReleaseAge` rule used `matchManagers: ["npm", "rubygems"]`, but `rubygems` is a **datasource**, not a manager (the Ruby manager is `bundler`). The rule was invalid, so the 7-day release-age delay wasn't reliably applying to Ruby gems. Switched to `matchDatasources: ["npm", "rubygems"]` — which is what those values were always meant to be — so the delay now correctly covers both npm packages and Ruby gems.

## Verification

`renovate-config-validator` passes:

```
 INFO: Validating renovate.json
 INFO: Config validated successfully
```

(Before this change it reported `Configuration Error … You have included an unsupported manager in a package rule. Your list: npm,rubygems`.)

`prettier --check renovate.json` is clean.
