### PR TITLE
Auto-recover calendars stuck in in_worker

### DIFF
--- a/app/jobs/calendar_importer/parsers/eventbrite.rb
+++ b/app/jobs/calendar_importer/parsers/eventbrite.rb
@@ -36,8 +36,15 @@ module CalendarImporter::Parsers
       end
 
       @events
-    rescue RestClient::BadGateway => e
+    rescue RestClient::BadGateway
       []
+    rescue EventbriteSDK::ResourceNotFound => e
+      # The Eventbrite organiser no longer exists — usually deleted, or renamed
+      # (which changes the numeric id baked into the source URL). Flag the
+      # calendar as a bad source rather than letting the error bubble up
+      # unhandled, which would strand the calendar in `in_worker` and retry the
+      # dead organiser forever.
+      raise InaccessibleFeed, "Eventbrite organiser #{organizer_id} not found (#{e.message})"
     end
 
     def import_events_from(data)

--- a/app/jobs/calendar_importer_job.rb
+++ b/app/jobs/calendar_importer_job.rb
@@ -5,6 +5,22 @@ class CalendarImporterJob < ApplicationJob
 
   queue_as :default
 
+  # Backstop for exceptions not matched by a more specific handler below. A
+  # worker that dies mid-import strands the calendar in `in_worker`; an
+  # *uncaught* exception does the same (the state transition never completes).
+  # Flag the calendar into the terminal `error` state so it isn't stranded,
+  # then re-raise so the exception still surfaces in error tracking — unexpected
+  # exceptions are bugs we want to see, not silently swallow (see the
+  # "does not swallow unrelated StandardError" spec).
+  #
+  # Declared first so the specific handlers below take precedence: rescue_from
+  # matches handlers in reverse declaration order, so this only catches what
+  # the others don't (and must not clobber e.g. the timeout -> bad_source map).
+  rescue_from StandardError do |exception|
+    report_error exception, 'Unexpected error during import'
+    raise exception
+  end
+
   rescue_from UnsupportedFeed do |exception|
     report_error exception, 'Calendar URL is not supported'
   end

--- a/app/jobs/recurring_calendar_scan_job.rb
+++ b/app/jobs/recurring_calendar_scan_job.rb
@@ -13,6 +13,9 @@ class RecurringCalendarScanJob < ApplicationJob
   def perform
     run do
       Appsignal::CheckIn.cron('calendar_scan') do
+        # Recover any calendars orphaned in `in_worker` by a dead worker
+        # before scanning, so they get re-queued in this same pass.
+        Calendar.reset_stuck_imports!
         Calendar.queue_all_for_import!
       end
     end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -12,6 +12,11 @@ class Calendar < ApplicationRecord
 
   ALLOWED_STATES = %i[idle in_queue in_worker error bad_source].freeze
 
+  # A calendar should only sit in `in_worker` for the seconds/minutes an import
+  # actually takes. Anything still `in_worker` for longer than this has been
+  # orphaned by a job worker that died mid-import (e.g. OOM-killed).
+  STUCK_IMPORT_THRESHOLD = 2.hours
+
   # ==== Enums / Enumerize ====
   # Defines the strategy this Calendar uses to assign events to locations.
   # @attr [Enumerable<Symbol>] :strategy
@@ -36,6 +41,7 @@ class Calendar < ApplicationRecord
   attribute :api_token,            :string                       # nullable
   attribute :checksum_updated_at,  :datetime                     # nullable
   attribute :critical_error,       :text                         # nullable
+  attribute :import_started_at,    :datetime                     # nullable — when the current import job began
   attribute :importer_mode,        :string, default: 'auto'      # nullable
   attribute :importer_used,        :string                       # nullable
   attribute :is_working,           :boolean, default: true       # NOT NULL
@@ -117,6 +123,25 @@ class Calendar < ApplicationRecord
     end
   end
 
+  # Recover calendars orphaned in `in_worker` by a job worker that died
+  # mid-import. Such calendars are never re-imported on their own:
+  # {#queue_for_import!} skips them ({#is_busy?}) and the admin UI can't
+  # requeue them ({#can_be_requeued?} is false). Resetting them to idle lets
+  # the next scan pick them up again.
+  # @param threshold [ActiveSupport::Duration] minimum time `in_worker` before
+  #   a calendar is considered stuck
+  # @return [Array<Integer>] ids of the calendars that were reset
+  def self.reset_stuck_imports!(threshold: STUCK_IMPORT_THRESHOLD)
+    stuck = where(calendar_state: :in_worker)
+            .where('import_started_at < :cutoff OR import_started_at IS NULL', cutoff: threshold.ago)
+    ids = stuck.pluck(:id)
+    return ids if ids.empty?
+
+    stuck.update_all(calendar_state: 'idle') # rubocop:disable Rails/SkipsModelValidations
+    Rails.logger.warn("[Calendar] Reset #{ids.size} stuck calendar(s) from in_worker to idle: #{ids.join(', ')}")
+    ids
+  end
+
   # ==== Instance methods ====
 
   # @return [Boolean] whether this strategy requires a default place
@@ -187,7 +212,7 @@ class Calendar < ApplicationRecord
     without_timestamps do
       return unless calendar_state.in_queue?
 
-      update! calendar_state: :in_worker, notices: nil
+      update! calendar_state: :in_worker, notices: nil, import_started_at: DateTime.current
     end
   end
 

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -12,9 +12,13 @@ class Calendar < ApplicationRecord
 
   ALLOWED_STATES = %i[idle in_queue in_worker error bad_source].freeze
 
-  # A calendar should only sit in `in_worker` for the seconds/minutes an import
-  # actually takes. Anything still `in_worker` for longer than this has been
-  # orphaned by a job worker that died mid-import (e.g. OOM-killed).
+  # An import attempt should occupy `in_queue`/`in_worker` for at most the time
+  # it takes the worker to drain the queue and run the import (a single import
+  # is capped at Delayed::Worker.max_run_time). Anything still busy for longer
+  # than this has been orphaned by a worker that died mid-import (e.g.
+  # OOM-killed) before it could record a terminal state. Kept comfortably above
+  # the worst-case queue-drain time to avoid resetting calendars that are
+  # legitimately still waiting their turn.
   STUCK_IMPORT_THRESHOLD = 2.hours
 
   # ==== Enums / Enumerize ====
@@ -41,7 +45,7 @@ class Calendar < ApplicationRecord
   attribute :api_token,            :string                       # nullable
   attribute :checksum_updated_at,  :datetime                     # nullable
   attribute :critical_error,       :text                         # nullable
-  attribute :import_started_at,    :datetime                     # nullable — when the current import job began
+  attribute :import_started_at,    :datetime                     # nullable — when the current import attempt was queued/started
   attribute :importer_mode,        :string, default: 'auto'      # nullable
   attribute :importer_used,        :string                       # nullable
   attribute :is_working,           :boolean, default: true       # NOT NULL
@@ -123,22 +127,24 @@ class Calendar < ApplicationRecord
     end
   end
 
-  # Recover calendars orphaned in `in_worker` by a job worker that died
-  # mid-import. Such calendars are never re-imported on their own:
-  # {#queue_for_import!} skips them ({#is_busy?}) and the admin UI can't
-  # requeue them ({#can_be_requeued?} is false). Resetting them to idle lets
-  # the next scan pick them up again.
-  # @param threshold [ActiveSupport::Duration] minimum time `in_worker` before
-  #   a calendar is considered stuck
+  # Recover calendars orphaned in a busy state (`in_queue` or `in_worker`) by a
+  # job worker that died before it could record a terminal state. Such
+  # calendars are never re-imported on their own: {#queue_for_import!} skips
+  # them ({#is_busy?}) and the admin UI can't requeue them
+  # ({#can_be_requeued?} is false). Resetting them to idle lets the next scan
+  # pick them up again. (`import_started_at IS NULL` covers legacy rows stuck
+  # before this column existed.)
+  # @param threshold [ActiveSupport::Duration] minimum time in a busy state
+  #   before a calendar is considered stuck
   # @return [Array<Integer>] ids of the calendars that were reset
   def self.reset_stuck_imports!(threshold: STUCK_IMPORT_THRESHOLD)
-    stuck = where(calendar_state: :in_worker)
+    stuck = where(calendar_state: %i[in_queue in_worker])
             .where('import_started_at < :cutoff OR import_started_at IS NULL', cutoff: threshold.ago)
     ids = stuck.pluck(:id)
     return ids if ids.empty?
 
     stuck.update_all(calendar_state: 'idle') # rubocop:disable Rails/SkipsModelValidations
-    Rails.logger.warn("[Calendar] Reset #{ids.size} stuck calendar(s) from in_worker to idle: #{ids.join(', ')}")
+    Rails.logger.warn("[Calendar] Reset #{ids.size} stuck calendar(s) to idle: #{ids.join(', ')}")
     ids
   end
 
@@ -201,7 +207,9 @@ class Calendar < ApplicationRecord
     without_timestamps do
       return if is_busy?
 
-      update! calendar_state: :in_queue, notices: nil
+      # Stamp when the attempt enters the pipeline so reset_stuck_imports! can
+      # detect attempts orphaned while still `in_queue` (not just `in_worker`).
+      update! calendar_state: :in_queue, notices: nil, import_started_at: DateTime.current
       CalendarImporterJob.perform_later id, from_date, force_import
     end
   end

--- a/db/migrate/20260609080000_add_import_started_at_to_calendars.rb
+++ b/db/migrate/20260609080000_add_import_started_at_to_calendars.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddImportStartedAtToCalendars < ActiveRecord::Migration[8.1]
+  def change
+    add_column :calendars, :import_started_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_172023) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_080000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -66,6 +66,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_172023) do
     t.datetime "checksum_updated_at"
     t.datetime "created_at", precision: nil, null: false
     t.text "critical_error"
+    t.datetime "import_started_at"
     t.string "importer_mode", default: "auto"
     t.string "importer_used"
     t.boolean "is_working", default: true, null: false

--- a/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
+++ b/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
@@ -44,5 +44,25 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
         expect { parser.download_calendar }.not_to raise_error
       end
     end
+
+    it "raises InaccessibleFeed when the Eventbrite organiser no longer exists" do
+      os_event_url = "https://www.eventbrite.co.uk/o/deleted-organiser-99999999999"
+      calendar = build(
+        :calendar,
+        strategy: :event,
+        name: :import_test_calendar,
+        source: os_event_url
+      )
+      allow(calendar).to receive(:check_source_reachable)
+
+      parser = described_class.new(calendar, url: os_event_url)
+      allow(EventbriteSDK::Organizer).to receive(:retrieve).and_raise(EventbriteSDK::ResourceNotFound)
+
+      # A deleted/renamed organiser must surface as an unreachable source
+      # (-> bad_source) rather than an uncaught exception that strands the
+      # calendar in `in_worker` and retries forever.
+      expect { parser.download_calendar }
+        .to raise_error(CalendarImporter::Exceptions::InaccessibleFeed, /not found/)
+    end
   end
 end

--- a/spec/jobs/calendar_importer_job_spec.rb
+++ b/spec/jobs/calendar_importer_job_spec.rb
@@ -116,12 +116,24 @@ RSpec.describe CalendarImporterJob do
   end
 
   describe "non-network errors" do
-    it "does not swallow unrelated StandardError exceptions" do
+    before do
       task = instance_double(CalendarImporter::CalendarImporterTask)
       allow(CalendarImporter::CalendarImporterTask).to receive(:new).and_return(task)
       allow(task).to receive(:run).and_raise(KeyError, "boom")
+    end
 
+    it "does not swallow unrelated StandardError exceptions" do
+      # Unexpected exceptions are bugs we want surfaced in error tracking, so
+      # the backstop re-raises rather than swallowing.
       expect { perform_import }.to raise_error(KeyError, /boom/)
+    end
+
+    it "still flags the calendar into a terminal state so it isn't stranded" do
+      expect { perform_import }.to raise_error(KeyError)
+
+      # Without this, the calendar would be stranded in `in_worker` forever.
+      expect(calendar.reload.calendar_state).to eq("error")
+      expect(calendar.critical_error).to include("boom")
     end
   end
 end

--- a/spec/models/calendar_spec.rb
+++ b/spec/models/calendar_spec.rb
@@ -160,4 +160,61 @@ RSpec.describe Calendar, type: :model do
       expect(calendar.events_this_week).to eq(0)
     end
   end
+
+  describe "#flag_start_import_job!" do
+    let(:calendar) { create(:calendar) }
+
+    it "stamps import_started_at when an import begins" do
+      calendar.update_columns(calendar_state: "in_queue", import_started_at: nil) # rubocop:disable Rails/SkipsModelValidations
+
+      expect { calendar.flag_start_import_job! }
+        .to change { calendar.reload.import_started_at }.from(nil)
+
+      expect(calendar.calendar_state).to eq("in_worker")
+      expect(calendar.import_started_at).to be_within(5.seconds).of(Time.current)
+    end
+  end
+
+  describe ".reset_stuck_imports!" do
+    let(:calendar) { create(:calendar) }
+
+    def put_in_worker(started_at)
+      calendar.update_columns(calendar_state: "in_worker", import_started_at: started_at) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    it "resets a calendar stuck in_worker beyond the threshold" do
+      put_in_worker(3.hours.ago)
+
+      expect(described_class.reset_stuck_imports!).to contain_exactly(calendar.id)
+      expect(calendar.reload.calendar_state).to eq("idle")
+    end
+
+    it "resets a legacy in_worker calendar with no import_started_at" do
+      put_in_worker(nil)
+
+      expect(described_class.reset_stuck_imports!).to contain_exactly(calendar.id)
+      expect(calendar.reload.calendar_state).to eq("idle")
+    end
+
+    it "leaves a calendar that started importing recently" do
+      put_in_worker(10.minutes.ago)
+
+      expect(described_class.reset_stuck_imports!).to be_empty
+      expect(calendar.reload.calendar_state).to eq("in_worker")
+    end
+
+    it "ignores calendars that are not in_worker" do
+      calendar.update_columns(calendar_state: "bad_source", import_started_at: 3.hours.ago) # rubocop:disable Rails/SkipsModelValidations
+
+      expect(described_class.reset_stuck_imports!).to be_empty
+      expect(calendar.reload.calendar_state).to eq("bad_source")
+    end
+
+    it "honours a custom threshold" do
+      put_in_worker(30.minutes.ago)
+
+      expect(described_class.reset_stuck_imports!(threshold: 15.minutes)).to contain_exactly(calendar.id)
+      expect(calendar.reload.calendar_state).to eq("idle")
+    end
+  end
 end

--- a/spec/models/calendar_spec.rb
+++ b/spec/models/calendar_spec.rb
@@ -161,10 +161,20 @@ RSpec.describe Calendar, type: :model do
     end
   end
 
-  describe "#flag_start_import_job!" do
+  describe "import attempt timestamps" do
     let(:calendar) { create(:calendar) }
 
-    it "stamps import_started_at when an import begins" do
+    it "stamps import_started_at when an attempt is queued" do
+      calendar.update_columns(calendar_state: "idle", import_started_at: nil) # rubocop:disable Rails/SkipsModelValidations
+
+      expect { calendar.queue_for_import!(false) }
+        .to change { calendar.reload.import_started_at }.from(nil)
+
+      expect(calendar.calendar_state).to eq("in_queue")
+      expect(calendar.import_started_at).to be_within(5.seconds).of(Time.current)
+    end
+
+    it "stamps import_started_at when the worker starts the import" do
       calendar.update_columns(calendar_state: "in_queue", import_started_at: nil) # rubocop:disable Rails/SkipsModelValidations
 
       expect { calendar.flag_start_import_job! }
@@ -178,40 +188,42 @@ RSpec.describe Calendar, type: :model do
   describe ".reset_stuck_imports!" do
     let(:calendar) { create(:calendar) }
 
-    def put_in_worker(started_at)
-      calendar.update_columns(calendar_state: "in_worker", import_started_at: started_at) # rubocop:disable Rails/SkipsModelValidations
+    def put_stuck(state, started_at)
+      calendar.update_columns(calendar_state: state, import_started_at: started_at) # rubocop:disable Rails/SkipsModelValidations
     end
 
-    it "resets a calendar stuck in_worker beyond the threshold" do
-      put_in_worker(3.hours.ago)
+    %w[in_worker in_queue].each do |state|
+      it "resets a calendar stuck in #{state} beyond the threshold" do
+        put_stuck(state, 3.hours.ago)
 
-      expect(described_class.reset_stuck_imports!).to contain_exactly(calendar.id)
-      expect(calendar.reload.calendar_state).to eq("idle")
+        expect(described_class.reset_stuck_imports!).to contain_exactly(calendar.id)
+        expect(calendar.reload.calendar_state).to eq("idle")
+      end
+
+      it "resets a legacy #{state} calendar with no import_started_at" do
+        put_stuck(state, nil)
+
+        expect(described_class.reset_stuck_imports!).to contain_exactly(calendar.id)
+        expect(calendar.reload.calendar_state).to eq("idle")
+      end
+
+      it "leaves a #{state} calendar whose attempt started recently" do
+        put_stuck(state, 10.minutes.ago)
+
+        expect(described_class.reset_stuck_imports!).to be_empty
+        expect(calendar.reload.calendar_state).to eq(state)
+      end
     end
 
-    it "resets a legacy in_worker calendar with no import_started_at" do
-      put_in_worker(nil)
-
-      expect(described_class.reset_stuck_imports!).to contain_exactly(calendar.id)
-      expect(calendar.reload.calendar_state).to eq("idle")
-    end
-
-    it "leaves a calendar that started importing recently" do
-      put_in_worker(10.minutes.ago)
-
-      expect(described_class.reset_stuck_imports!).to be_empty
-      expect(calendar.reload.calendar_state).to eq("in_worker")
-    end
-
-    it "ignores calendars that are not in_worker" do
-      calendar.update_columns(calendar_state: "bad_source", import_started_at: 3.hours.ago) # rubocop:disable Rails/SkipsModelValidations
+    it "ignores calendars that are not in a busy state" do
+      put_stuck("bad_source", 3.hours.ago)
 
       expect(described_class.reset_stuck_imports!).to be_empty
       expect(calendar.reload.calendar_state).to eq("bad_source")
     end
 
     it "honours a custom threshold" do
-      put_in_worker(30.minutes.ago)
+      put_stuck("in_worker", 30.minutes.ago)
 
       expect(described_class.reset_stuck_imports!(threshold: 15.minutes)).to contain_exactly(calendar.id)
       expect(calendar.reload.calendar_state).to eq("idle")


### PR DESCRIPTION
## Problem

A community partner (Queer Bachata Manchester) reported their listing showed *no upcoming events* despite running weekly classes. Investigation on production found the root cause is **not** the Eventbrite feed — it's a stuck state in our import state machine.

Their calendar (id 262) was frozen in `in_worker` since **2026-01-20 03:10**, with `last_import_at` ~5 months stale and 0 future events.

### Why a stuck calendar never recovers

When the job worker dies mid-import — or an **uncaught exception** escapes the import job (the 512MB-capped container also gets OOM-killed) — the calendar is left busy and nothing ever resets it:

1. The hourly `RecurringCalendarScanJob` → `Calendar.queue_all_for_import!` → `queue_for_import!` does `return if is_busy?`, and `is_busy?` is true for `in_worker`/`in_queue` — so it's **silently skipped every cycle**.
2. The admin UI can't rescue it either — `can_be_requeued?` is false for those states.
3. `RecurringWatchdogJob` only re-seeds *missing recurring jobs*, not stuck calendars.

### Blast radius

This was affecting **49 calendars** in production (`in_worker`), with ~28 frozen together at `2026-01-20 03:05–03:11` during one nightly run — many of them community/LGBTQ+ orgs showing stale or no events.

## Fix

### 1. Auto-recover stuck calendars
- Add an `import_started_at` timestamp, stamped both when an attempt is **queued** (`queue_for_import!`) and when the worker **starts** it (`flag_start_import_job!`). (`updated_at` can't be used — state transitions run inside `without_timestamps`.)
- Add `Calendar.reset_stuck_imports!(threshold: 2.hours)` which resets calendars stuck in `in_queue` **or** `in_worker` past the threshold (or with a null timestamp, for legacy rows) back to `idle`. The threshold sits comfortably above the worst-case queue-drain time so it never resets a calendar that's legitimately still waiting.
- Call it from `RecurringCalendarScanJob` **before** `queue_all_for_import!`, so orphaned calendars recover and re-queue in the same hourly pass.

### 2. Stop uncaught exceptions from stranding calendars
- Add a backstop `rescue_from StandardError` in `CalendarImporterJob`. Previously any exception not matched by a specific handler escaped uncaught, stranding the calendar in `in_worker`. The backstop flags the calendar into the terminal `error` state (un-stranding it) and then **re-raises** — unexpected exceptions are bugs we want surfaced in error tracking, not silently swallowed (preserving the documented behaviour in the `does not swallow unrelated StandardError` spec).
- Declared first so the specific handlers keep precedence (`rescue_from` matches in reverse declaration order); verified by the existing `timeout → bad_source` specs still passing.

### 3. Handle deleted Eventbrite organisers as bad_source
- A deleted/renamed Eventbrite organiser makes `EventbriteSDK::Organizer.retrieve` raise `EventbriteSDK::ResourceNotFound`. The parser now catches it and re-raises `InaccessibleFeed`, which the job maps to `bad_source` — the correct terminal state for a vanished source, and quieter than the generic backstop (no alert for an expected condition).
- (Surfaced live during this investigation: calendar 304 had a bad source URL hitting exactly this path; the admin has since corrected it.)

## Production remediation (already applied)

The 49 stuck calendars were manually reset to `idle` and re-queued during the investigation. They re-imported successfully — Queer Bachata now shows **29 upcoming events** (was 0), and `in_worker` dropped from 49 to ~2 (actively importing). This PR prevents recurrence.

## Tests

- `Calendar` stamps `import_started_at` on both queue and worker-start.
- `Calendar.reset_stuck_imports!`: recovers stale + legacy-nil rows in **both** `in_queue` and `in_worker`, leaves recently-started attempts and non-busy states alone, honours a custom threshold.
- `CalendarImporterJob` backstop: re-raises unexpected exceptions **and** flags the calendar into `error` (no longer stranded); specific handlers still take precedence.
- `Parsers::Eventbrite#download_calendar` raises `InaccessibleFeed` on `ResourceNotFound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)