### PR TITLE
Hierarchical neighbourhood picker for directory partners filter

### DIFF
--- a/app/components/directory/custom_select.rb
+++ b/app/components/directory/custom_select.rb
@@ -37,12 +37,12 @@ class Components::Directory::CustomSelect < Components::Directory::Base
     button(
       type: 'button',
       data: { custom_select_target: 'trigger', action: 'custom-select#toggle' },
-      class: 'w-full flex items-center justify-between border-2 border-rules rounded-full px-4 py-2 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors'
+      class: 'w-full flex items-center justify-between border-2 border-rules rounded-sm px-4 py-2 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors'
     ) do
-      span(data: { role: 'label' }) { selected_label }
+      span(class: 'truncate min-w-0 text-left', data: { role: 'label' }) { selected_label }
       span(
         data: { custom_select_target: 'arrow' },
-        class: 'transition-transform duration-200'
+        class: 'transition-transform duration-200 shrink-0'
       ) { raw(chevron_svg) }
     end
   end
@@ -51,7 +51,7 @@ class Components::Directory::CustomSelect < Components::Directory::Base
     div(
       data: { custom_select_target: 'panel' },
       style: 'display: none',
-      class: 'absolute z-50 left-0 right-0 mt-1 bg-foreground rounded-card overflow-hidden shadow-lg'
+      class: 'absolute z-50 left-0 right-0 mt-1 bg-foreground rounded-sm overflow-hidden shadow-lg'
     ) do
       div(class: 'max-h-60 overflow-y-auto py-1') do
         all_options.each do |opt|

--- a/app/components/directory/custom_select.rb
+++ b/app/components/directory/custom_select.rb
@@ -2,7 +2,7 @@
 
 class Components::Directory::CustomSelect < Components::Directory::Base
   prop :name, String
-  prop :label_text, String
+  prop :label_text, _Nilable(String), default: nil
   prop :options, _Interface(:each)
   prop :selected, _Nilable(String), default: nil
   prop :default_label, _Nilable(String), default: nil
@@ -10,7 +10,7 @@ class Components::Directory::CustomSelect < Components::Directory::Base
 
   def view_template
     div(class: 'min-w-0 flex-1 relative', data: { controller: 'custom-select' }) do
-      label(class: 'block allcaps-label text-tertiary mb-1') { @label_text }
+      label(class: 'block allcaps-label text-tertiary mb-1') { @label_text } if @label_text.present?
       render_hidden_select
       render_trigger
       render_panel
@@ -21,7 +21,7 @@ class Components::Directory::CustomSelect < Components::Directory::Base
 
   def render_hidden_select
     select(
-      name: @name, id: @name,
+      name: @name,
       data: { custom_select_target: 'hiddenSelect' },
       class: 'sr-only', tabindex: '-1', aria: { hidden: 'true' }
     ) do
@@ -108,7 +108,7 @@ class Components::Directory::CustomSelect < Components::Directory::Base
   end
 
   def placeholder
-    @default_label || "All #{@label_text.downcase.pluralize}"
+    @default_label || (@label_text.present? ? "All #{@label_text.downcase.pluralize}" : 'All')
   end
 
   def selected_label

--- a/app/components/directory/custom_select.rb
+++ b/app/components/directory/custom_select.rb
@@ -53,7 +53,7 @@ class Components::Directory::CustomSelect < Components::Directory::Base
       style: 'display: none',
       class: 'absolute z-50 left-0 right-0 mt-1 bg-foreground rounded-sm overflow-hidden shadow-lg'
     ) do
-      div(class: 'max-h-60 overflow-y-auto py-1') do
+      div(class: 'max-h-[60vh] overflow-y-auto py-1') do
         all_options.each do |opt|
           render_option(opt)
         end

--- a/app/components/directory/custom_select.rb
+++ b/app/components/directory/custom_select.rb
@@ -37,9 +37,9 @@ class Components::Directory::CustomSelect < Components::Directory::Base
     button(
       type: 'button',
       data: { custom_select_target: 'trigger', action: 'custom-select#toggle' },
-      class: 'w-full h-[42px] flex items-center justify-between border-2 border-rules rounded-sm px-4 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors'
+      class: 'w-full h-[42px] flex items-center gap-2 border-2 border-rules rounded-sm px-4 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors'
     ) do
-      span(class: 'truncate min-w-0 text-left', data: { role: 'label' }) { selected_label }
+      span(class: 'flex-1 min-w-0 truncate text-left', data: { role: 'label' }) { selected_label }
       span(
         data: { custom_select_target: 'arrow' },
         class: 'transition-transform duration-200 shrink-0'

--- a/app/components/directory/custom_select.rb
+++ b/app/components/directory/custom_select.rb
@@ -37,7 +37,7 @@ class Components::Directory::CustomSelect < Components::Directory::Base
     button(
       type: 'button',
       data: { custom_select_target: 'trigger', action: 'custom-select#toggle' },
-      class: 'w-full flex items-center justify-between border-2 border-rules rounded-sm px-4 py-2 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors'
+      class: 'w-full h-[42px] flex items-center justify-between border-2 border-rules rounded-sm px-4 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors'
     ) do
       span(class: 'truncate min-w-0 text-left', data: { role: 'label' }) { selected_label }
       span(

--- a/app/components/directory/neighbourhood_cascade.rb
+++ b/app/components/directory/neighbourhood_cascade.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Cascading neighbourhood filter for the directory site.
+#
+# Renders a hidden `neighbourhood` field plus a container the
+# `neighbourhood-cascade` Stimulus controller fills with linked selects, one per
+# geographic level (region > county > district > ward). The preloaded tree comes
+# from PartnersQuery#neighbourhood_tree, so no AJAX is needed; selecting a higher
+# level filters its whole subtree.
+class Components::Directory::NeighbourhoodCascade < Components::Directory::Base
+  prop :tree, _Interface(:each)
+  prop :selected, _Nilable(String), default: nil
+  prop :label_text, String, default: 'Neighbourhood'
+
+  def view_template
+    div(
+      class: 'min-w-0',
+      data: {
+        controller: 'neighbourhood-cascade',
+        neighbourhood_cascade_tree_value: @tree.to_a.to_json,
+        neighbourhood_cascade_selected_value: @selected.to_s
+      }
+    ) do
+      label(class: 'block allcaps-label text-tertiary mb-1') { @label_text }
+      input(
+        type: 'hidden', name: 'neighbourhood', value: @selected,
+        data: { neighbourhood_cascade_target: 'field' }
+      )
+      div(
+        class: 'flex flex-wrap gap-2',
+        data: { neighbourhood_cascade_target: 'selects' }
+      )
+    end
+  end
+end

--- a/app/components/directory/neighbourhood_cascade.rb
+++ b/app/components/directory/neighbourhood_cascade.rb
@@ -18,7 +18,8 @@ class Components::Directory::NeighbourhoodCascade < Components::Directory::Base
       data: {
         controller: 'neighbourhood-cascade',
         neighbourhood_cascade_tree_value: @tree.to_a.to_json,
-        neighbourhood_cascade_selected_value: @selected.to_s
+        neighbourhood_cascade_selected_value: @selected.to_s,
+        neighbourhood_cascade_label_value: @label_text
       }
     ) do
       label(class: 'block allcaps-label text-tertiary mb-1') { @label_text }

--- a/app/components/directory/neighbourhood_cascade.rb
+++ b/app/components/directory/neighbourhood_cascade.rb
@@ -68,12 +68,12 @@ class Components::Directory::NeighbourhoodCascade < Components::Directory::Base
         options: nodes.map { |n| option_for(n) },
         selected: selected_node && selected_node[:id].to_s,
         include_blank: true,
-        default_label: "All #{@label_text.downcase.pluralize}"
+        default_label: t('directory.partners.index.filters.all_neighbourhoods')
       }
     else
       parent = path[depth - 1]
       {
-        options: [{ id: parent[:id], name: "All of #{parent[:name]}" }] + nodes.map { |n| option_for(n) },
+        options: [{ id: parent[:id], name: t('directory.partners.index.filters.all_of', name: parent[:name]) }] + nodes.map { |n| option_for(n) },
         selected: (selected_node || parent)[:id].to_s,
         include_blank: false,
         default_label: nil

--- a/app/components/directory/neighbourhood_cascade.rb
+++ b/app/components/directory/neighbourhood_cascade.rb
@@ -2,11 +2,12 @@
 
 # Cascading neighbourhood filter for the directory site.
 #
-# Renders a hidden `neighbourhood` field plus a container the
-# `neighbourhood-cascade` Stimulus controller fills with linked selects, one per
-# geographic level (region > county > district > ward). The preloaded tree comes
-# from PartnersQuery#neighbourhood_tree, so no AJAX is needed; selecting a higher
-# level filters its whole subtree.
+# Renders one styled dropdown per geographic level (region > county > district >
+# ward) using the same CustomSelect widget as the other filters, so the open
+# dropdown looks identical. Every level submits under the `neighbourhood` name;
+# the `neighbourhood-cascade` Stimulus controller disables the other levels on
+# change so only the one you touched is applied. Selecting any level filters its
+# whole subtree, and the page re-renders the levels for the new selection.
 class Components::Directory::NeighbourhoodCascade < Components::Directory::Base
   prop :tree, _Interface(:each)
   prop :selected, _Nilable(String), default: nil
@@ -14,23 +15,86 @@ class Components::Directory::NeighbourhoodCascade < Components::Directory::Base
 
   def view_template
     div(
-      class: 'min-w-0',
-      data: {
-        controller: 'neighbourhood-cascade',
-        neighbourhood_cascade_tree_value: @tree.to_a.to_json,
-        neighbourhood_cascade_selected_value: @selected.to_s,
-        neighbourhood_cascade_label_value: @label_text
-      }
+      class: 'basis-full md:basis-auto md:shrink-0',
+      data: { controller: 'neighbourhood-cascade', action: 'change->neighbourhood-cascade#onChange' }
     ) do
       label(class: 'block allcaps-label text-tertiary mb-1') { @label_text }
-      input(
-        type: 'hidden', name: 'neighbourhood', value: @selected,
-        data: { neighbourhood_cascade_target: 'field' }
-      )
-      div(
-        class: 'flex flex-wrap gap-2',
-        data: { neighbourhood_cascade_target: 'selects' }
-      )
+      div(class: 'flex flex-wrap gap-2') do
+        cascade_levels.each do |level|
+          div(class: 'w-full md:w-56') do
+            Directory::CustomSelect(
+              name: 'neighbourhood',
+              label_text: nil,
+              options: level[:options],
+              selected: level[:selected],
+              include_blank: level[:include_blank],
+              default_label: level[:default_label]
+            )
+          end
+        end
+      end
     end
+  end
+
+  private
+
+  # One dropdown per level along the selected path, plus the next level so you
+  # can keep drilling. The first level clears the filter; deeper levels offer an
+  # "All of <parent>" option that filters by the parent's whole subtree.
+  def cascade_levels
+    roots = @tree.to_a
+    path = find_path(roots, @selected)
+    levels = []
+    nodes = roots
+    depth = 0
+
+    loop do
+      selected_node = path[depth]
+      levels << level_for(nodes, selected_node, path, depth)
+      break unless selected_node
+
+      nodes = selected_node[:children] || []
+      break if nodes.empty?
+
+      depth += 1
+    end
+
+    levels
+  end
+
+  def level_for(nodes, selected_node, path, depth)
+    if depth.zero?
+      {
+        options: nodes.map { |n| option_for(n) },
+        selected: selected_node && selected_node[:id].to_s,
+        include_blank: true,
+        default_label: "All #{@label_text.downcase.pluralize}"
+      }
+    else
+      parent = path[depth - 1]
+      {
+        options: [{ id: parent[:id], name: "All of #{parent[:name]}" }] + nodes.map { |n| option_for(n) },
+        selected: (selected_node || parent)[:id].to_s,
+        include_blank: false,
+        default_label: nil
+      }
+    end
+  end
+
+  def option_for(node)
+    { id: node[:id], name: node[:name], count: node[:count] }
+  end
+
+  # Chain of nodes from a root down to the node with the given id.
+  def find_path(nodes, target_id)
+    return [] if target_id.blank?
+
+    nodes.each do |node|
+      return [node] if node[:id].to_s == target_id.to_s
+
+      child_path = find_path(node[:children] || [], target_id)
+      return [node, *child_path] if child_path.any?
+    end
+    []
   end
 end

--- a/app/components/directory/neighbourhood_cascade.rb
+++ b/app/components/directory/neighbourhood_cascade.rb
@@ -21,7 +21,7 @@ class Components::Directory::NeighbourhoodCascade < Components::Directory::Base
       label(class: 'block allcaps-label text-tertiary mb-1') { @label_text }
       div(class: 'flex flex-wrap gap-2') do
         cascade_levels.each do |level|
-          div(class: 'w-full md:w-56') do
+          div(class: 'flex-1 min-w-0 md:flex-none md:w-56') do
             Directory::CustomSelect(
               name: 'neighbourhood',
               label_text: nil,

--- a/app/components/directory/partner_filter.rb
+++ b/app/components/directory/partner_filter.rb
@@ -18,11 +18,11 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
          class: 'bg-home-background-3 rounded-card p-4 mb-4 text-sm') do
       div(class: 'flex flex-wrap lg:flex-nowrap gap-3 items-end') do
         render_search_field
-        Directory::CustomSelect(name: 'category', label_text: 'Category', options: @categories, selected: @selected_category) if @categories.any?
-        Directory::CustomSelect(name: 'partnership', label_text: 'Partnership', options: @partnerships_list, selected: @selected_partnership) if @partnerships_list.any?
+        Directory::CustomSelect(name: 'category', label_text: t('directory.partners.index.filters.category'), default_label: t('directory.partners.index.filters.all_categories'), options: @categories, selected: @selected_category) if @categories.any?
+        Directory::CustomSelect(name: 'partnership', label_text: t('directory.partners.index.filters.partnership'), default_label: t('directory.partners.index.filters.all_partnerships'), options: @partnerships_list, selected: @selected_partnership) if @partnerships_list.any?
       end
       div(class: 'flex flex-wrap gap-3 items-end mt-3') do
-        Directory::NeighbourhoodCascade(tree: @neighbourhoods_tree, selected: @selected_neighbourhood) if @neighbourhoods_tree.any?
+        Directory::NeighbourhoodCascade(tree: @neighbourhoods_tree, selected: @selected_neighbourhood, label_text: t('directory.partners.index.filters.neighbourhood')) if @neighbourhoods_tree.any?
         render_buttons
       end
     end
@@ -34,10 +34,10 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
     # Full width on its own line when wrapped, so Category and Partnership get a
     # roomy half each instead of three cramped columns; shares the row on lg.
     div(class: 'flex-1 basis-full lg:basis-auto min-w-35') do
-      label(for: 'q', class: 'block allcaps-label text-tertiary mb-1') { 'Search' }
+      label(for: 'q', class: 'block allcaps-label text-tertiary mb-1') { t('directory.partners.index.filters.search') }
       input(
         type: 'text', name: 'q', id: 'q', value: @query,
-        placeholder: 'Name or keyword…',
+        placeholder: t('directory.partners.index.filters.search_placeholder'),
         class: 'w-full h-[42px] border-2 border-rules rounded-sm px-4 text-sm bg-background text-foreground outline-none focus:border-foreground transition-colors'
       )
     end
@@ -47,12 +47,12 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
     div(class: 'flex gap-2 items-end') do
       button(type: 'submit',
              class: 'inline-flex items-center justify-center h-[42px] bg-foreground text-background rounded-sm px-5 text-sm font-bold border-2 border-foreground cursor-pointer hover:bg-tertiary hover:border-tertiary transition-colors') do
-        plain 'Filter'
+        plain t('directory.partners.index.filters.apply')
       end
       if any_filter_active?
         a(href: partners_path,
           class: 'with-no-sass inline-flex items-center justify-center h-[42px] rounded-sm px-4 text-sm font-bold bg-background text-foreground border-2 border-foreground no-underline hover:bg-foreground hover:text-background transition-colors') do
-          plain 'Clear'
+          plain t('directory.partners.index.filters.clear')
         end
       end
     end

--- a/app/components/directory/partner_filter.rb
+++ b/app/components/directory/partner_filter.rb
@@ -6,19 +6,23 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
   prop :query, _Nilable(String), default: nil
   prop :categories, _Interface(:each), default: -> { [] }
   prop :partnerships_list, _Interface(:each), default: -> { [] }
-  prop :neighbourhoods, _Interface(:each), default: -> { [] }
+  prop :neighbourhoods_tree, _Interface(:each), default: -> { [] }
   prop :selected_category, _Nilable(String), default: nil
   prop :selected_partnership, _Nilable(String), default: nil
   prop :selected_neighbourhood, _Nilable(String), default: nil
 
   def view_template
+    # text-sm on the form so buttons/inputs (which an unlayered `font-size:100%`
+    # reset pins to the base size) inherit the same size as the native selects.
     form(action: partners_path, method: 'get',
-         class: 'bg-home-background-3 rounded-card p-4 mb-4') do
+         class: 'bg-home-background-3 rounded-card p-4 mb-4 text-sm') do
       div(class: 'flex flex-wrap lg:flex-nowrap gap-3 items-end') do
         render_search_field
         Directory::CustomSelect(name: 'category', label_text: 'Category', options: @categories, selected: @selected_category) if @categories.any?
         Directory::CustomSelect(name: 'partnership', label_text: 'Partnership', options: @partnerships_list, selected: @selected_partnership) if @partnerships_list.any?
-        Directory::CustomSelect(name: 'neighbourhood', label_text: 'Neighbourhood', options: @neighbourhoods, selected: @selected_neighbourhood) if @neighbourhoods.any?
+      end
+      div(class: 'flex flex-wrap gap-3 items-end mt-3') do
+        Directory::NeighbourhoodCascade(tree: @neighbourhoods_tree, selected: @selected_neighbourhood) if @neighbourhoods_tree.any?
         render_buttons
       end
     end
@@ -27,12 +31,14 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
   private
 
   def render_search_field
-    div(class: 'flex-1 min-w-35') do
+    # Full width on its own line when wrapped, so Category and Partnership get a
+    # roomy half each instead of three cramped columns; shares the row on lg.
+    div(class: 'flex-1 basis-full lg:basis-auto min-w-35') do
       label(for: 'q', class: 'block allcaps-label text-tertiary mb-1') { 'Search' }
       input(
         type: 'text', name: 'q', id: 'q', value: @query,
         placeholder: 'Name or keyword…',
-        class: 'w-full border-2 border-rules rounded-full px-4 py-2 text-sm bg-background text-foreground outline-none focus:border-foreground transition-colors'
+        class: 'w-full border-2 border-rules rounded-sm px-4 py-2 text-sm bg-background text-foreground outline-none focus:border-foreground transition-colors'
       )
     end
   end
@@ -40,12 +46,12 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
   def render_buttons
     div(class: 'flex gap-2 items-end') do
       button(type: 'submit',
-             class: 'bg-foreground text-background rounded-full px-5 py-2 text-sm font-bold border-0 cursor-pointer hover:bg-tertiary transition-colors') do
+             class: 'bg-foreground text-background rounded-sm px-5 py-2 text-sm font-bold border-2 border-foreground cursor-pointer hover:bg-tertiary hover:border-tertiary transition-colors') do
         plain 'Filter'
       end
       if any_filter_active?
         a(href: partners_path,
-          class: 'inline-flex items-center rounded-full px-4 py-2 text-sm font-bold text-tertiary border-2 border-rules no-underline hover:border-foreground transition-colors') do
+          class: 'inline-flex items-center rounded-sm px-4 py-2 text-sm font-bold bg-background text-foreground border-2 border-rules no-underline hover:border-foreground transition-colors') do
           plain 'Clear'
         end
       end

--- a/app/components/directory/partner_filter.rb
+++ b/app/components/directory/partner_filter.rb
@@ -38,7 +38,7 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
       input(
         type: 'text', name: 'q', id: 'q', value: @query,
         placeholder: 'Name or keyword…',
-        class: 'w-full border-2 border-rules rounded-sm px-4 py-2 text-sm bg-background text-foreground outline-none focus:border-foreground transition-colors'
+        class: 'w-full h-[42px] border-2 border-rules rounded-sm px-4 text-sm bg-background text-foreground outline-none focus:border-foreground transition-colors'
       )
     end
   end

--- a/app/components/directory/partner_filter.rb
+++ b/app/components/directory/partner_filter.rb
@@ -46,12 +46,12 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
   def render_buttons
     div(class: 'flex gap-2 items-end') do
       button(type: 'submit',
-             class: 'bg-foreground text-background rounded-sm px-5 py-2 text-sm font-bold border-2 border-foreground cursor-pointer hover:bg-tertiary hover:border-tertiary transition-colors') do
+             class: 'inline-flex items-center justify-center h-[42px] bg-foreground text-background rounded-sm px-5 text-sm font-bold border-2 border-foreground cursor-pointer hover:bg-tertiary hover:border-tertiary transition-colors') do
         plain 'Filter'
       end
       if any_filter_active?
         a(href: partners_path,
-          class: 'inline-flex items-center rounded-sm px-4 py-2 text-sm font-bold bg-background text-foreground border-2 border-rules no-underline hover:border-foreground transition-colors') do
+          class: 'inline-flex items-center justify-center h-[42px] rounded-sm px-4 text-sm font-bold bg-background text-foreground border-2 border-rules no-underline hover:border-foreground transition-colors') do
           plain 'Clear'
         end
       end

--- a/app/components/directory/partner_filter.rb
+++ b/app/components/directory/partner_filter.rb
@@ -51,7 +51,7 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
       end
       if any_filter_active?
         a(href: partners_path,
-          class: 'inline-flex items-center justify-center h-[42px] rounded-sm px-4 text-sm font-bold bg-background text-foreground border-2 border-rules no-underline hover:border-foreground transition-colors') do
+          class: 'inline-flex items-center justify-center h-[42px] rounded-sm px-4 text-sm font-bold bg-background text-foreground border-2 border-foreground no-underline hover:bg-foreground hover:text-background transition-colors') do
           plain 'Clear'
         end
       end

--- a/app/components/directory/partner_filter.rb
+++ b/app/components/directory/partner_filter.rb
@@ -51,7 +51,7 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
       end
       if any_filter_active?
         a(href: partners_path,
-          class: 'inline-flex items-center justify-center h-[42px] rounded-sm px-4 text-sm font-bold bg-background text-foreground border-2 border-foreground no-underline hover:bg-foreground hover:text-background transition-colors') do
+          class: 'with-no-sass inline-flex items-center justify-center h-[42px] rounded-sm px-4 text-sm font-bold bg-background text-foreground border-2 border-foreground no-underline hover:bg-foreground hover:text-background transition-colors') do
           plain 'Clear'
         end
       end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -113,23 +113,30 @@ class PartnersController < ApplicationController
   def render_directory_index
     @sort = params[:sort] || 'recent'
     query = PartnersQuery.new(site: current_site)
-    partners = query.call(
+    filters = {
       query: params[:q],
       tag_id: params[:category],
       partnership_id: params[:partnership],
-      neighbourhood_id: params[:neighbourhood],
-      sort: @sort
-    )
+      neighbourhood_id: params[:neighbourhood]
+    }
+    partners = query.call(**filters, sort: @sort)
     paginate_with_az_filter(partners)
+
+    # Each facet's counts cross-filter on the OTHER active filters but not its
+    # own, so the numbers narrow as you filter while you can still switch within
+    # a facet (e.g. the category list reflects the chosen neighbourhood).
+    category_scope = query.call(**filters.except(:tag_id))
+    partnership_scope = query.call(**filters.except(:partnership_id))
+    neighbourhood_scope = query.call(**filters.except(:neighbourhood_id))
 
     render Views::Directory::Partners::Index.new(
       partners: @partners, pagy: @pagy, site: @site, query: params[:q], sort: @sort,
       az_letters: @az_letters, selected_letter: @selected_letter,
       total_count: Partner.visible.count,
       partnership_count: Site.where(is_published: true).where.not(slug: 'default-site').count,
-      categories: query.categories_with_counts.map { |c| { id: c[:category].id, name: c[:category].name, count: c[:count] } },
-      partnerships_list: query.partnerships_with_counts.map { |p| { id: p[:partnership].id, name: p[:partnership].name, count: p[:count] } },
-      neighbourhoods_tree: query.neighbourhood_tree,
+      categories: query.categories_with_counts(scope: category_scope).map { |c| { id: c[:category].id, name: c[:category].name, count: c[:count] } },
+      partnerships_list: query.partnerships_with_counts(scope: partnership_scope).map { |p| { id: p[:partnership].id, name: p[:partnership].name, count: p[:count] } },
+      neighbourhoods_tree: query.neighbourhood_tree(scope: neighbourhood_scope),
       selected_category: params[:category],
       selected_partnership: params[:partnership],
       selected_neighbourhood: params[:neighbourhood]

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -129,9 +129,7 @@ class PartnersController < ApplicationController
       partnership_count: Site.where(is_published: true).where.not(slug: 'default-site').count,
       categories: query.categories_with_counts.map { |c| { id: c[:category].id, name: c[:category].name, count: c[:count] } },
       partnerships_list: query.partnerships_with_counts.map { |p| { id: p[:partnership].id, name: p[:partnership].name, count: p[:count] } },
-      neighbourhoods: ensure_selected_neighbourhood(
-        group_neighbourhoods_by_district(query.neighbourhoods_with_counts), params[:neighbourhood]
-      ),
+      neighbourhoods_tree: query.neighbourhood_tree,
       selected_category: params[:category],
       selected_partnership: params[:partnership],
       selected_neighbourhood: params[:neighbourhood]
@@ -152,32 +150,6 @@ class PartnersController < ApplicationController
       @selected_letter = nil
       @pagy, @partners = pagy(partners, limit: 30)
     end
-  end
-
-  def group_neighbourhoods_by_district(neighbourhoods_with_counts)
-    grouped = neighbourhoods_with_counts
-              .group_by { |n| n[:neighbourhood].district&.shortname || n[:neighbourhood].shortname }
-              .map do |district_name, items|
-                {
-                  group: district_name,
-                  items: items.map { |n| { id: n[:neighbourhood].id, name: n[:neighbourhood].shortname, count: n[:count] } }
-                }
-              end
-    grouped.sort_by { |g| g[:group] }
-  end
-
-  # Area-level neighbourhoods (e.g. a district linked from a homepage jump
-  # link) aren't in the dropdown, which only lists neighbourhoods partners are
-  # directly assigned to. Inject the selected one so the filter UI reflects it.
-  def ensure_selected_neighbourhood(grouped, neighbourhood_id)
-    return grouped if neighbourhood_id.blank?
-    return grouped if grouped.any? { |g| g[:items].any? { |i| i[:id].to_s == neighbourhood_id.to_s } }
-
-    neighbourhood = Neighbourhood.find_by(id: neighbourhood_id)
-    return grouped unless neighbourhood
-
-    group_name = neighbourhood.district&.shortname || neighbourhood.shortname
-    grouped + [{ group: group_name, items: [{ id: neighbourhood.id, name: neighbourhood.shortname }] }]
   end
 
   def render_local_index

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -136,7 +136,7 @@ class PartnersController < ApplicationController
       partnership_count: Site.where(is_published: true).where.not(slug: 'default-site').count,
       categories: query.categories_with_counts(scope: category_scope).map { |c| { id: c[:category].id, name: c[:category].name, count: c[:count] } },
       partnerships_list: query.partnerships_with_counts(scope: partnership_scope).map { |p| { id: p[:partnership].id, name: p[:partnership].name, count: p[:count] } },
-      neighbourhoods_tree: query.neighbourhood_tree(scope: neighbourhood_scope),
+      neighbourhoods_tree: query.neighbourhood_tree(scope: neighbourhood_scope, selected_id: params[:neighbourhood]),
       selected_category: params[:category],
       selected_partnership: params[:partnership],
       selected_neighbourhood: params[:neighbourhood]

--- a/app/javascript/controllers/custom_select_controller.js
+++ b/app/javascript/controllers/custom_select_controller.js
@@ -47,6 +47,9 @@ export default class extends Controller {
 		this.hiddenSelectTarget.dispatchEvent(
 			new Event("change", { bubbles: true }),
 		);
+
+		// Apply the filter immediately on selection — no need to press Filter.
+		this.element.closest("form")?.requestSubmit();
 	}
 
 	closeOnOutsideClick(event) {

--- a/app/javascript/controllers/neighbourhood_cascade_controller.js
+++ b/app/javascript/controllers/neighbourhood_cascade_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
 	static values = {
 		tree: Array,
 		selected: String,
+		label: { type: String, default: "Neighbourhood" },
 	};
 
 	connect() {
@@ -41,6 +42,14 @@ export default class extends Controller {
 		select.className =
 			"w-full sm:w-56 border-2 border-rules rounded-sm px-4 py-2 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors";
 		select.dataset.depth = depth;
+		// Accessible name: the dynamically-created selects aren't tied to the
+		// visible label, so give each one an explicit aria-label.
+		select.setAttribute(
+			"aria-label",
+			depth === 0
+				? this.labelValue
+				: `${this.labelValue} within ${this.path[depth - 1].name}`,
+		);
 		// Bind directly rather than via data-action: these selects are created
 		// dynamically and Stimulus's action observer binds asynchronously, which
 		// can miss a fast first interaction. A direct listener is bound immediately.

--- a/app/javascript/controllers/neighbourhood_cascade_controller.js
+++ b/app/javascript/controllers/neighbourhood_cascade_controller.js
@@ -95,6 +95,11 @@ export default class extends Controller {
 			if (node) this.path.push(node);
 		}
 		this.render();
+
+		// Apply the filter immediately on selection — no need to press Filter.
+		// (render() has already updated the hidden field.) The cascade rebuilds
+		// itself from the URL on the next page, so drilling further still works.
+		this.element.closest("form")?.requestSubmit();
 	}
 
 	// The list of nodes shown by the select at the given depth.

--- a/app/javascript/controllers/neighbourhood_cascade_controller.js
+++ b/app/javascript/controllers/neighbourhood_cascade_controller.js
@@ -1,0 +1,123 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Cascading neighbourhood filter for the directory.
+//
+// Drills the geographic hierarchy (region > county > district > ward) using a
+// preloaded tree — no AJAX. Each select shows the children of the level above;
+// the hidden `neighbourhood` field always carries the deepest selected id, so
+// stopping at any level filters that whole subtree.
+export default class extends Controller {
+	static targets = ["field", "selects"];
+	static values = {
+		tree: Array,
+		selected: String,
+	};
+
+	connect() {
+		// Path of selected nodes from the root down to the deepest selection.
+		this.path = this.findPath(this.treeValue, this.selectedValue);
+		this.render({ initial: true });
+	}
+
+	// Rebuild one select per level along the current path, plus the next empty
+	// level so the user can keep drilling down.
+	render({ initial = false } = {}) {
+		this.selectsTarget.innerHTML = "";
+		let nodes = this.treeValue;
+		for (let depth = 0; nodes && nodes.length > 0; depth++) {
+			const selected = this.path[depth];
+			this.appendSelect(nodes, selected, depth);
+			if (!selected) break;
+			nodes = selected.children || [];
+		}
+		this.updateField(initial);
+	}
+
+	appendSelect(nodes, selected, depth) {
+		const wrapper = document.createElement("div");
+		wrapper.className = "min-w-0 flex-1";
+
+		const select = document.createElement("select");
+		select.className =
+			"w-full sm:w-56 border-2 border-rules rounded-sm px-4 py-2 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors";
+		select.dataset.depth = depth;
+		// Bind directly rather than via data-action: these selects are created
+		// dynamically and Stimulus's action observer binds asynchronously, which
+		// can miss a fast first interaction. A direct listener is bound immediately.
+		select.addEventListener("change", (event) => this.change(event));
+
+		// Parent-relative placeholder, so messy/inconsistent unit labels in the
+		// source data never produce a wrong level name ("All districts" over a
+		// list of counties). Picking it filters by the parent's whole subtree.
+		const placeholder = document.createElement("option");
+		placeholder.value = "";
+		placeholder.textContent =
+			depth === 0
+				? "All neighbourhoods"
+				: `All of ${this.path[depth - 1].name}`;
+		select.appendChild(placeholder);
+
+		nodes.forEach((node) => {
+			const option = document.createElement("option");
+			option.value = String(node.id);
+			option.textContent = node.count
+				? `${node.name} (${node.count})`
+				: node.name;
+			if (selected && String(node.id) === String(selected.id)) {
+				option.selected = true;
+			}
+			select.appendChild(option);
+		});
+
+		wrapper.appendChild(select);
+		this.selectsTarget.appendChild(wrapper);
+	}
+
+	change(event) {
+		const depth = Number(event.target.dataset.depth);
+		const value = event.target.value;
+
+		// Drop this level and anything below it, then re-add the new selection.
+		this.path = this.path.slice(0, depth);
+		if (value) {
+			const node = this.nodesAtDepth(depth).find(
+				(n) => String(n.id) === String(value),
+			);
+			if (node) this.path.push(node);
+		}
+		this.render();
+	}
+
+	// The list of nodes shown by the select at the given depth.
+	nodesAtDepth(depth) {
+		let nodes = this.treeValue;
+		for (let d = 0; d < depth; d++) {
+			nodes = this.path[d] ? this.path[d].children || [] : [];
+		}
+		return nodes;
+	}
+
+	updateField(initial = false) {
+		const deepest = this.path[this.path.length - 1];
+		if (deepest) {
+			this.fieldTarget.value = String(deepest.id);
+		} else if (!initial) {
+			// User cleared the selection. On initial render we leave the
+			// server-rendered value untouched, so a selected neighbourhood that
+			// isn't in the preloaded tree (e.g. one with no partners) survives.
+			this.fieldTarget.value = "";
+		}
+	}
+
+	// Walk the tree to the node with the given id, returning the chain of nodes
+	// from the root down to it (empty when nothing is selected or not found).
+	findPath(nodes, targetId) {
+		if (!targetId) return [];
+		for (const node of nodes) {
+			if (String(node.id) === String(targetId)) return [node];
+			const childPath = this.findPath(node.children || [], targetId);
+			if (childPath.length) return [node, ...childPath];
+		}
+		return [];
+	}
+}

--- a/app/javascript/controllers/neighbourhood_cascade_controller.js
+++ b/app/javascript/controllers/neighbourhood_cascade_controller.js
@@ -40,7 +40,7 @@ export default class extends Controller {
 
 		const select = document.createElement("select");
 		select.className =
-			"w-full sm:w-56 border-2 border-rules rounded-sm px-4 py-2 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors";
+			"w-full sm:w-56 h-[42px] border-2 border-rules rounded-sm px-4 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors";
 		select.dataset.depth = depth;
 		// Accessible name: the dynamically-created selects aren't tied to the
 		// visible label, so give each one an explicit aria-label.

--- a/app/javascript/controllers/neighbourhood_cascade_controller.js
+++ b/app/javascript/controllers/neighbourhood_cascade_controller.js
@@ -1,137 +1,17 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Cascading neighbourhood filter for the directory.
+// Cascading neighbourhood filter.
 //
-// Drills the geographic hierarchy (region > county > district > ward) using a
-// preloaded tree — no AJAX. Each select shows the children of the level above;
-// the hidden `neighbourhood` field always carries the deepest selected id, so
-// stopping at any level filters that whole subtree.
+// Each geographic level is a CustomSelect that submits under the same
+// `neighbourhood` name. When one changes, disable the others so only the level
+// you touched is submitted — then the form's auto-submit applies just that one
+// and the server re-renders the levels for the new selection.
 export default class extends Controller {
-	static targets = ["field", "selects"];
-	static values = {
-		tree: Array,
-		selected: String,
-		label: { type: String, default: "Neighbourhood" },
-	};
-
-	connect() {
-		// Path of selected nodes from the root down to the deepest selection.
-		this.path = this.findPath(this.treeValue, this.selectedValue);
-		this.render({ initial: true });
-	}
-
-	// Rebuild one select per level along the current path, plus the next empty
-	// level so the user can keep drilling down.
-	render({ initial = false } = {}) {
-		this.selectsTarget.innerHTML = "";
-		let nodes = this.treeValue;
-		for (let depth = 0; nodes && nodes.length > 0; depth++) {
-			const selected = this.path[depth];
-			this.appendSelect(nodes, selected, depth);
-			if (!selected) break;
-			nodes = selected.children || [];
+	onChange(event) {
+		for (const select of this.element.querySelectorAll(
+			"select[name='neighbourhood']",
+		)) {
+			if (select !== event.target) select.disabled = true;
 		}
-		this.updateField(initial);
-	}
-
-	appendSelect(nodes, selected, depth) {
-		const wrapper = document.createElement("div");
-		wrapper.className = "min-w-0 flex-1";
-
-		const select = document.createElement("select");
-		select.className =
-			"w-full sm:w-56 h-[42px] border-2 border-rules rounded-sm px-4 text-sm bg-background text-foreground cursor-pointer hover:border-foreground transition-colors";
-		select.dataset.depth = depth;
-		// Accessible name: the dynamically-created selects aren't tied to the
-		// visible label, so give each one an explicit aria-label.
-		select.setAttribute(
-			"aria-label",
-			depth === 0
-				? this.labelValue
-				: `${this.labelValue} within ${this.path[depth - 1].name}`,
-		);
-		// Bind directly rather than via data-action: these selects are created
-		// dynamically and Stimulus's action observer binds asynchronously, which
-		// can miss a fast first interaction. A direct listener is bound immediately.
-		select.addEventListener("change", (event) => this.change(event));
-
-		// Parent-relative placeholder, so messy/inconsistent unit labels in the
-		// source data never produce a wrong level name ("All districts" over a
-		// list of counties). Picking it filters by the parent's whole subtree.
-		const placeholder = document.createElement("option");
-		placeholder.value = "";
-		placeholder.textContent =
-			depth === 0
-				? "All neighbourhoods"
-				: `All of ${this.path[depth - 1].name}`;
-		select.appendChild(placeholder);
-
-		nodes.forEach((node) => {
-			const option = document.createElement("option");
-			option.value = String(node.id);
-			option.textContent = node.count
-				? `${node.name} (${node.count})`
-				: node.name;
-			if (selected && String(node.id) === String(selected.id)) {
-				option.selected = true;
-			}
-			select.appendChild(option);
-		});
-
-		wrapper.appendChild(select);
-		this.selectsTarget.appendChild(wrapper);
-	}
-
-	change(event) {
-		const depth = Number(event.target.dataset.depth);
-		const value = event.target.value;
-
-		// Drop this level and anything below it, then re-add the new selection.
-		this.path = this.path.slice(0, depth);
-		if (value) {
-			const node = this.nodesAtDepth(depth).find(
-				(n) => String(n.id) === String(value),
-			);
-			if (node) this.path.push(node);
-		}
-		this.render();
-
-		// Apply the filter immediately on selection — no need to press Filter.
-		// (render() has already updated the hidden field.) The cascade rebuilds
-		// itself from the URL on the next page, so drilling further still works.
-		this.element.closest("form")?.requestSubmit();
-	}
-
-	// The list of nodes shown by the select at the given depth.
-	nodesAtDepth(depth) {
-		let nodes = this.treeValue;
-		for (let d = 0; d < depth; d++) {
-			nodes = this.path[d] ? this.path[d].children || [] : [];
-		}
-		return nodes;
-	}
-
-	updateField(initial = false) {
-		const deepest = this.path[this.path.length - 1];
-		if (deepest) {
-			this.fieldTarget.value = String(deepest.id);
-		} else if (!initial) {
-			// User cleared the selection. On initial render we leave the
-			// server-rendered value untouched, so a selected neighbourhood that
-			// isn't in the preloaded tree (e.g. one with no partners) survives.
-			this.fieldTarget.value = "";
-		}
-	}
-
-	// Walk the tree to the node with the given id, returning the chain of nodes
-	// from the root down to it (empty when nothing is selected or not found).
-	findPath(nodes, targetId) {
-		if (!targetId) return [];
-		for (const node of nodes) {
-			if (String(node.id) === String(targetId)) return [node];
-			const childPath = this.findPath(node.children || [], targetId);
-			if (childPath.length) return [node, ...childPath];
-		}
-		return [];
 	}
 }

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -62,13 +62,20 @@ class PartnersQuery
   # matching what filtering by that node returns. The country level is dropped
   # (it filters to everything, same as no filter) and its children become roots.
   #
+  # @param selected_id [Integer, String, nil] keep this neighbourhood in the
+  #   tree even when the current scope leaves it with no partners, so the picker
+  #   still reflects the active selection
   # @return [Array<Hash>] nested nodes of
   #   { id:, name:, unit:, count:, children: [...] }
-  def neighbourhood_tree(scope: nil)
+  def neighbourhood_tree(scope: nil, selected_id: nil)
     pairs = neighbourhood_partner_pairs(scope: scope)
-    return [] if pairs.empty?
-
     direct = Neighbourhood.where(id: pairs.map { |r| r['neighbourhood_id'] }.uniq).to_a
+
+    selected = Neighbourhood.find_by(id: selected_id) if selected_id.present?
+    direct << selected if selected && direct.none? { |n| n.id == selected.id }
+
+    return [] if direct.empty?
+
     ancestor_ids = direct.flat_map(&:ancestor_ids).uniq
     nodes = Neighbourhood.where(id: (direct.map(&:id) + ancestor_ids).uniq).to_a
     by_id = nodes.index_by(&:id)

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -39,23 +39,7 @@ class PartnersQuery
   #
   # @return [Array<Hash>] array of { neighbourhood: Neighbourhood, count: Integer }
   def neighbourhoods_with_counts(scope: nil)
-    partner_ids = (scope || base_scope).reorder(nil).select(:id)
-
-    pairs = ActiveRecord::Base.connection.select_all(<<~SQL) # rubocop:disable Rails/SquishedSQLHeredocs
-      SELECT neighbourhood_id, partner_id FROM (
-        SELECT a.neighbourhood_id, p.id AS partner_id
-        FROM partners p
-        INNER JOIN addresses a ON a.id = p.address_id
-        WHERE p.id IN (#{partner_ids.to_sql})
-          AND a.neighbourhood_id IS NOT NULL
-        UNION
-        SELECT sa.neighbourhood_id, sa.partner_id
-        FROM service_areas sa
-        WHERE sa.partner_id IN (#{partner_ids.to_sql})
-          AND sa.neighbourhood_id IS NOT NULL
-      ) AS combined
-    SQL
-
+    pairs = neighbourhood_partner_pairs(scope: scope)
     return [] if pairs.empty?
 
     direct_ids = pairs.map { |r| r['neighbourhood_id'] }.uniq
@@ -64,17 +48,33 @@ class PartnersQuery
     # Roll each partner up to its neighbourhood and all listed ancestors, so an
     # area-level neighbourhood's count matches what filtering by it returns (its
     # whole subtree) and the dropdown stays consistent with the results.
-    listed = neighbourhoods.index_by(&:id)
-    partner_sets = Hash.new { |hash, key| hash[key] = Set.new }
-    pairs.each do |row|
-      node = listed[row['neighbourhood_id']]
-      next unless node
+    counts = rollup_partner_counts(pairs, neighbourhoods.index_by(&:id))
 
-      credited = [node.id] + node.ancestor_ids.select { |id| listed.key?(id) }
-      credited.each { |id| partner_sets[id] << row['partner_id'] }
-    end
+    neighbourhoods.map { |n| { neighbourhood: n, count: counts[n.id] } }
+  end
 
-    neighbourhoods.map { |n| { neighbourhood: n, count: partner_sets[n.id].size } }
+  # Returns the full geographic hierarchy of neighbourhoods that have partners,
+  # as a nested tree for the directory's cascading neighbourhood filter.
+  #
+  # Every neighbourhood a partner is assigned to is included along with all of
+  # its ancestors, so the cascade can be drilled region > county > district >
+  # ward. Each node's count is the number of distinct partners in its subtree,
+  # matching what filtering by that node returns. The country level is dropped
+  # (it filters to everything, same as no filter) and its children become roots.
+  #
+  # @return [Array<Hash>] nested nodes of
+  #   { id:, name:, unit:, count:, children: [...] }
+  def neighbourhood_tree(scope: nil)
+    pairs = neighbourhood_partner_pairs(scope: scope)
+    return [] if pairs.empty?
+
+    direct = Neighbourhood.where(id: pairs.map { |r| r['neighbourhood_id'] }.uniq).to_a
+    ancestor_ids = direct.flat_map(&:ancestor_ids).uniq
+    nodes = Neighbourhood.where(id: (direct.map(&:id) + ancestor_ids).uniq).to_a
+    by_id = nodes.index_by(&:id)
+
+    counts = rollup_partner_counts(pairs, by_id)
+    build_neighbourhood_tree(nodes, by_id, counts)
   end
 
   # Returns partnerships that have partners, with counts
@@ -106,6 +106,91 @@ class PartnersQuery
   end
 
   private
+
+  # ===================
+  # Neighbourhood roll-up helpers
+  # ===================
+
+  # Distinct (neighbourhood_id, partner_id) pairs for partners in the scope,
+  # via either their address or a service area. Shared by the dropdown count
+  # and the cascade tree so both reflect the same set of partners.
+  #
+  # @return [Array<Hash>] rows with 'neighbourhood_id' and 'partner_id'
+  def neighbourhood_partner_pairs(scope: nil)
+    partner_ids = (scope || base_scope).reorder(nil).select(:id)
+
+    ActiveRecord::Base.connection.select_all(<<~SQL).to_a # rubocop:disable Rails/SquishedSQLHeredocs
+      SELECT neighbourhood_id, partner_id FROM (
+        SELECT a.neighbourhood_id, p.id AS partner_id
+        FROM partners p
+        INNER JOIN addresses a ON a.id = p.address_id
+        WHERE p.id IN (#{partner_ids.to_sql})
+          AND a.neighbourhood_id IS NOT NULL
+        UNION
+        SELECT sa.neighbourhood_id, sa.partner_id
+        FROM service_areas sa
+        WHERE sa.partner_id IN (#{partner_ids.to_sql})
+          AND sa.neighbourhood_id IS NOT NULL
+      ) AS combined
+    SQL
+  end
+
+  # Credit each partner to its neighbourhood and every ancestor present in
+  # +by_id+, so an area-level node's count matches its whole subtree.
+  #
+  # @param pairs [Array<Hash>] neighbourhood/partner rows
+  # @param by_id [Hash{Integer => Neighbourhood}] nodes to credit
+  # @return [Hash{Integer => Integer}] neighbourhood id => distinct partner count
+  def rollup_partner_counts(pairs, by_id)
+    partner_sets = Hash.new { |hash, key| hash[key] = Set.new }
+    pairs.each do |row|
+      node = by_id[row['neighbourhood_id']]
+      next unless node
+
+      [node.id, *node.ancestor_ids].each do |id|
+        partner_sets[id] << row['partner_id'] if by_id.key?(id)
+      end
+    end
+    partner_sets.transform_values(&:size)
+  end
+
+  # Assemble +nodes+ into a nested tree, dropping the country level and
+  # re-rooting its children. Children are sorted by name at every level.
+  #
+  # @return [Array<Hash>] root nodes of { id:, name:, unit:, count:, children: }
+  def build_neighbourhood_tree(nodes, by_id, counts)
+    children_of = Hash.new { |hash, key| hash[key] = [] }
+    roots = []
+
+    nodes.each do |node|
+      next if country?(node)
+
+      parent = by_id[node.parent_id]
+      if parent.nil? || country?(parent)
+        roots << node
+      else
+        children_of[node.parent_id] << node
+      end
+    end
+
+    build = lambda do |node|
+      {
+        id: node.id,
+        name: node.shortname,
+        unit: node.unit.to_s,
+        count: counts[node.id] || 0,
+        children: children_of[node.id].sort_by { |c| c.shortname.downcase }.map(&build)
+      }
+    end
+
+    roots.sort_by { |n| n.shortname.downcase }.map(&build)
+  end
+
+  # @return [Boolean] whether the node is country-level (the unit attribute is
+  #   the canonical level marker; the numeric `level` column is often unset)
+  def country?(node)
+    node.unit.to_s == 'country'
+  end
 
   # ===================
   # Base Scope

--- a/app/views/directory/partners/index.rb
+++ b/app/views/directory/partners/index.rb
@@ -7,7 +7,7 @@ class Views::Directory::Partners::Index < Views::Base
   prop :query, _Nilable(String), default: nil
   prop :categories, _Interface(:each), default: -> { [] }
   prop :partnerships_list, _Interface(:each), default: -> { [] }
-  prop :neighbourhoods, _Interface(:each), default: -> { [] }
+  prop :neighbourhoods_tree, _Interface(:each), default: -> { [] }
   prop :selected_category, _Nilable(String), default: nil
   prop :selected_partnership, _Nilable(String), default: nil
   prop :selected_neighbourhood, _Nilable(String), default: nil
@@ -33,7 +33,7 @@ class Views::Directory::Partners::Index < Views::Base
         query: @query,
         categories: @categories,
         partnerships_list: @partnerships_list,
-        neighbourhoods: @neighbourhoods,
+        neighbourhoods_tree: @neighbourhoods_tree,
         selected_category: @selected_category,
         selected_partnership: @selected_partnership,
         selected_neighbourhood: @selected_neighbourhood

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,19 @@ en:
     breadcrumbs:
       root: "Directory"
     partners:
+      index:
+        filters:
+          search: "Search"
+          search_placeholder: "Name or keyword…"
+          category: "Category"
+          partnership: "Partnership"
+          neighbourhood: "Neighbourhood"
+          apply: "Filter"
+          clear: "Clear"
+          all_categories: "All categories"
+          all_partnerships: "All partnerships"
+          all_neighbourhoods: "All neighbourhoods"
+          all_of: "All of %{name}"
       show:
         upcoming_events: "Upcoming events"
         location: "Location"

--- a/spec/components/directory/neighbourhood_cascade_component_spec.rb
+++ b/spec/components/directory/neighbourhood_cascade_component_spec.rb
@@ -14,31 +14,31 @@ RSpec.describe Components::Directory::NeighbourhoodCascade, type: :component do
     ]
   end
 
-  it "renders the cascade controller with the tree serialised as JSON" do
+  it "labels the control once" do
     render_inline(described_class.new(tree: tree))
 
-    root = page.find("[data-controller='neighbourhood-cascade']")
-    expect(JSON.parse(root["data-neighbourhood-cascade-tree-value"]))
-      .to eq(tree.map { |n| n.transform_keys(&:to_s).merge("children" => n[:children].map { |c| c.transform_keys(&:to_s) }) })
+    expect(page).to have_css("label", text: "Neighbourhood", count: 1)
   end
 
-  it "renders a hidden neighbourhood field carrying the selected id" do
-    render_inline(described_class.new(tree: tree, selected: "2"))
-
-    field = page.find("input[type='hidden'][name='neighbourhood']", visible: false)
-    expect(field[:value]).to eq("2")
-    expect(field["data-neighbourhood-cascade-target"]).to eq("field")
-  end
-
-  it "renders the selects container the controller fills in" do
+  it "wires up the cascade controller" do
     render_inline(described_class.new(tree: tree))
 
-    expect(page).to have_css("[data-neighbourhood-cascade-target='selects']")
+    expect(page).to have_css("[data-controller='neighbourhood-cascade']")
   end
 
-  it "labels the control" do
+  it "renders a root dropdown of regions, styled like the other filters" do
     render_inline(described_class.new(tree: tree))
 
-    expect(page).to have_css("label", text: "Neighbourhood")
+    # Same CustomSelect widget — a hidden select plus a styled trigger button.
+    expect(page).to have_css("[data-controller='custom-select'] select[name='neighbourhood']")
+    expect(page).to have_text("All neighbourhoods")
+    expect(page).to have_text("Northvale (3)")
+  end
+
+  it "drills into the selected region with an 'All of' option" do
+    render_inline(described_class.new(tree: tree, selected: "1"))
+
+    expect(page).to have_text("All of Northvale")
+    expect(page).to have_text("Millbrook (3)")
   end
 end

--- a/spec/components/directory/neighbourhood_cascade_component_spec.rb
+++ b/spec/components/directory/neighbourhood_cascade_component_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Directory::NeighbourhoodCascade, type: :component do
+  let(:tree) do
+    [
+      {
+        id: 1, name: "Northvale", unit: "region", count: 3,
+        children: [
+          { id: 2, name: "Millbrook", unit: "district", count: 3, children: [] }
+        ]
+      }
+    ]
+  end
+
+  it "renders the cascade controller with the tree serialised as JSON" do
+    render_inline(described_class.new(tree: tree))
+
+    root = page.find("[data-controller='neighbourhood-cascade']")
+    expect(JSON.parse(root["data-neighbourhood-cascade-tree-value"]))
+      .to eq(tree.map { |n| n.transform_keys(&:to_s).merge("children" => n[:children].map { |c| c.transform_keys(&:to_s) }) })
+  end
+
+  it "renders a hidden neighbourhood field carrying the selected id" do
+    render_inline(described_class.new(tree: tree, selected: "2"))
+
+    field = page.find("input[type='hidden'][name='neighbourhood']", visible: false)
+    expect(field[:value]).to eq("2")
+    expect(field["data-neighbourhood-cascade-target"]).to eq("field")
+  end
+
+  it "renders the selects container the controller fills in" do
+    render_inline(described_class.new(tree: tree))
+
+    expect(page).to have_css("[data-neighbourhood-cascade-target='selects']")
+  end
+
+  it "labels the control" do
+    render_inline(described_class.new(tree: tree))
+
+    expect(page).to have_css("label", text: "Neighbourhood")
+  end
+end

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -248,6 +248,72 @@ RSpec.describe PartnersQuery do
     end
   end
 
+  describe "#neighbourhood_tree" do
+    # Directory site so the scope is all visible partners, independent of which
+    # neighbourhoods the site owns — matching how the public directory uses it.
+    subject(:tree) { described_class.new(site: directory_site).neighbourhood_tree }
+
+    let(:directory_site) { create(:default_site) }
+    let(:district) { create(:millbrook_district) }
+    let(:riverside) { create(:riverside_ward, parent: district) }
+    let(:oldtown) { create(:oldtown_ward, parent: district) }
+
+    let!(:riverside_partners) do
+      Array.new(2) { create(:partner, address: create(:address, neighbourhood: riverside)) }
+    end
+    let!(:oldtown_partner) do
+      create(:partner, address: create(:address, neighbourhood: oldtown))
+    end
+
+    it "drops the country level and roots the tree at regions" do
+      expect(tree.length).to eq(1)
+      expect(tree.first[:unit]).to eq("region")
+    end
+
+    it "nests region > county > district > ward" do
+      region = tree.first
+      county = region[:children].first
+      district_node = county[:children].first
+      wards = district_node[:children]
+
+      expect(region[:unit]).to eq("region")
+      expect(county[:unit]).to eq("county")
+      expect(district_node[:unit]).to eq("district")
+      expect(district_node[:id]).to eq(district.id)
+      expect(wards.map { |w| w[:id] }).to contain_exactly(riverside.id, oldtown.id)
+    end
+
+    it "rolls subtree partner counts up to every ancestor level" do
+      region = tree.first
+      county = region[:children].first
+      district_node = county[:children].first
+
+      expect(region[:count]).to eq(3)
+      expect(county[:count]).to eq(3)
+      expect(district_node[:count]).to eq(3)
+    end
+
+    it "counts each ward on its own" do
+      wards = tree.first[:children].first[:children].first[:children]
+      counts = wards.to_h { |w| [w[:id], w[:count]] }
+
+      expect(counts[riverside.id]).to eq(2)
+      expect(counts[oldtown.id]).to eq(1)
+    end
+
+    it "sorts children by name at each level" do
+      wards = tree.first[:children].first[:children].first[:children]
+      names = wards.map { |w| w[:name] }
+
+      expect(names).to eq(names.sort_by(&:downcase))
+    end
+
+    it "returns an empty array when no partners have neighbourhoods" do
+      Partner.destroy_all
+      expect(tree).to eq([])
+    end
+  end
+
   describe "#categories_with_counts" do
     let!(:category1) { create(:category, name: "Arts") }
     let!(:category2) { create(:category, name: "Sports") }

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -312,6 +312,28 @@ RSpec.describe PartnersQuery do
       Partner.destroy_all
       expect(tree).to eq([])
     end
+
+    context "with a selected neighbourhood that has no partners under the scope" do
+      let(:empty_ward) { create(:greenfield_ward, parent: district) }
+
+      def find_node(nodes, id)
+        nodes.each do |node|
+          return node if node[:id] == id
+
+          found = find_node(node[:children], id)
+          return found if found
+        end
+        nil
+      end
+
+      it "keeps the selected neighbourhood in the tree with a zero count" do
+        result = described_class.new(site: directory_site).neighbourhood_tree(selected_id: empty_ward.id)
+        node = find_node(result, empty_ward.id)
+
+        expect(node).to be_present
+        expect(node[:count]).to eq(0)
+      end
+    end
   end
 
   describe "#categories_with_counts" do

--- a/spec/requests/public/directory_partners_spec.rb
+++ b/spec/requests/public/directory_partners_spec.rb
@@ -123,6 +123,12 @@ RSpec.describe "Directory Partners", type: :request do
         expect(response.body).to include("Alphacat")
         expect(response.body).not_to include("Bravocat")
       end
+
+      it "still shows the selected neighbourhood when no partners match the other filters" do
+        # other_ward has no Alphacat partners, but the picker should reflect it.
+        get partners_url(host: "lvh.me", params: { neighbourhood: other_ward.id, category: alpha_partner.categories.first.id })
+        expect(response.body).to include(other_ward.shortname)
+      end
     end
   end
 

--- a/spec/requests/public/directory_partners_spec.rb
+++ b/spec/requests/public/directory_partners_spec.rb
@@ -100,6 +100,30 @@ RSpec.describe "Directory Partners", type: :request do
         expect(response.body).to include(partner.name)
       end
     end
+
+    context "with cross-filtering facets" do
+      let(:other_ward) { create(:oldtown_ward) }
+      let!(:alpha_partner) do
+        create(:partner, address: create(:address, neighbourhood: ward))
+          .tap { |p| p.categories << create(:category_tag, name: "Alphacat") }
+      end
+      let!(:bravo_partner) do
+        create(:partner, address: create(:address, neighbourhood: other_ward))
+          .tap { |p| p.categories << create(:category_tag, name: "Bravocat") }
+      end
+
+      it "lists every category when unfiltered" do
+        get partners_url(host: "lvh.me")
+        expect(response.body).to include("Alphacat")
+        expect(response.body).to include("Bravocat")
+      end
+
+      it "limits the category facet to the selected neighbourhood" do
+        get partners_url(host: "lvh.me", params: { neighbourhood: ward.id })
+        expect(response.body).to include("Alphacat")
+        expect(response.body).not_to include("Bravocat")
+      end
+    end
   end
 
   describe "GET /partners/:id (directory show)" do

--- a/spec/system/directory/partner_filtering_spec.rb
+++ b/spec/system/directory/partner_filtering_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Exercises the JS-driven neighbourhood cascade end to end: selecting a level
+# auto-submits and filters the partner list, and drilling reveals the next
+# level. This lives in a system spec because it depends on the custom-select and
+# neighbourhood-cascade Stimulus controllers running in a real browser.
+RSpec.describe "Directory partner filtering", :slow, type: :system do
+  let!(:default_site) { create(:default_site) }
+
+  # Two partners in different regions so filtering by one is observable.
+  let(:northvale_ward) { create(:riverside_ward) }
+  let(:southmere_ward) { create(:cliffside_ward) }
+
+  let!(:northern_partner) do
+    create(:partner, name: "Northern Partner", address: create(:address, neighbourhood: northvale_ward))
+  end
+  let!(:southern_partner) do
+    create(:partner, name: "Southern Partner", address: create(:address, neighbourhood: southmere_ward))
+  end
+
+  it "filters partners by neighbourhood and reveals the next level on selection" do
+    visit public_url("/partners")
+
+    expect(page).to have_content("Northern Partner")
+    expect(page).to have_content("Southern Partner")
+
+    within("[data-controller='neighbourhood-cascade']") do
+      find("[data-custom-select-target='trigger']").click
+      click_button("Northvale (1)")
+    end
+
+    # The selection auto-applied: only the Northvale partner remains...
+    expect(page).to have_content("Northern Partner")
+    expect(page).to have_no_content("Southern Partner")
+    # ...and the cascade drilled in, offering the region's subtree.
+    expect(page).to have_button("All of Northvale")
+  end
+end


### PR DESCRIPTION
Resolves #3133

## Description

Replaces the directory partners filter's flat list of wards with a **cascading geographic picker** — region → county → district → ward. Each select reveals the children of the one above; selecting any level filters that level's whole subtree.

The cascade is driven by a preloaded tree of only partner-bearing neighbourhoods (plus their ancestors), with partner counts rolled up to every level — so what you see in the dropdown matches what the filter returns. No AJAX.

**What changed**

- `PartnersQuery#neighbourhood_tree` builds the nested tree: includes ancestors of every partner-bearing neighbourhood, drops the country level (filtering by it == no filter) and re-roots its children, and rolls partner counts up to each ancestor. Shared partner-pairs SQL and count roll-up were extracted into private helpers reused by the existing `neighbourhoods_with_counts`.
- New `Components::Directory::NeighbourhoodCascade` Phlex component renders a hidden `neighbourhood` field, the tree as JSON, and a container the controller fills.
- New `neighbourhood_cascade` Stimulus controller drills the tree client-side and keeps the hidden field pointed at the deepest selection. Change listeners are bound **directly at element creation** (not via `data-action`) so dynamically-created selects respond reliably.
- Removed the now-dead `group_neighbourhoods_by_district` / `ensure_selected_neighbourhood` controller helpers; the tree already includes area-level nodes.
- Filter layout/styling polish: search goes full-width when wrapped (so Category/Partnership get room), neighbourhood sits on its own row, consistent control font-size and rounding, and a distinct, aligned Clear button.

### Motivation and Context

A flat ward list made no sense at national scale — potentially hundreds of entries with no geographic context (#3133). The `Neighbourhood` model already has full `has_ancestry` support, so the hierarchy was there to use.

One wrinkle worth flagging: the production hierarchy below country is uneven (England has regions; some Welsh/Scottish areas sit directly under country) and ONS `unit` labels are inconsistent (e.g. "Greater Manchester", a county, is coded as a district). Rather than name each level (which was sometimes wrong), the placeholders are **parent-relative**: "All neighbourhoods" at the top, "All of North West" deeper — always correct regardless of the source data.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- Specs: `PartnersQuery#neighbourhood_tree` (nesting, roll-up counts, country-dropping, sorting, empty case), a `NeighbourhoodCascade` component spec, and the existing directory partners request spec — all green. Rubocop clean.
- Manually in Chrome against real data: North West (164) → its counties → Manchester (116)…; `?neighbourhood=<id>` filters correctly (London → 104 partners) and the cascade restores the drilled path on load.

### How Will This Be Deployed?

No special steps. Public Tailwind CSS is rebuilt by the normal asset build (`yarn build`); no migrations, no env changes.

### Screenshots

Filter with cascade restored to North West › Greater Manchester, and the polished control row (consistent sizing, calm rounding, distinct Clear button) — verified in-browser during development.