### PR TITLE
Pin remaining GitHub Action digests to stop Renovate loop

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -34,7 +34,7 @@ jobs:
           bundler-cache: true
           cache-version: 3
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".node-version"
           cache: yarn
@@ -112,7 +112,7 @@ jobs:
         with:
           chrome-version: stable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".node-version"
           cache: yarn
@@ -214,7 +214,7 @@ jobs:
       REGISTRY: ghcr.io
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set deploy destination
         id: dest


### PR DESCRIPTION
## Problem

Renovate has been stuck opening repeated identical "Pin dependencies" PRs (#3216, #3217, #3218, and the now-stuck #3219).

Three action references in `.github/workflows/test-and-deploy.yml` were still on the floating `@v6` tag:
- `actions/setup-node@v6` (lint job, line 37)
- `actions/setup-node@v6` (test job, line 115)
- `actions/checkout@v6` (deploy job, line 217)

With `helpers:pinGitHubActionDigests` enabled, each Renovate scan finds an unpinned `@v6`, opens a PR pinning a single line, automerges, then the next scan finds the next one. Renovate's automerge then self-disabled ("a matching PR was automerged previously"), leaving #3219 open indefinitely.

## Fix

Pin all remaining references to their commit digests so there is nothing left for Renovate to pin:
- `actions/setup-node` → `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6`
- `actions/checkout` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` (same digest already used elsewhere in the file)

Once merged, #3219 can be closed and the loop ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)