### PR TITLE
fix(directory): only show published sites in partner sidebar

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -314,7 +314,9 @@ class Site < ApplicationRecord
 
       return [] if site_ids.empty?
 
-      sites = Site.where(id: site_ids).includes(:tags).order(:name)
+      # Only published sites are live on the public directory, so a partner can
+      # only "appear" on a published site.
+      sites = Site.published.where(id: site_ids).includes(:tags).order(:name)
 
       # Sites with tags only match if the partner has at least one of those tags
       partner_tag_ids = partner.tag_ids.to_set

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -127,6 +127,31 @@ RSpec.describe Site, type: :model do
     end
   end
 
+  describe ".sites_that_contain_partner" do
+    let(:neighbourhood) { create(:neighbourhood) }
+    let(:address) { create(:address, neighbourhood: neighbourhood) }
+    let(:partner) { create(:partner, address: address) }
+
+    it "returns published sites that contain the partner" do
+      site = create(:site, is_published: true, neighbourhoods: [neighbourhood])
+
+      expect(described_class.sites_that_contain_partner(partner)).to include(site)
+    end
+
+    it "excludes unpublished sites that contain the partner" do
+      create(:site, is_published: false, neighbourhoods: [neighbourhood])
+
+      expect(described_class.sites_that_contain_partner(partner)).to be_empty
+    end
+
+    it "returns only the published sites when both exist" do
+      published = create(:site, is_published: true, neighbourhoods: [neighbourhood])
+      create(:site, is_published: false, neighbourhoods: [neighbourhood])
+
+      expect(described_class.sites_that_contain_partner(partner)).to contain_exactly(published)
+    end
+  end
+
   describe "scopes" do
     describe "default ordering" do
       let!(:site_a) { create(:site, name: "Alpha Site") }

--- a/spec/requests/public/partners_spec.rb
+++ b/spec/requests/public/partners_spec.rb
@@ -577,7 +577,7 @@ RSpec.describe "Public Partners", type: :request do
 
     context "with containing sites (partnerships)" do
       let(:partner) { create(:riverside_partner) }
-      let(:partnership_site) { create(:site, slug: "test-partnership", name: "Test Partnership") }
+      let(:partnership_site) { create(:site, slug: "test-partnership", name: "Test Partnership", is_published: true) }
 
       before do
         partnership_site.neighbourhoods << partner.address.neighbourhood


### PR DESCRIPTION
## Problem

On the public directory partner show pages (and event show pages), the "appears on" sidebar lists the sites that contain the partner. This list is produced by `Site.sites_that_contain_partner`, which queried **all** sites matching the partner's neighbourhood subtree without filtering on `is_published`:

```ruby
sites = Site.where(id: site_ids).includes(:tags).order(:name)
```

As a result, **unpublished (hidden) sites leaked into the public-facing sidebar** — inconsistent with the rest of the public directory, where e.g. partnership counts already filter on `Site.where(is_published: true)`.

## Fix

Scope the query to the existing `.published` scope so only live sites are listed:

```ruby
sites = Site.published.where(id: site_ids).includes(:tags).order(:name)
```

Both real public callers (`PartnersController#show`, `EventsController#show`) are guarded by `default_site?` and want published-only results. The only other caller, `Admin::PartnersController#edit`, assigns `@sites` but never passes it to the Phlex view (which takes only `:partner`), so it has no behavioural effect.

## Tests

Added model specs for `.sites_that_contain_partner` covering published, unpublished, and mixed cases. Full `site_spec.rb` passes (24 examples, 0 failures).