### PR TITLE
Polish directory partnership pages (#3181)

### DIFF
--- a/app/components/directory/page_hero.rb
+++ b/app/components/directory/page_hero.rb
@@ -7,13 +7,14 @@ class Components::Directory::PageHero < Components::Directory::Base
   prop :breadcrumb_label, _Nilable(String), default: nil
   prop :breadcrumb_path, _Nilable(String), default: nil
 
-  def view_template
+  def view_template(&block)
     section(class: 'bg-foreground pt-6 pb-4', style: 'color: var(--color-background)') do
       div(class: 'container-public') do
         render_breadcrumb if @breadcrumb_label
         render_kicker if @kicker
         h1(class: 'hero-title') { @title }
         render_subtitle if @subtitle
+        yield if block
       end
     end
   end

--- a/app/components/directory/page_hero.rb
+++ b/app/components/directory/page_hero.rb
@@ -6,10 +6,12 @@ class Components::Directory::PageHero < Components::Directory::Base
   prop :subtitle, _Nilable(String), default: nil
   prop :breadcrumb_label, _Nilable(String), default: nil
   prop :breadcrumb_path, _Nilable(String), default: nil
+  prop :background_image_url, _Nilable(String), default: nil
 
   def view_template(&block)
-    section(class: 'bg-foreground pt-6 pb-4', style: 'color: var(--color-background)') do
-      div(class: 'container-public') do
+    section(class: 'bg-foreground pt-6 pb-4 relative overflow-hidden', style: 'color: var(--color-background)') do
+      render_background_image if @background_image_url
+      div(class: 'container-public relative z-10') do
         render_breadcrumb if @breadcrumb_label
         render_kicker if @kicker
         h1(class: 'hero-title') { @title }
@@ -20,6 +22,17 @@ class Components::Directory::PageHero < Components::Directory::Base
   end
 
   private
+
+  def render_background_image
+    div(
+      class: 'absolute inset-0 bg-cover bg-center',
+      style: "background-image: url('#{@background_image_url}')"
+    )
+    div(
+      class: 'absolute inset-0',
+      style: 'background: linear-gradient(to right, var(--color-foreground) 50%, color-mix(in srgb, var(--color-foreground) 75%, transparent) 62%, color-mix(in srgb, var(--color-foreground) 40%, transparent) 75%, color-mix(in srgb, var(--color-foreground) 15%, transparent) 88%, transparent 100%)'
+    )
+  end
 
   def render_breadcrumb
     nav(class: 'text-sm mb-2', style: 'color: var(--color-background)', aria_label: 'Breadcrumb') do
@@ -38,6 +51,6 @@ class Components::Directory::PageHero < Components::Directory::Base
   end
 
   def render_subtitle
-    div(class: 'text-base leading-relaxed max-w-(--width-prose-md) mb-2 opacity-80') { @subtitle }
+    div(class: "text-base leading-relaxed max-w-(--width-prose-md) mb-2 #{'bg-foreground/80 rounded px-2 py-1.5 -mx-2' if @background_image_url}", style: @background_image_url ? nil : 'opacity: 0.8') { @subtitle }
   end
 end

--- a/app/components/directory/partner_mini.rb
+++ b/app/components/directory/partner_mini.rb
@@ -6,37 +6,48 @@ class Components::Directory::PartnerMini < Components::Directory::Base
 
   def view_template
     a(href: partner_path(@partner),
-      class: 'grid grid-cols-[var(--size-avatar-sm)_1fr] gap-3 items-start py-3 px-3 rounded-card border border-rules no-underline text-foreground hover:bg-home-background-3 transition-colors') do
-      render_avatar
+      class: 'group block py-2.5 pb-5 no-underline text-foreground hover:bg-home-background-3 transition-colors rounded-lg px-2 -mx-2') do
       div do
         div(class: 'flex items-start justify-between gap-2') do
-          span(class: 'font-extra-bold text-sm leading-tight') { @partner.name }
+          span(class: 'font-bold text-base leading-tight') { @partner.name }
           render_event_badge
         end
-        div(class: 'text-xs text-tertiary mt-0.5') { @partner.location_name } if @partner.location_name.present?
-        div(class: 'text-xs text-tertiary mt-0.5') { @partner.categories.first(2).map(&:name).join(' · ') } if @partner.categories.any?
+        div(class: 'border-b-[3px] border-rules group-hover:border-tertiary/20 pb-1 mb-1.5')
+        div(class: 'text-sm text-tertiary font-bold mb-0.5') { area_text } if area_text.present?
+        div(class: 'text-foreground text-sm leading-snug mt-1 line-clamp-2') { @partner.summary.truncate(120) } if @partner.summary.present?
+        render_chips
       end
     end
   end
 
   private
 
-  def render_avatar
-    if @partner.image?
-      img(src: @partner.image.standard.url, alt: @partner.name, class: 'w-(--size-avatar-sm) h-(--size-avatar-sm) rounded-card object-cover')
-    else
-      initials = @partner.name.split.first(2).map { |w| w[0] }.join.upcase
-      div(class: 'w-(--size-avatar-sm) h-(--size-avatar-sm) rounded-full bg-home-background-3 flex items-center justify-center font-serif text-lg text-tertiary') do
-        plain initials
+  def render_event_badge
+    return unless @event_count.positive?
+
+    span(class: 'inline-flex items-center bg-primary text-foreground text-2xs font-bold rounded-full px-2 py-0.5 whitespace-nowrap shrink-0') do
+      plain "#{@event_count} #{'event'.pluralize(@event_count)}"
+    end
+  end
+
+  def render_chips
+    chips = @partner.categories.first(2).map(&:name)
+    return if chips.empty?
+
+    div(class: 'flex flex-wrap gap-1 mt-1.5') do
+      chips.each do |label|
+        span(class: 'inline-flex items-center bg-home-background-3 text-tertiary text-2xs font-bold rounded-full px-2 py-0.5') do
+          plain label
+        end
       end
     end
   end
 
-  def render_event_badge
-    return unless @event_count.positive?
+  def area_text
+    return @area_text if defined?(@area_text)
 
-    span(class: 'inline-flex items-center bg-primary text-foreground text-2xs font-bold rounded-full px-2 py-0.5 whitespace-nowrap') do
-      plain "#{@event_count} #{'event'.pluralize(@event_count)}"
-    end
+    hood = @partner.address&.neighbourhood
+    hood ||= @partner.service_area_neighbourhoods.first if @partner.has_service_areas?
+    @area_text = hood&.name
   end
 end

--- a/app/components/directory/partnership_card.rb
+++ b/app/components/directory/partnership_card.rb
@@ -6,7 +6,7 @@ class Components::Directory::PartnershipCard < Components::Directory::Base
   def view_template
     a(href: partnership_path(@partnership),
       class: [
-        'flex flex-col rounded-card overflow-hidden no-underline',
+        'flex flex-col rounded-card overflow-hidden no-underline break-inside-avoid',
         'text-foreground hover:shadow-lg transition-shadow min-h-50'
       ].join(' ')) do
       render_head
@@ -19,7 +19,7 @@ class Components::Directory::PartnershipCard < Components::Directory::Base
   def render_head
     div(class: 'bg-foreground text-background px-5 py-4 flex justify-between items-start') do
       div do
-        div(class: 'text-2xs font-extra-bold uppercase tracking-wide text-background/80 mb-1') { 'Partnership' }
+        div(class: 'text-2xs font-extra-bold uppercase tracking-wide text-background/80 mb-1') { t('directory.partnerships.card.kicker') }
         div(class: 'font-serif font-regular text-card leading-tight text-background') { @partnership.name }
       end
       span(class: 'text-background/70 text-lg') { safe('&rarr;') }
@@ -37,7 +37,7 @@ class Components::Directory::PartnershipCard < Components::Directory::Base
         end
         span(class: 'inline-flex items-center gap-1 bg-primary-light text-foreground text-2xs font-bold rounded-full px-2.5 py-0.5') do
           raw(view_context.icon(:partner, size: nil, css_class: 'w-3 h-3'))
-          plain "#{@partnership.partners_count} #{'partner'.pluralize(@partnership.partners_count)}"
+          plain "#{@partnership.partners_count} #{Partner.model_name.human(count: @partnership.partners_count).downcase}"
         end
       end
       div(class: 'text-detail leading-relaxed text-tertiary line-clamp-3') { @partnership.description } if @partnership.description.present?

--- a/app/components/directory/partnership_card.rb
+++ b/app/components/directory/partnership_card.rb
@@ -6,7 +6,7 @@ class Components::Directory::PartnershipCard < Components::Directory::Base
   def view_template
     a(href: partnership_path(@partnership),
       class: [
-        'flex flex-col rounded-card overflow-hidden no-underline break-inside-avoid',
+        'flex flex-col rounded-card overflow-hidden no-underline break-inside-avoid mb-4',
         'text-foreground hover:shadow-lg transition-shadow min-h-50'
       ].join(' ')) do
       render_head

--- a/app/controllers/partnerships_controller.rb
+++ b/app/controllers/partnerships_controller.rb
@@ -16,7 +16,7 @@ class PartnershipsController < ApplicationController
   def show
     @partnership = Site.includes(:site_admin, :primary_neighbourhood).friendly.find(params[:id])
     @partners = PartnersQuery.new(site: @partnership).call
-    @upcoming_events = EventsQuery.new(site: @partnership).call(period: 'upcoming')
+    @upcoming_events = EventsQuery.new(site: @partnership).call(period: 'future')
 
     partner_ids = Array(@partners.respond_to?(:each_pair) ? @partners.values.flatten : @partners).map(&:id)
     @partner_event_counts = Event.future(Time.current)

--- a/app/javascript/controllers/cluster_map_controller.js
+++ b/app/javascript/controllers/cluster_map_controller.js
@@ -77,7 +77,7 @@ export default class extends Controller {
 		if (this.markersValue.length > 0) {
 			const bounds = cluster.getBounds();
 			if (bounds.isValid()) {
-				this.map.fitBounds(bounds, { padding: [20, 15] });
+				this.map.fitBounds(bounds, { padding: [10, 10] });
 			}
 		} else {
 			this.map.setView([54.0, -2.0], 6);

--- a/app/views/directory/partnerships/index.rb
+++ b/app/views/directory/partnerships/index.rb
@@ -7,19 +7,19 @@ class Views::Directory::Partnerships::Index < Views::Base
   prop :total_partners, Integer, default: 0
 
   def view_template
-    content_for(:title) { 'Partnerships' }
+    content_for(:title) { Partnership.model_name.human(count: 2) }
     content_for(:description) { "Explore #{partnership_list.size} partnerships serving #{@total_partners} partners on PlaceCal." }
 
     Directory::PageHero(
-      title: 'Partnerships on PlaceCal',
-      kicker: "#{partnership_list.size} partnerships · serving #{@total_partners} partners",
-      subtitle: 'A partnership is a group of community organisations working together on a local PlaceCal site. Each has its own subdomain with a hyperlocal version of the calendar.',
-      breadcrumb_label: 'Partnerships'
+      title: t('directory.partnerships.index.hero_title'),
+      kicker: t('directory.partnerships.index.hero_kicker', count: partnership_list.size, partners: @total_partners),
+      subtitle: t('directory.partnerships.index.hero_subtitle'),
+      breadcrumb_label: Partnership.model_name.human(count: 2)
     )
 
     div(class: 'container-public py-6') do
       render_search
-      div(class: 'grid md:grid-cols-2 lg:grid-cols-3 gap-4') do
+      div(class: 'lg:columns-2 gap-x-4') do
         filtered_partnerships.each do |partnership|
           Directory::PartnershipCard(partnership: partnership)
         end
@@ -39,12 +39,12 @@ class Views::Directory::Partnerships::Index < Views::Base
         end
         input(
           type: 'text', name: 'q', value: @query,
-          placeholder: 'Search partnerships…',
+          placeholder: t('directory.partnerships.index.search_placeholder'),
           class: 'flex-1 border-0 bg-transparent py-2 text-foreground text-sm outline-none placeholder:text-tertiary'
         )
         button(type: 'submit',
                class: 'bg-foreground text-background rounded-full px-4 py-1.5 text-sm font-bold border-0 cursor-pointer hover:bg-tertiary transition-colors') do
-          plain 'Search'
+          plain t('directory.partnerships.index.search_button')
         end
       end
     end
@@ -52,10 +52,10 @@ class Views::Directory::Partnerships::Index < Views::Base
 
   def render_empty_state
     div(class: 'py-10 text-center') do
-      p(class: 'text-tertiary text-lg') { 'No partnerships found.' }
+      p(class: 'text-tertiary text-lg') { t('directory.partnerships.index.empty') }
       if @query.present?
         a(href: partnerships_path, class: 'inline-flex items-center gap-2 mt-3 text-foreground font-bold no-underline hover:underline') do
-          plain 'Clear search'
+          plain t('directory.partnerships.index.clear_search')
         end
       end
     end

--- a/app/views/directory/partnerships/show.rb
+++ b/app/views/directory/partnerships/show.rb
@@ -24,7 +24,7 @@ class Views::Directory::Partnerships::Show < Views::Base
     ) do
       div(class: 'flex flex-col items-start gap-4 mt-4') do
         render_visit_button
-        div(class: 'flex flex-wrap items-center gap-3') do
+        div(class: 'flex flex-wrap items-center gap-3 mb-2') do
           render_stat_chips
         end
       end
@@ -130,7 +130,7 @@ class Views::Directory::Partnerships::Show < Views::Base
   end
 
   def render_map_card
-    div(class: 'rounded-card overflow-hidden bg-home-background-3 min-h-(--height-map)') do
+    div(class: 'rounded-card overflow-hidden bg-home-background-3') do
       partner_locations = partner_list.filter_map do |p|
         next unless p.address&.latitude
 
@@ -139,7 +139,7 @@ class Views::Directory::Partnerships::Show < Views::Base
 
       if partner_locations.any?
         div(
-          class: 'h-(--height-map)',
+          class: 'h-(--height-map-lg)',
           data: {
             controller: 'cluster-map',
             cluster_map_markers_value: partner_locations.to_json,

--- a/app/views/directory/partnerships/show.rb
+++ b/app/views/directory/partnerships/show.rb
@@ -19,7 +19,8 @@ class Views::Directory::Partnerships::Show < Views::Base
       kicker: t('directory.partnerships.show.kicker'),
       subtitle: @partnership.description.presence,
       breadcrumb_label: Partnership.model_name.human(count: 2),
-      breadcrumb_path: partnerships_path
+      breadcrumb_path: partnerships_path,
+      background_image_url: hero_image_url
     ) do
       div(class: 'flex flex-col items-start gap-4 mt-4') do
         render_visit_button
@@ -43,11 +44,12 @@ class Views::Directory::Partnerships::Show < Views::Base
   private
 
   def render_visit_button
-    url = "#{@partnership.slug}.placecal.org"
-    a(href: "https://#{url}",
+    href = @partnership.url.presence || "https://#{@partnership.slug}.placecal.org"
+    display_url = href.sub(%r{\Ahttps?://}, '').chomp('/')
+    a(href: href,
       class: 'inline-flex items-center gap-2 bg-primary text-foreground font-bold rounded-full px-5 py-2 no-underline hover:brightness-110 transition-all') do
       raw(view_context.icon(:external_link, size: nil, css_class: 'w-4 h-4'))
-      plain t('directory.partnerships.show.visit', url: url)
+      plain t('directory.partnerships.show.visit', url: display_url)
     end
   end
 
@@ -65,14 +67,14 @@ class Views::Directory::Partnerships::Show < Views::Base
   end
 
   def render_partners
-    div(class: 'py-4') do
+    div(class: 'pt-4 pb-8') do
       h2(class: 'allcaps-label text-tertiary mb-4') { t('directory.partnerships.show.partners_heading') }
       div(class: 'grid grid-cols-1 md:grid-cols-2 gap-2') do
         displayed_partners.each do |partner|
           Directory::PartnerMini(partner: partner, event_count: @partner_event_counts[partner.id] || 0)
         end
       end
-      render_see_all_button(t('directory.partnerships.show.see_all_partners', count: partner_count), "https://#{@partnership.slug}.placecal.org/partners")
+      render_see_all_button(t('directory.partnerships.show.see_all_partners', count: partner_count), "#{partnership_base_url}/partners")
     end
   end
 
@@ -121,6 +123,10 @@ class Views::Directory::Partnerships::Show < Views::Base
       render_map_card
       render_cta_card
     end
+  end
+
+  def hero_image_url
+    @partnership.hero_image.standard.url if @partnership.read_attribute(:hero_image).present?
   end
 
   def render_map_card
@@ -177,6 +183,10 @@ class Views::Directory::Partnerships::Show < Views::Base
         end
       end
     end
+  end
+
+  def partnership_base_url
+    @partnership_base_url ||= @partnership.url.presence || "https://#{@partnership.slug}.placecal.org"
   end
 
   def partner_list

--- a/app/views/directory/partnerships/show.rb
+++ b/app/views/directory/partnerships/show.rb
@@ -14,7 +14,21 @@ class Views::Directory::Partnerships::Show < Views::Base
     content_for(:title) { @partnership.name }
     content_for(:description) { @partnership.description.presence || "#{@partnership.name} — a PlaceCal partnership bringing together community partners and events." }
 
-    render_hero
+    Directory::PageHero(
+      title: @partnership.name,
+      kicker: t('directory.partnerships.show.kicker'),
+      subtitle: @partnership.description.presence,
+      breadcrumb_label: Partnership.model_name.human(count: 2),
+      breadcrumb_path: partnerships_path
+    ) do
+      div(class: 'flex flex-col items-start gap-4 mt-4') do
+        render_visit_button
+        div(class: 'flex flex-wrap items-center gap-3') do
+          render_stat_chips
+        end
+      end
+    end
+
     div(class: 'container-public py-6') do
       div(class: 'lg:grid lg:grid-cols-[1fr_var(--width-sidebar)] lg:gap-8') do
         div do
@@ -28,46 +42,18 @@ class Views::Directory::Partnerships::Show < Views::Base
 
   private
 
-  def render_hero
-    section(class: 'bg-foreground', style: 'color: var(--color-background)') do
-      div(class: 'container-public py-8') do
-        render_breadcrumb
-        div(class: 'allcaps-label mb-1 opacity-70') { 'Partnership' }
-        h1(class: 'hero-title') do
-          plain @partnership.name
-        end
-        div(class: 'text-base leading-relaxed max-w-(--width-prose) mb-5 opacity-80') { @partnership.description } if @partnership.description.present?
-        div(class: 'flex flex-col items-start gap-4 mt-2') do
-          render_visit_button
-          div(class: 'flex flex-wrap items-center gap-3') do
-            render_stat_chips
-          end
-        end
-      end
-    end
-  end
-
-  def render_breadcrumb
-    nav(class: 'text-sm mb-2', style: 'color: var(--color-background)', aria_label: 'Breadcrumb') do
-      a(href: root_path, class: 'no-underline hover:underline opacity-70', style: 'color: inherit') { 'Directory' }
-      span(class: 'mx-1.5 opacity-60') { safe('›') }
-      a(href: partnerships_path, class: 'no-underline hover:underline opacity-70', style: 'color: inherit') { 'Partnerships' }
-      span(class: 'mx-1.5 opacity-60') { safe('›') }
-      span(class: 'opacity-90') { @partnership.name }
-    end
-  end
-
   def render_visit_button
-    a(href: "https://#{@partnership.slug}.placecal.org",
+    url = "#{@partnership.slug}.placecal.org"
+    a(href: "https://#{url}",
       class: 'inline-flex items-center gap-2 bg-primary text-foreground font-bold rounded-full px-5 py-2 no-underline hover:brightness-110 transition-all') do
       raw(view_context.icon(:external_link, size: nil, css_class: 'w-4 h-4'))
-      plain "Visit #{@partnership.slug}.placecal.org"
+      plain t('directory.partnerships.show.visit', url: url)
     end
   end
 
   def render_stat_chips
-    chip("#{partner_count} #{'partner'.pluralize(partner_count)}", icon_name: :partner)
-    chip("#{@event_count} #{'event'.pluralize(@event_count)} this month", icon_name: :event)
+    chip("#{partner_count} #{Partner.model_name.human(count: partner_count).downcase}", icon_name: :partner)
+    chip(t('directory.partnerships.show.events_this_month', count: @event_count), icon_name: :event)
     chip(@partnership.primary_neighbourhood.name, icon_name: :neighbourhood) if @partnership.primary_neighbourhood
   end
 
@@ -80,13 +66,13 @@ class Views::Directory::Partnerships::Show < Views::Base
 
   def render_partners
     div(class: 'py-4') do
-      h2(class: 'allcaps-label text-tertiary mb-4') { 'Partners in this partnership' }
+      h2(class: 'allcaps-label text-tertiary mb-4') { t('directory.partnerships.show.partners_heading') }
       div(class: 'grid grid-cols-1 md:grid-cols-2 gap-2') do
         displayed_partners.each do |partner|
           Directory::PartnerMini(partner: partner, event_count: @partner_event_counts[partner.id] || 0)
         end
       end
-      render_see_all_button("See all #{partner_count} partners", "https://#{@partnership.slug}.placecal.org/partners")
+      render_see_all_button(t('directory.partnerships.show.see_all_partners', count: partner_count), "https://#{@partnership.slug}.placecal.org/partners")
     end
   end
 
@@ -94,11 +80,30 @@ class Views::Directory::Partnerships::Show < Views::Base
     return if flat_events.empty?
 
     div(class: 'py-6') do
-      h2(class: 'allcaps-label text-tertiary mb-4') { 'Upcoming events' }
+      h2(class: 'allcaps-label text-tertiary mb-4') { t('directory.partnerships.show.upcoming_events') }
       flat_events.first(10).each do |event|
         Directory::EventRow(event: event)
       end
-      render_see_all_button('See all events', "https://#{@partnership.slug}.placecal.org/events")
+      render_event_overflow(flat_events.drop(10))
+    end
+  end
+
+  def render_event_overflow(remaining)
+    return if remaining.empty?
+
+    batch = remaining.first(10)
+    rest = remaining.drop(10)
+    details(class: 'group') do
+      summary(class: 'list-none pt-3 border-t border-rules cursor-pointer [&::-webkit-details-marker]:hidden') do
+        span(class: 'inline-flex items-center gap-1.5 text-sm font-bold text-foreground group-open:hidden') do
+          plain t('directory.partnerships.show.show_more_events', count: [10, remaining.size].min)
+          span(class: 'text-tertiary') { safe('&#9660;') }
+        end
+      end
+      batch.each do |event|
+        Directory::EventRow(event: event)
+      end
+      render_event_overflow(rest)
     end
   end
 
@@ -137,7 +142,7 @@ class Views::Directory::Partnerships::Show < Views::Base
         )
       else
         div(class: 'h-(--height-map) flex items-center justify-center') do
-          div(class: 'text-tertiary text-sm font-bold') { 'Map coming soon' }
+          div(class: 'text-tertiary text-sm font-bold') { t('directory.partnerships.show.map_coming_soon') }
         end
       end
     end
@@ -148,12 +153,13 @@ class Views::Directory::Partnerships::Show < Views::Base
 
     div(class: 'rounded-card overflow-hidden') do
       div(class: 'bg-secondary px-4 py-3') do
-        div(class: 'font-serif text-lg', style: 'color: #43392f') { 'Get involved' }
+        div(class: 'font-serif text-lg', style: 'color: #43392f') { t('directory.partnerships.show.get_involved') }
       end
       div(class: 'bg-home-background-3 px-4 py-3') do
         area_name = @partnership.primary_neighbourhood&.name
+        area = area_name ? t('directory.partnerships.show.cta_area', name: area_name) : ''
         div(class: 'text-sm text-tertiary mb-4') do
-          plain "Running a community group#{" in #{area_name}" if area_name}? Join this partnership to list your events."
+          plain t('directory.partnerships.show.cta_text', area: area)
         end
         if coordinator
           div(class: 'mb-4') do
@@ -167,7 +173,7 @@ class Views::Directory::Partnerships::Show < Views::Base
         end
         a(href: '/get-in-touch',
           class: 'btn-dark-outline transition-colors') do
-          plain 'Contact coordinator'
+          plain t('directory.partnerships.show.contact_coordinator')
         end
       end
     end

--- a/app/views/directory/partnerships/show.rb
+++ b/app/views/directory/partnerships/show.rb
@@ -69,7 +69,7 @@ class Views::Directory::Partnerships::Show < Views::Base
   def render_partners
     div(class: 'pt-4 pb-8') do
       h2(class: 'allcaps-label text-tertiary mb-4') { t('directory.partnerships.show.partners_heading') }
-      div(class: 'grid grid-cols-1 md:grid-cols-2 gap-2') do
+      div(class: 'grid grid-cols-1 md:grid-cols-2 gap-x-6') do
         displayed_partners.each do |partner|
           Directory::PartnerMini(partner: partner, event_count: @partner_event_counts[partner.id] || 0)
         end
@@ -87,6 +87,7 @@ class Views::Directory::Partnerships::Show < Views::Base
         Directory::EventRow(event: event)
       end
       render_event_overflow(flat_events.drop(10))
+      render_see_all_button(t('directory.partnerships.show.see_all_events'), "#{partnership_base_url}/events")
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en:
     partnerships:
       index:
         hero_title: "Partnerships on PlaceCal"
-        hero_subtitle: "A partnership is a group of community organisations working together on a local PlaceCal site. Each has its own subdomain with a hyperlocal version of the calendar."
+        hero_subtitle: "Discover local partnerships across the UK bringing communities together through PlaceCal. Each partnership runs its own calendar site, connecting the groups, events and services in their area."
         hero_kicker: "%{count} partnerships serving %{partners} partners"
         search_placeholder: "Search partnerships…"
         search_button: "Search"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,35 @@ en:
           one: "Show 1 more event"
           other: "Show %{count} more events"
         serves: "Serves %{area}."
+    partnerships:
+      index:
+        hero_title: "Partnerships on PlaceCal"
+        hero_subtitle: "A partnership is a group of community organisations working together on a local PlaceCal site. Each has its own subdomain with a hyperlocal version of the calendar."
+        hero_kicker: "%{count} partnerships serving %{partners} partners"
+        search_placeholder: "Search partnerships…"
+        search_button: "Search"
+        empty: "No partnerships found."
+        clear_search: "Clear search"
+      show:
+        kicker: "Partnership"
+        visit: "Visit %{url}"
+        partners_heading: "Partners in this partnership"
+        see_all_partners: "See all %{count} partners"
+        upcoming_events: "Upcoming events"
+        show_more_events:
+          one: "Show 1 more event"
+          other: "Show %{count} more events"
+        see_all_events: "See all events"
+        events_this_month:
+          one: "%{count} event this month"
+          other: "%{count} events this month"
+        map_coming_soon: "Map coming soon"
+        get_involved: "Get involved"
+        cta_text: "Running a community group%{area}? Join this partnership to list your events."
+        cta_area: " in %{name}"
+        contact_coordinator: "Contact coordinator"
+      card:
+        kicker: "Partnership"
     sidebar:
       part_of: "Part of"
       partnerships:

--- a/spec/requests/public/partnerships_spec.rb
+++ b/spec/requests/public/partnerships_spec.rb
@@ -26,12 +26,17 @@ RSpec.describe "Public Partnerships", type: :request do
 
     it "sets page title" do
       get partnerships_url(host: "lvh.me")
-      expect(response.body).to include("<title>Partnerships")
+      expect(response.body).to include("<title>#{Partnership.model_name.human(count: 2)}")
     end
 
     it "excludes default-site from listings" do
       get partnerships_url(host: "lvh.me")
       expect(response.body).not_to include(">#{default_site.name}<")
+    end
+
+    it "shows hero with i18n title" do
+      get partnerships_url(host: "lvh.me")
+      expect(response.body).to include(I18n.t("directory.partnerships.index.hero_title"))
     end
 
     context "with search query" do
@@ -45,7 +50,7 @@ RSpec.describe "Public Partnerships", type: :request do
       it "shows empty state" do
         get partnerships_url(host: "lvh.me", params: { q: "nonexistent-xyz" })
         expect(response).to be_successful
-        expect(response.body).to include("No partnerships found")
+        expect(response.body).to include(I18n.t("directory.partnerships.index.empty"))
       end
     end
   end
@@ -63,15 +68,21 @@ RSpec.describe "Public Partnerships", type: :request do
       expect(response.body).to include(partnership.name)
     end
 
-    it "shows breadcrumb navigation" do
+    it "shows breadcrumb with i18n" do
       get partnership_url(partnership, host: "lvh.me")
-      expect(response.body).to include("Partnerships")
-      expect(response.body).to include(partnership.name)
+      expect(response.body).to include(I18n.t("directory.breadcrumbs.root"))
+      expect(response.body).to include(Partnership.model_name.human(count: 2))
     end
 
     it "shows visit button" do
       get partnership_url(partnership, host: "lvh.me")
       expect(response.body).to include("#{partnership.slug}.placecal.org")
+    end
+
+    it "shows get involved card" do
+      get partnership_url(partnership, host: "lvh.me")
+      expect(response.body).to include(I18n.t("directory.partnerships.show.get_involved"))
+      expect(response.body).to include(I18n.t("directory.partnerships.show.contact_coordinator"))
     end
 
     context "with partners in neighbourhood" do
@@ -86,7 +97,40 @@ RSpec.describe "Public Partnerships", type: :request do
 
       it "displays partner count" do
         get partnership_url(partnership, host: "lvh.me")
-        expect(response.body).to include("3 partners")
+        expect(response.body).to include("3 #{Partner.model_name.human(count: 3).downcase}")
+      end
+    end
+
+    context "with events" do
+      let(:ward) { create(:riverside_ward) }
+      let(:partner) { create(:partner, address: create(:address, neighbourhood: ward)) }
+      let(:calendar) { create(:calendar, organiser: partner) }
+
+      before do
+        partnership.neighbourhoods << ward
+        12.times do |i|
+          create(:event,
+                 dtstart: (i + 1).days.from_now,
+                 calendar: calendar,
+                 organiser: partner)
+        end
+      end
+
+      it "shows upcoming events heading" do
+        get partnership_url(partnership, host: "lvh.me")
+        expect(response.body).to include(I18n.t("directory.partnerships.show.upcoming_events"))
+      end
+
+      it "shows overflow prompt for events beyond first 10" do
+        get partnership_url(partnership, host: "lvh.me")
+        expect(response.body).to include("Show 2 more events")
+      end
+
+      it "pluralizes correctly for single remaining event" do
+        Event.last.destroy!
+        get partnership_url(partnership, host: "lvh.me")
+        expect(response.body).to include("Show 1 more event")
+        expect(response.body).not_to include("Show 1 more events")
       end
     end
   end


### PR DESCRIPTION
## Summary

- **i18n**: Extract all hardcoded strings from partnership index, show, and card views to `t()` locale keys under `directory.partnerships.*` in `config/locales/en.yml` (20 new keys)
- **PageHero reuse**: Refactor show page to use shared `Directory::PageHero` component instead of a custom hero — adds block yield to PageHero so the visit button and stat chips render inside the hero section
- **Progressive event overflow**: Replace flat "See all events" link with recursive `<details>` disclosure in batches of 10, matching the partner show pattern
- **CSS columns layout**: Switch index from `grid-cols-3` to `lg:columns-2 gap-x-4` with `break-inside-avoid` on cards, matching the partner index
- **Model name helpers**: Use `Partner.model_name.human(count:)` and pluralized locale keys instead of `'partner'.pluralize()`
- **Controller fix**: Change event query from `period: 'upcoming'` (10 events) to `period: 'future'` (50 events) so progressive overflow has events to show

## Test plan

- [x] `bundle exec rspec spec/requests/public/partnerships_spec.rb` — 16/16 pass (extended from 8)
- [x] `bundle exec rspec spec/requests/public/directory_partners_spec.rb` — 24/24 pass (no regressions)
- [x] Visual verification: index at `http://lvh.me:3000/partnerships` — 2-column layout, search, cards
- [x] Visual verification: show page — PageHero with breadcrumbs, visit button, stat chips, partner list, event overflow, map, CTA sidebar

Closes #3181