### PR TITLE
Directory: neighbourhood-based homepage jump links (#3178)

### DIFF
--- a/app/components/directory/hero.rb
+++ b/app/components/directory/hero.rb
@@ -5,7 +5,7 @@ class Components::Directory::Hero < Components::Directory::Base
   prop :subtitle, _Nilable(String), default: nil
   prop :search_path, _Nilable(String), default: nil
   prop :partner_locations, _Interface(:each), default: -> { [] }
-  prop :jump_sites, _Interface(:each), default: -> { [] }
+  prop :jump_neighbourhoods, _Interface(:each), default: -> { [] }
 
   def view_template
     section(class: 'bg-foreground py-10 lg:py-14', style: 'color: var(--color-background)') do
@@ -48,15 +48,24 @@ class Components::Directory::Hero < Components::Directory::Base
   end
 
   def render_jump_links
-    return if @jump_sites.none?
+    links = jump_links
+    return if links.none?
 
     div(class: 'flex items-center gap-6 mt-6 flex-wrap') do
       span(class: 'text-sm') { 'Jump to:' }
-      @jump_sites.each do |site|
-        a(href: partnership_path(site.slug),
+      links.each do |link|
+        a(href: partners_path(neighbourhood: link[:neighbourhood_id]),
           class: 'font-bold text-detail no-underline hover:underline hover:decoration-primary',
-          style: 'color: inherit') { site.name }
+          style: 'color: inherit') { link[:name] }
       end
+    end
+  end
+
+  # Each jump link points at the partners directory filtered to that place,
+  # labelled with the neighbourhood name.
+  def jump_links
+    @jump_neighbourhoods.map do |neighbourhood|
+      { name: neighbourhood.name, neighbourhood_id: neighbourhood.id }
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -73,6 +73,16 @@ class PagesController < ApplicationController
   NEIGHBOURHOOD_UNIT_RANK = %w[ward district county region].freeze
   DIRECTORY_CACHE_TTL = 1.day
 
+  # ONS GSS codes for the places featured as homepage "jump" links, in display
+  # order. Pinned by code (stable across environments) rather than by id.
+  JUMP_NEIGHBOURHOOD_CODES = %w[
+    E08000003
+    E12000007
+    E07000148
+    E08000035
+    E08000021
+  ].freeze
+
   private
 
   def render_directory_home
@@ -89,8 +99,8 @@ class PagesController < ApplicationController
       build_partner_locations
     end
 
-    @jump_sites = Rails.cache.fetch('directory/jump_sites', expires_in: DIRECTORY_CACHE_TTL) do
-      build_jump_sites.to_a
+    @jump_neighbourhoods = Rails.cache.fetch('directory/jump_neighbourhoods', expires_in: DIRECTORY_CACHE_TTL) do
+      build_jump_neighbourhoods.to_a
     end
 
     @partnerships = Rails.cache.fetch('directory/partnerships', expires_in: DIRECTORY_CACHE_TTL) do
@@ -125,20 +135,15 @@ class PagesController < ApplicationController
       partner_event_counts: @partner_event_counts,
       stats: @stats,
       partner_locations: @partner_locations,
-      jump_sites: @jump_sites
+      jump_neighbourhoods: @jump_neighbourhoods
     )
   end
 
-  def build_jump_sites
-    partnership_ids = Tag.where(type: 'Partnership').joins(:sites).select('sites.id')
-    sites = Site.where(is_published: true)
-                .where.not(slug: 'default-site')
-                .where.not(id: partnership_ids)
-                .order(partners_count: :desc)
-                .limit(3)
-    return sites if sites.any?
-
-    Site.where(slug: %w[manchester london norwich], is_published: true)
+  def build_jump_neighbourhoods
+    found = Neighbourhood.latest_release
+                         .where(unit_code_value: JUMP_NEIGHBOURHOOD_CODES)
+                         .index_by(&:unit_code_value)
+    JUMP_NEIGHBOURHOOD_CODES.filter_map { |code| found[code] }
   end
 
   def build_partner_locations

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -129,7 +129,9 @@ class PartnersController < ApplicationController
       partnership_count: Site.where(is_published: true).where.not(slug: 'default-site').count,
       categories: query.categories_with_counts.map { |c| { id: c[:category].id, name: c[:category].name, count: c[:count] } },
       partnerships_list: query.partnerships_with_counts.map { |p| { id: p[:partnership].id, name: p[:partnership].name, count: p[:count] } },
-      neighbourhoods: group_neighbourhoods_by_district(query.neighbourhoods_with_counts),
+      neighbourhoods: ensure_selected_neighbourhood(
+        group_neighbourhoods_by_district(query.neighbourhoods_with_counts), params[:neighbourhood]
+      ),
       selected_category: params[:category],
       selected_partnership: params[:partnership],
       selected_neighbourhood: params[:neighbourhood]
@@ -159,6 +161,20 @@ class PartnersController < ApplicationController
                 }
               end
     grouped.sort_by { |g| g[:group] }
+  end
+
+  # Area-level neighbourhoods (e.g. a district linked from a homepage jump
+  # link) aren't in the dropdown, which only lists neighbourhoods partners are
+  # directly assigned to. Inject the selected one so the filter UI reflects it.
+  def ensure_selected_neighbourhood(grouped, neighbourhood_id)
+    return grouped if neighbourhood_id.blank?
+    return grouped if grouped.any? { |g| g[:items].any? { |i| i[:id].to_s == neighbourhood_id.to_s } }
+
+    neighbourhood = Neighbourhood.find_by(id: neighbourhood_id)
+    return grouped unless neighbourhood
+
+    group_name = neighbourhood.district&.shortname || neighbourhood.shortname
+    grouped + [{ group: group_name, items: [{ id: neighbourhood.id, name: neighbourhood.shortname }] }]
   end
 
   def render_local_index

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -141,6 +141,8 @@ class PartnersQuery
   # in its wards, not just those assigned to the area node itself.
   def filter_by_neighbourhood(partners, neighbourhood_id)
     ids = neighbourhood_subtree_ids(neighbourhood_id)
+    return partners.none if ids.empty?
+
     partners
       .left_joins(:address, :service_areas)
       .where(
@@ -150,10 +152,11 @@ class PartnersQuery
       .distinct
   end
 
-  # @return [Array<Integer>] the neighbourhood id plus all descendant ids
+  # @return [Array<Integer>] the neighbourhood id plus all descendant ids, or
+  #   [] when the id is blank/unknown — so an invalid filter matches nothing
+  #   rather than raising on a non-integer value passed to an integer column.
   def neighbourhood_subtree_ids(neighbourhood_id)
-    neighbourhood = Neighbourhood.find_by(id: neighbourhood_id)
-    neighbourhood ? neighbourhood.subtree_ids : [neighbourhood_id]
+    Neighbourhood.find_by(id: neighbourhood_id)&.subtree_ids || []
   end
 
   def filter_by_tag(partners, tag_id)

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -56,14 +56,25 @@ class PartnersQuery
       ) AS combined
     SQL
 
-    counts = pairs.group_by { |r| r['neighbourhood_id'] }
-                  .transform_values { |rows| rows.map { |r| r['partner_id'] }.uniq.length }
+    return [] if pairs.empty?
 
-    return [] if counts.empty?
+    direct_ids = pairs.map { |r| r['neighbourhood_id'] }.uniq
+    neighbourhoods = Neighbourhood.where(id: direct_ids).order(:name).to_a
 
-    Neighbourhood.where(id: counts.keys).order(:name).map do |n|
-      { neighbourhood: n, count: counts[n.id] }
+    # Roll each partner up to its neighbourhood and all listed ancestors, so an
+    # area-level neighbourhood's count matches what filtering by it returns (its
+    # whole subtree) and the dropdown stays consistent with the results.
+    listed = neighbourhoods.index_by(&:id)
+    partner_sets = Hash.new { |hash, key| hash[key] = Set.new }
+    pairs.each do |row|
+      node = listed[row['neighbourhood_id']]
+      next unless node
+
+      credited = [node.id] + node.ancestor_ids.select { |id| listed.key?(id) }
+      credited.each { |id| partner_sets[id] << row['partner_id'] }
     end
+
+    neighbourhoods.map { |n| { neighbourhood: n, count: partner_sets[n.id].size } }
   end
 
   # Returns partnerships that have partners, with counts
@@ -123,14 +134,26 @@ class PartnersQuery
   # Filtering
   # ===================
 
-  # Filter by neighbourhood (partner's address OR service area)
+  # Filter by neighbourhood (partner's address OR service area).
+  #
+  # Matches the neighbourhood and all of its descendants, so an area-level
+  # neighbourhood (e.g. "Manchester" the district) includes partners living
+  # in its wards, not just those assigned to the area node itself.
   def filter_by_neighbourhood(partners, neighbourhood_id)
+    ids = neighbourhood_subtree_ids(neighbourhood_id)
     partners
       .left_joins(:address, :service_areas)
       .where(
-        'addresses.neighbourhood_id = :id OR service_areas.neighbourhood_id = :id',
-        id: neighbourhood_id
+        'addresses.neighbourhood_id IN (:ids) OR service_areas.neighbourhood_id IN (:ids)',
+        ids: ids
       )
+      .distinct
+  end
+
+  # @return [Array<Integer>] the neighbourhood id plus all descendant ids
+  def neighbourhood_subtree_ids(neighbourhood_id)
+    neighbourhood = Neighbourhood.find_by(id: neighbourhood_id)
+    neighbourhood ? neighbourhood.subtree_ids : [neighbourhood_id]
   end
 
   def filter_by_tag(partners, tag_id)

--- a/app/views/directory/home.rb
+++ b/app/views/directory/home.rb
@@ -9,7 +9,7 @@ class Views::Directory::Home < Views::Base
   prop :stats, Hash
   prop :partner_event_counts, Hash, default: -> { {} }
   prop :partner_locations, _Interface(:each), default: -> { [] }
-  prop :jump_sites, _Interface(:each), default: -> { [] }
+  prop :jump_neighbourhoods, _Interface(:each), default: -> { [] }
 
   def view_template
     content_for(:description) { 'Find community groups, venues and events near you. PlaceCal aggregates thousands of events from hundreds of local organisations across the UK.' }
@@ -19,7 +19,7 @@ class Views::Directory::Home < Views::Base
       subtitle: 'PlaceCal aggregates thousands of events and activities from hundreds of local community organisations across the UK. This is the directory for all of it — search by place, by interest, or browse the map.',
       search_path: partners_path,
       partner_locations: @partner_locations,
-      jump_sites: @jump_sites
+      jump_neighbourhoods: @jump_neighbourhoods
     )
 
     Directory::StatsStrip(stats: [

--- a/app/views/directory/partners/index.rb
+++ b/app/views/directory/partners/index.rb
@@ -54,11 +54,11 @@ class Views::Directory::Partners::Index < Views::Base
   end
 
   def render_results_header
-    filtered_count = @pagy ? @pagy.count : partner_list.size
+    filtered_total = @pagy ? @pagy.count : partner_list.size
     div(class: 'flex justify-between items-baseline flex-wrap gap-2 py-3') do
       div(class: 'text-sm text-tertiary') do
         if any_filter_active?
-          plain "Showing #{filtered_count} of #{@total_count} partners"
+          plain "Showing #{partner_list.size} of #{filtered_total} partners"
         else
           plain "#{@total_count} partners"
         end

--- a/app/views/directory/partnerships/show.rb
+++ b/app/views/directory/partnerships/show.rb
@@ -178,7 +178,8 @@ class Views::Directory::Partnerships::Show < Views::Base
             end
           end
         end
-        a(href: '/get-in-touch',
+        contact_href = coordinator&.email.present? ? "mailto:#{coordinator.email}" : '/get-in-touch'
+        a(href: contact_href,
           class: 'btn-dark-outline transition-colors') do
           plain t('directory.partnerships.show.contact_coordinator')
         end

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -76,6 +76,23 @@ RSpec.describe PartnersQuery do
       end
     end
 
+    context "with an area-level neighbourhood filter" do
+      let(:district) { create(:millbrook_district) }
+      let(:ward) { create(:riverside_ward, parent: district) }
+      let!(:partner_in_ward) do
+        address = create(:address, neighbourhood: ward)
+        create(:partner, address: address)
+      end
+
+      before { site.neighbourhoods << district }
+
+      it "includes partners in descendant neighbourhoods" do
+        results = described_class.new(site: site).call(neighbourhood_id: district.id)
+
+        expect(results).to include(partner_in_ward)
+      end
+    end
+
     context "with tag filter" do
       let!(:category) { create(:category) }
       let!(:partner_with_tag) do
@@ -152,6 +169,31 @@ RSpec.describe PartnersQuery do
 
         other_result = results.find { |r| r[:neighbourhood].id == other_neighbourhood.id }
         expect(other_result[:count]).to eq(2)
+      end
+    end
+
+    context "with partners in descendant neighbourhoods" do
+      let(:district) { create(:millbrook_district) }
+      let(:ward) { create(:riverside_ward, parent: district) }
+
+      before do
+        site.neighbourhoods << district
+        create(:partner, address: create(:address, neighbourhood: district))
+        create(:partner, address: create(:address, neighbourhood: ward))
+      end
+
+      it "rolls descendant partners up into the area-level count" do
+        results = described_class.new(site: site).neighbourhoods_with_counts
+
+        district_result = results.find { |r| r[:neighbourhood].id == district.id }
+        expect(district_result[:count]).to eq(2)
+      end
+
+      it "still counts the descendant neighbourhood on its own" do
+        results = described_class.new(site: site).neighbourhoods_with_counts
+
+        ward_result = results.find { |r| r[:neighbourhood].id == ward.id }
+        expect(ward_result[:count]).to eq(1)
       end
     end
 

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -93,6 +93,25 @@ RSpec.describe PartnersQuery do
       end
     end
 
+    context "with an unknown or invalid neighbourhood filter" do
+      before do
+        address = create(:address, neighbourhood: neighbourhood)
+        create(:partner, address: address)
+      end
+
+      it "returns no partners for a non-existent neighbourhood id" do
+        results = described_class.new(site: site).call(neighbourhood_id: 0)
+
+        expect(results).to be_empty
+      end
+
+      it "does not raise for a non-integer neighbourhood id" do
+        expect do
+          described_class.new(site: site).call(neighbourhood_id: "not-a-number").to_a
+        end.not_to raise_error
+      end
+    end
+
     context "with tag filter" do
       let!(:category) { create(:category) }
       let!(:partner_with_tag) do

--- a/spec/requests/public/pages_spec.rb
+++ b/spec/requests/public/pages_spec.rb
@@ -54,6 +54,23 @@ RSpec.describe "Public Pages", type: :request do
       expect(response).to be_successful
       expect(response.body).to include("<title>")
     end
+
+    context "with a featured jump-link neighbourhood" do
+      # E08000003 is one of the pinned JUMP_NEIGHBOURHOOD_CODES (Manchester)
+      let!(:manchester) do
+        create(:neighbourhood, name: "Manchester", unit: "district", unit_code_value: "E08000003")
+      end
+
+      before { Rails.cache.delete("directory/jump_neighbourhoods") }
+
+      it "links the jump label to the partners directory filtered by that neighbourhood" do
+        get "http://lvh.me"
+
+        expect(response).to be_successful
+        expect(response.body).to include("/partners?neighbourhood=#{manchester.id}")
+        expect(response.body).to include("Manchester")
+      end
+    end
   end
 
   describe "GET /privacy" do


### PR DESCRIPTION
## What & why

Closes #3178 — decides the neighbourhood-vs-site linking question for the directory homepage in favour of **neighbourhoods**, and makes the behaviour consistent.

The homepage "Jump to" links previously pointed at site pages (and were chosen by partner count, so e.g. Torbay appeared). They now point at the **partners directory filtered to a place**, driven by neighbourhoods rather than sites. Because they no longer depend on a PlaceCal site existing, places like Leeds and Newcastle work too.

Jump links are pinned by **ONS GSS code** (stable across environments) and resolved to the current ONS release:

| Place | GSS code |
|---|---|
| Manchester | E08000003 |
| London | E12000007 |
| Norwich | E07000148 |
| Leeds | E08000035 |
| Newcastle upon Tyne | E08000021 |

## Changes

- **Subtree-aware neighbourhood filter** (`PartnersQuery#filter_by_neighbourhood`): an area-level neighbourhood (e.g. "Manchester" the district) now includes partners in its descendant wards, not just partners assigned directly to the area node. Previously Manchester returned 26 of its 116 partners. Added `.distinct` to avoid duplicate rows from the service-area join.
- **Dropdown counts roll up** to match (`neighbourhoods_with_counts`), so the filter dropdown agrees with the result count (e.g. "Manchester (116)" → 116 results).
- **Controller injects the arriving area-level neighbourhood** into the filter dropdown so the UI reflects the active filter even when that neighbourhood isn't itself a partner-assignment neighbourhood.
- **Results header** now shows the filtered-set total instead of the global total — "Showing 16 of 16 partners" rather than "16 of 409".
- **"Contact coordinator"** button on partnership pages is now a `mailto:` link (falls back to `/get-in-touch` when the coordinator has no email).

## Reviewer notes

- Jump links are renamed end-to-end from `jump_sites` → `jump_neighbourhoods` (controller / `Views::Directory::Home` / `Directory::Hero`), and the cache key changed (`directory/jump_sites` → `directory/jump_neighbourhoods`).
- Specs added for subtree filtering and rolled-up counts.

## Verified locally

| Jump link | Filtered results |
|---|---|
| Manchester | 116 |
| London | 104 |
| Norwich | 15 |
| Leeds | 20 |
| Newcastle upon Tyne | 16 |

`spec/queries/partners_query_spec.rb` (20 examples) plus the directory/partners/partnerships/pages request specs pass.
