### PR TITLE
Fix SELECT DISTINCT ORDER BY error on partners directory index (#3226)

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -138,7 +138,10 @@ class PartnersController < ApplicationController
 
   def paginate_with_az_filter(partners)
     if @sort == 'name'
-      @az_letters = partners.pluck(Arel.sql('UPPER(LEFT(partners.name, 1))')).uniq.select { |l| l&.match?(/[A-Z]/) }.to_set
+      # reorder(nil) drops the name ORDER BY: with a DISTINCT relation (added by
+      # the neighbourhood filter) Postgres rejects ordering by a column that's
+      # not in the restricted DISTINCT select list. See issue #3226.
+      @az_letters = partners.reorder(nil).pluck(Arel.sql('UPPER(LEFT(partners.name, 1))')).uniq.select { |l| l&.match?(/[A-Z]/) }.to_set
       @selected_letter = params[:letter]&.upcase if params[:letter].present? && params[:letter].match?(/\A[a-zA-Z]\z/)
       filtered = @selected_letter ? partners.where('partners.name LIKE ?', "#{@selected_letter}%") : partners
       @pagy, @partners = pagy(filtered, limit: 30)

--- a/spec/requests/public/directory_partners_spec.rb
+++ b/spec/requests/public/directory_partners_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe "Directory Partners", type: :request do
         letter = partner.name[0].upcase
         expect(response.body).to include("letter-#{letter}")
       end
+
+      # Regression for #3226: the neighbourhood filter adds DISTINCT, and the
+      # A-Z letter pluck must not carry the name ORDER BY into the DISTINCT
+      # select or Postgres raises PG::InvalidColumnReference.
+      it "succeeds when combined with a neighbourhood filter" do
+        get partners_url(host: "lvh.me", params: { sort: "name", neighbourhood: ward.id })
+        expect(response).to be_successful
+      end
     end
 
     context "with service-area-only partner" do


### PR DESCRIPTION
Resolves #3226

## Description

The directory partners index (`PartnersController#index`) raised `ActiveRecord::StatementInvalid` / `PG::InvalidColumnReference: for SELECT DISTINCT, ORDER BY expressions must appear in select list` whenever **A-Z sort** (`sort=name`) was combined with a **neighbourhood filter**.

The neighbourhood filter appends `.distinct` to the relation, and the `name` sort appends `ORDER BY partners.name`. The A-Z jump-bar letter pluck in `paginate_with_az_filter` then issued:

```sql
SELECT DISTINCT UPPER(LEFT(partners.name, 1)) ... ORDER BY partners.name
```

Postgres rejects this because, under `SELECT DISTINCT`, every `ORDER BY` expression must appear in the (now restricted) select list.

The fix adds `.reorder(nil)` before the pluck. Ordering is meaningless for a uniq'd set of first letters anyway, so dropping it removes the offending `ORDER BY` and the `DISTINCT` select becomes valid.

### Motivation and Context

Production exception incident #194 (AppSignal). Users hitting the directory with both `sort=name` and a neighbourhood filter got a 500.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Reproduced the exact `PG::InvalidColumnReference` against the dev DB via `rails runner`, then confirmed the `reorder(nil)` version returns letters cleanly.
- Added a request-spec regression test (`spec/requests/public/directory_partners_spec.rb`) covering `sort=name` + neighbourhood filter. Verified it **fails without** the fix and **passes with** it.
- Full `directory_partners_spec.rb` suite passes (25 examples, 0 failures).

### How Will This Be Deployed?

Standard deploy. No infra, env var, or migration changes.
