### PR TITLE
Fix mobile layout overflow and partnerships button spacing (#3228)

### DIFF
--- a/app/components/directory/stats_strip.rb
+++ b/app/components/directory/stats_strip.rb
@@ -16,11 +16,14 @@ class Components::Directory::StatsStrip < Components::Directory::Base
   private
 
   def render_bead(value, label, _icon_name = nil)
-    div(class: 'flex flex-col bg-home-background border-2 border-rules rounded-card py-3.5 px-4.5') do
+    # min-w-0 lets the bead shrink below its content in the 2-col mobile grid;
+    # wrap-anywhere breaks long single-word labels (e.g. "Neighbourhoods") so the
+    # letter-spaced uppercase text can't overflow the cell and widen the page
+    div(class: 'flex flex-col bg-home-background border-2 border-rules rounded-card py-3.5 px-4.5 min-w-0') do
       span(class: 'font-serif text-stat leading-none text-foreground') do
         plain ActiveSupport::NumberHelper.number_to_delimited(value)
       end
-      span(class: 'allcaps-label text-tertiary mt-1.5') { label }
+      span(class: 'allcaps-label text-tertiary mt-1.5 wrap-anywhere') { label }
     end
   end
 end

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -132,10 +132,13 @@ class Components::Navigation < Components::Base
   def menu_nav_classes
     [
       'nav header__menu row-start-2 col-start-1 col-span-2 flex flex-col justify-evenly is-hidden',
-      '-mx-6 h-auto overflow-clip transition-[display,height,margin-top,padding-block] duration-300',
+      'h-auto overflow-clip transition-[display,height,margin-top,padding-block] duration-300',
       'md:flex-row',
       *(if @site&.default_site?
           [
+            # negative margins must match container-public's padding (0.75rem, then 1.25rem at md)
+            # so the dropdown sits flush to the edges without overflowing the viewport; lg:mx-0 below
+            '-mx-3 md:-mx-5',
             'pt-4 gap-0.5  lg:row-start-1 lg:col-start-2 lg:col-span-1',
             'md:flex-row md:gap-8 md:pt-3 md:pb-4 md:mt-6',
             'md:max-lg:[&:is(.is-hidden)]:py-0 md:max-lg:[&:is(.is-hidden)]:mt-4.5 md:max-lg:bg-home-background',
@@ -144,7 +147,7 @@ class Components::Navigation < Components::Base
           ]
         else
           [
-            'gap-1 mt-4',
+            '-mx-6 gap-1 mt-4',
             'max-md:pb-1 max-md:bg-tertiary max-md:[&:is(.is-hidden)]:h-0 max-md:[&:is(.is-hidden)]:pb-0',
             'md:-mx-6',
             'md:max-lg:px-2 md:max-lg:bg-foreground',

--- a/app/views/directory/home.rb
+++ b/app/views/directory/home.rb
@@ -50,7 +50,7 @@ class Views::Directory::Home < Views::Base
             span { safe('&rarr;') }
           end
         end
-        div(class: 'grid md:grid-cols-2 lg:grid-cols-3 gap-4') do
+        div(class: 'grid md:grid-cols-2 lg:grid-cols-3 gap-4 mt-5') do
           @partnerships.first(6).each do |partnership|
             Directory::PartnershipCard(partnership: partnership)
           end

--- a/app/views/directory/home.rb
+++ b/app/views/directory/home.rb
@@ -50,7 +50,7 @@ class Views::Directory::Home < Views::Base
             span { safe('&rarr;') }
           end
         end
-        div(class: 'grid md:grid-cols-2 lg:grid-cols-3 gap-4 mt-5') do
+        div(class: 'grid md:grid-cols-2 lg:grid-cols-3 gap-4 mt-5 lg:mt-0') do
           @partnerships.first(6).each do |partnership|
             Directory::PartnershipCard(partnership: partnership)
           end


### PR DESCRIPTION
Resolves #3228

## Description

Fixes two mobile layout issues on the public homepage:

1. **Horizontal overflow** that let the page scroll sideways by a small amount. There were two contributing causes (the second was masked by the first):
   - **Nav dropdown** (`app/components/navigation.rb`): the default-site menu used a hardcoded `-mx-6` (−1.5rem) negative margin, but `container-public`'s mobile padding is only `0.75rem` — so the menu overshot the viewport by ~14px. Replaced with `-mx-3 md:-mx-5` so the negative margin matches the container's responsive padding (`lg:mx-0` already resets it on desktop). The partner-site branch keeps its existing `-mx-6` (relocated from the shared base — effective classes unchanged).
   - **Stats strip** (`app/components/directory/stats_strip.rb`): long single-word labels like "NEIGHBOURHOODS"/"PARTNERSHIPS" (uppercase + letter-spacing, unbreakable) overflowed the narrow 2-column grid cells by up to 18px at 360px. Added `min-w-0` to the bead and `wrap-anywhere` to the label.

2. **Button spacing** (`app/views/directory/home.rb`): the "See all partnerships" button sat flush against the partnership cards. Added `mt-5` to the grid.

### Motivation and Context

Reported in #3228: on mobile (Firefox/Android) the page was slightly too wide, allowing a tiny sideways scroll, and the "see all partnerships" button had no spacing below it.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Reproduced and verified with headless Chromium at real mobile viewports (the Chrome dev integration's viewport is locked at 1200px, so it can't trigger the mobile media queries). Measured `document.documentElement.scrollWidth - clientWidth`:

| width | before | after |
|------:|-------:|------:|
| 360px | 18px | **0** |
| 390px | 14px | **0** |
| 599px | 0 | 0 |
| 700px | 0 | 0 |
| 899px | 0 | 0 |
| 1000px | 0 | 0 |

- 0px overflow at all widths after the fix, including with the mobile menu open (the full-bleed dropdown still spans edge-to-edge).
- RuboCop clean; `navigation_component_spec` (3 examples) and `requests/public/pages_spec` (25 examples) pass.

### How Will This Be Deployed?

No special steps. The new Tailwind utility classes (`-mx-3`, `md:-mx-5`, `min-w-0`, `wrap-anywhere`) are generated by the existing `yarn build` step during deploy (the built CSS is gitignored); all confirmed to generate locally.

### Screenshots

Verified at 360–390px: nav and stats strip no longer overflow the viewport, the mobile menu still opens flush to the edges, and the "See all partnerships" button now has clear spacing above the partnership cards.