### PR TITLE
Remove the default-site concept; apex serves the directory with no Site row

### DIFF
--- a/app/components/directory/partner_card.rb
+++ b/app/components/directory/partner_card.rb
@@ -2,7 +2,7 @@
 
 class Components::Directory::PartnerCard < Components::Directory::Base
   prop :partner, ::Partner
-  prop :site, ::Site
+  prop :site, _Nilable(::Site)
 
   def view_template
     a(href: partner_path(@partner),

--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -4,7 +4,7 @@ class Components::Map < Components::Base
   register_value_helper :args_for_map
 
   prop :points, _Nilable(Array)
-  prop :site, String
+  prop :site, _Nilable(String), default: nil
   prop :style, _Nilable(Symbol), default: nil
   prop :compact, _Boolean, default: false
 

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Tailwind classes are generally [ base, default site, partner site]. each section may be split into targets and breakpoints depending on complexity
+# Tailwind classes are generally [ base, directory, partner site]. each section may be split into targets and breakpoints depending on complexity
 
 class Components::Navigation < Components::Base
   prop :navigation, Array # Array of tuples of [name, URL]

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -10,7 +10,7 @@ class Components::Navigation < Components::Base
     header(class: [
              'header grid grid-cols-[1fr_auto] items-center',
              *(
-              if @site&.default_site?
+              if @site.nil?
                 ['header__default container-public py-6 bg-background border-b border-rules']
               else
                 ['header__partner mx-4 pt-4', 'lg:py-4 lg:mx-12 lg:py-6']
@@ -31,7 +31,7 @@ class Components::Navigation < Components::Base
               ("header__branding--#{@site.slug}" if @site&.slug.presence),
               # svg/img classes are here because partner svgs are inlined with File.read
               '[&>svg,&>img]:object-contain [&>svg,&>img]:max-w-full [&>svg,&>img]:max-h-full',
-              *(if @site&.default_site?
+              *(if @site.nil?
                   ['w-32 h-10 md:w-42 md:h-12']
                 else
                   ['w-42 h-12']
@@ -44,7 +44,7 @@ class Components::Navigation < Components::Base
 
   def render_logo
     logo_url = @site&.logo&.url.presence
-    if @site&.default_site?
+    if @site.nil?
       raw(view_context.svg_image('home/icons/logo-dark.svg', alt_text: 'PlaceCal'))
     elsif logo_url
       logo_path = Rails.public_path.join(logo_url.delete_prefix('/'))
@@ -59,7 +59,7 @@ class Components::Navigation < Components::Base
   end
 
   def render_site_name
-    if @site&.default_site?
+    if @site.nil?
       if request.path == '/'
         h1(class: 'sr-only') { 'PlaceCal' }
       else
@@ -77,7 +77,7 @@ class Components::Navigation < Components::Base
         @navigation.each do |link_text, link_path|
           li(class: menu_li_classes) { active_link_to(link_text, link_path, data: { turbolinks: false }, base_css_class: menu_link_classes, active_css_class: menu_active_classes) }
         end
-        render_join_button if @site&.default_site?
+        render_join_button if @site.nil?
       end
     end
   end
@@ -92,7 +92,7 @@ class Components::Navigation < Components::Base
   def menu_li_classes
     [
       'text-center',
-      *(if @site&.default_site?
+      *(if @site.nil?
           ['max-md:bg-home-background max-md:py-3']
         else
           [
@@ -108,7 +108,7 @@ class Components::Navigation < Components::Base
     [
       'with-reset with-no-sass text-base',
       'after:block after:mx-auto after:w-10',
-      *(if @site&.default_site?
+      *(if @site.nil?
           [
             'text-foreground font-bold',
             'after:h-[3.5px] after:mt-0.5 after:transition-colors after:duration-300',
@@ -126,7 +126,7 @@ class Components::Navigation < Components::Base
   end
 
   def menu_active_classes
-    (@site&.default_site? ? 'after:bg-foreground' : 'md:after:bg-primary')
+    (@site.nil? ? 'after:bg-foreground' : 'md:after:bg-primary')
   end
 
   def menu_nav_classes
@@ -134,7 +134,7 @@ class Components::Navigation < Components::Base
       'nav header__menu row-start-2 col-start-1 col-span-2 flex flex-col justify-evenly is-hidden',
       'h-auto overflow-clip transition-[display,height,margin-top,padding-block] duration-300',
       'md:flex-row',
-      *(if @site&.default_site?
+      *(if @site.nil?
           [
             # negative margins must match container-public's padding (0.75rem, then 1.25rem at md)
             # so the dropdown sits flush to the edges without overflowing the viewport; lg:mx-0 below
@@ -160,15 +160,15 @@ class Components::Navigation < Components::Base
   def render_toggle
     button(type: 'button', class: [
              'header__toggle row-start-1 col-start-2 flex gap-2 ms-auto me-1.5 items-center',
-             (@site&.default_site? ? 'text-foreground' : 'text-background'),
+             (@site.nil? ? 'text-foreground' : 'text-background'),
              'md:me-4',
-             *(if @site&.default_site?
+             *(if @site.nil?
                  ['lg:hidden']
                else
                  ['md:hidden']
                end)
            ], data: { action: 'click->mobile-menu#toggle', turbo: 'false' }) do
-      span(class: 'text-base font-semibold') { 'Menu' } if @site&.default_site?
+      span(class: 'text-base font-semibold') { 'Menu' } if @site.nil?
       raw(view_context.icon(:misc_menu, size: nil, css_class: 'size-8 fill-secondary'))
     end
   end

--- a/app/constraints/sites.rb
+++ b/app/constraints/sites.rb
@@ -6,7 +6,7 @@ module Sites
       return false if request.subdomain == Site::ADMIN_SUBDOMAIN
 
       site = Site.find_by_request request
-      site&.local_site?
+      site.present?
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,27 +90,31 @@ class ApplicationController < ActionController::Base
 
   # Get an object representing the requested site.
   # Note:
-  #   The admin site does not have a Site object.
+  #   The admin site does not have a Site object, and neither does the
+  #   nationwide directory: an apex (no-subdomain) request resolves to nil.
   # Side effects:
-  #   If the requested site is invalid then redirect to the home page of the
-  #   default site.
+  #   An unmatched subdomain redirects to the apex (the directory).
   def current_site
-    return @current_site if @current_site
+    return @current_site if defined?(@current_site)
 
-    if Site.any?
-      # Do not return a site for the admin subdomain.
-      # The admin subdomain gives a global view of data.
-      return if request.subdomain == Site::ADMIN_SUBDOMAIN
+    # Do not return a site for the admin subdomain.
+    # The admin subdomain gives a global view of data.
+    return @current_site = nil if request.subdomain == Site::ADMIN_SUBDOMAIN
 
-      @current_site = Site.find_by_request(request)
+    @current_site = Site.find_by_request(request)
 
-      redirect_to(root_url(subdomain: false), allow_other_host: true) if @current_site.nil? && !response.redirect?
-    else
-      flash.now[:warning] = 'You have no site in your database, have you run `rails db:seed`?'
-      @current_site = Site.new
+    if @current_site.nil? && request.subdomain.present? &&
+       request.subdomain != 'www' && !response.redirect?
+      redirect_to(root_url(subdomain: false), allow_other_host: true)
     end
 
     @current_site
+  end
+
+  # @return [Boolean] true when this request is for the nationwide directory:
+  #   the apex (no matched site) outside the admin subdomain.
+  def directory_request?
+    current_site.nil? && request.subdomain != Site::ADMIN_SUBDOMAIN
   end
 
   def set_primary_neighbourhood
@@ -217,15 +221,15 @@ class ApplicationController < ActionController::Base
     @site = current_site
   end
 
-  def redirect_from_default_site
-    redirect_to '/find-placecal' if default_site?
+  def redirect_from_directory
+    redirect_to '/find-placecal' if directory_request?
   end
 
   def set_navigation
     return @navigation if @navigation
 
-    @navigation = if default_site?
-                    default_site_navigation
+    @navigation = if directory_request?
+                    directory_navigation
                   else
                     sub_site_navigation
                   end
@@ -252,11 +256,7 @@ class ApplicationController < ActionController::Base
     stored_location_for(resource_or_scope) || admin_root_url(subdomain: Site::ADMIN_SUBDOMAIN)
   end
 
-  def default_site?
-    current_site&.default_site?
-  end
-
-  def default_site_navigation
+  def directory_navigation
     [
       ['Home', root_path],
       ['Partners', partners_path],

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,7 +13,7 @@ class EventsController < ApplicationController
   # GET /events
   # GET /events.json
   def index
-    if default_site? && request.format.html? && params[:simple].blank?
+    if directory_request? && html_format? && params[:simple].blank?
       render_directory_index
     else
       render_local_index
@@ -30,7 +30,7 @@ class EventsController < ApplicationController
     elsif @event.address
       @map = get_map_markers([@event.address])
     end
-    @containing_sites = Site.sites_that_contain_partner(@event.organiser) if default_site? && @event.organiser
+    @containing_sites = Site.sites_that_contain_partner(@event.organiser) if directory_request? && @event.organiser
     respond_to do |format|
       format.html do
         render Views::Events::Show.new(
@@ -47,6 +47,13 @@ class EventsController < ApplicationController
   end
 
   private
+
+  # Treats a wildcard Accept header (curl, crawlers) as HTML, matching how
+  # respond_to would serve it. The directory has no Site row, so falling
+  # through to the local index would render a site-less local view.
+  def html_format?
+    request.format.html? || request.format == Mime::ALL
+  end
 
   def set_event
     @event = Event.find(params[:id])
@@ -78,7 +85,6 @@ class EventsController < ApplicationController
     @events = paginated.group_by { |e| e.dtstart.to_date }
 
     partnerships = Site.where(is_published: true)
-                       .where.not(slug: 'default-site')
                        .order(:name)
                        .pluck(:slug, :name)
                        .map { |slug, name| { slug: slug, name: name } }

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -5,7 +5,7 @@ class NewsController < ApplicationController
 
   before_action :set_article, only: %i[show]
   before_action :set_site
-  before_action :redirect_from_default_site
+  before_action :redirect_from_directory
 
   def index
     @offset = params[:offset].to_i

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,7 +5,7 @@ class PagesController < ApplicationController
   before_action :set_site
 
   def home
-    if default_site?
+    if directory_request?
       render_directory_home
     else
       @neighbourhoods = Site.published.select do |site|
@@ -64,8 +64,11 @@ class PagesController < ApplicationController
   def robots
     if current_site
       render plain: current_site.robots
+    elsif directory_request?
+      # The apex serves the nationwide directory: always crawlable
+      render plain: Site.directory_robots
     else
-      # Admin subdomain or no site found - disallow all indexing
+      # Admin subdomain - disallow all indexing
       render plain: "User-agent: *\nDisallow: /"
     end
   end
@@ -88,7 +91,7 @@ class PagesController < ApplicationController
   def render_directory_home
     @stats = Rails.cache.fetch('directory/stats', expires_in: DIRECTORY_CACHE_TTL) do
       {
-        partnerships: Site.where(is_published: true).where.not(slug: 'default-site').count,
+        partnerships: Site.where(is_published: true).count,
         partners: Partner.visible.count,
         events: Event.where(dtstart: Time.zone.today..30.days.from_now).count,
         neighbourhoods: Neighbourhood.districts.count
@@ -105,7 +108,6 @@ class PagesController < ApplicationController
 
     @partnerships = Rails.cache.fetch('directory/partnerships', expires_in: DIRECTORY_CACHE_TTL) do
       Site.where(is_published: true)
-          .where.not(slug: 'default-site')
           .order(partners_count: :desc)
           .limit(6)
           .to_a

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -15,7 +15,7 @@ class PartnersController < ApplicationController
   # GET /partners
   # GET /partners.json
   def index
-    if default_site?
+    if directory_request?
       render_directory_index
     else
       render_local_index
@@ -59,11 +59,11 @@ class PartnersController < ApplicationController
     # Map
     @map = get_map_markers([@partner])
 
-    @containing_sites = Site.sites_that_contain_partner(@partner) if default_site?
+    @containing_sites = Site.sites_that_contain_partner(@partner) if directory_request?
 
     respond_to do |format|
       format.html do
-        view_class = default_site? ? Views::Directory::Partners::Show : Views::Partners::Show
+        view_class = directory_request? ? Views::Directory::Partners::Show : Views::Partners::Show
         render view_class.new(
           partner: @partner, site: @site, current_day: @current_day,
           map: @map, events: @events,
@@ -133,7 +133,7 @@ class PartnersController < ApplicationController
       partners: @partners, pagy: @pagy, site: @site, query: params[:q], sort: @sort,
       az_letters: @az_letters, selected_letter: @selected_letter,
       total_count: Partner.visible.count,
-      partnership_count: Site.where(is_published: true).where.not(slug: 'default-site').count,
+      partnership_count: Site.where(is_published: true).count,
       categories: query.categories_with_counts(scope: category_scope).map { |c| { id: c[:category].id, name: c[:category].name, count: c[:count] } },
       partnerships_list: query.partnerships_with_counts(scope: partnership_scope).map { |p| { id: p[:partnership].id, name: p[:partnership].name, count: p[:count] } },
       neighbourhoods_tree: query.neighbourhood_tree(scope: neighbourhood_scope, selected_id: params[:neighbourhood]),

--- a/app/controllers/partnerships_controller.rb
+++ b/app/controllers/partnerships_controller.rb
@@ -6,7 +6,6 @@ class PartnershipsController < ApplicationController
 
   def index
     @partnerships = Site.where(is_published: true)
-                        .where.not(slug: 'default-site')
                         .order(partners_count: :desc)
     @total_partners = Partner.visible.count
 

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -3,13 +3,13 @@
 class SitemapsController < ApplicationController
   CACHE_TTL = 1.day
   MAX_URLS_PER_SITEMAP = 50_000
-  BASE = 'https://placecal.org'
+  BASE = Site::DIRECTORY_URL
 
   skip_before_action :set_supporters
   skip_before_action :set_navigation
 
   before_action :set_site
-  before_action :require_default_site
+  before_action :require_directory
 
   def index
     render xml: cached_xml('sitemap/index') { build_index }
@@ -33,8 +33,8 @@ class SitemapsController < ApplicationController
 
   private
 
-  def require_default_site
-    head :not_found unless default_site?
+  def require_directory
+    head :not_found unless directory_request?
   end
 
   def cached_xml(key, &)
@@ -72,7 +72,7 @@ class SitemapsController < ApplicationController
     urls = []
     urls << url_entry("#{BASE}/partnerships")
 
-    Site.published.where.not(slug: 'default-site').pluck(:slug, :url, :updated_at).each do |slug, site_url, updated_at|
+    Site.published.pluck(:slug, :url, :updated_at).each do |slug, site_url, updated_at|
       urls << url_entry("#{BASE}/partnerships/#{slug}", updated_at)
       urls << url_entry(site_url.chomp('/'), updated_at)
     end

--- a/app/models/concerns/permalinkable.rb
+++ b/app/models/concerns/permalinkable.rb
@@ -10,7 +10,7 @@
 #     permalink_resource 'events'
 #   end
 #
-#   # Default: uses the default site's URL (https://placecal.org)
+#   # Default: uses the directory apex URL (https://placecal.org)
 #   event.permalink  # => "https://placecal.org/events/42"
 #
 #   # With site context: pass the site's URL for subdomain-aware links
@@ -21,7 +21,7 @@ module Permalinkable
   class_methods do
     def permalink_resource(resource_name)
       define_method(:permalink) do |base_url: nil|
-        base_url ||= Site.find_by(slug: 'default-site')&.url || 'https://placecal.org'
+        base_url ||= Site::DIRECTORY_URL
         "#{base_url.chomp('/')}/#{resource_name}/#{id}"
       end
     end

--- a/app/models/concerns/site_json_ld.rb
+++ b/app/models/concerns/site_json_ld.rb
@@ -3,30 +3,31 @@
 module SiteJsonLd
   extend ActiveSupport::Concern
 
-  def to_json_ld(base_url:)
-    if default_site?
-      default_site_json_ld(base_url)
-    else
-      subsite_json_ld(base_url)
+  class_methods do
+    # Static JSON-LD for the nationwide directory (no Site row backs it).
+    # @param base_url [String]
+    # @return [Hash]
+    def directory_json_ld(base_url)
+      {
+        '@context' => 'https://schema.org',
+        '@type' => 'WebSite',
+        'name' => 'PlaceCal',
+        'url' => base_url,
+        'publisher' => {
+          '@type' => 'Organization',
+          'name' => 'PlaceCal',
+          'url' => self::DIRECTORY_URL,
+          'sameAs' => ['https://twitter.com/PlaceCal']
+        }
+      }
     end
   end
 
-  private
-
-  def default_site_json_ld(base_url)
-    {
-      '@context' => 'https://schema.org',
-      '@type' => 'WebSite',
-      'name' => 'PlaceCal',
-      'url' => base_url,
-      'publisher' => {
-        '@type' => 'Organization',
-        'name' => 'PlaceCal',
-        'url' => 'https://placecal.org',
-        'sameAs' => ['https://twitter.com/PlaceCal']
-      }
-    }
+  def to_json_ld(base_url:)
+    subsite_json_ld(base_url)
   end
+
+  private
 
   def subsite_json_ld(base_url)
     data = {

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -13,6 +13,10 @@ class Site < ApplicationRecord
   # defining the admin subdomain string here.
   ADMIN_SUBDOMAIN = 'admin'
 
+  # Canonical apex URL for the nationwide directory. The directory has no Site
+  # row — an apex request resolves to no site and renders the directory.
+  DIRECTORY_URL = 'https://placecal.org'
+
   # ==== Enums / Enumerize ====
   # Theme picker
   enumerize :theme,
@@ -79,7 +83,6 @@ class Site < ApplicationRecord
   # ==== Validations ====
   validates :name, :slug, :url, presence: true
   validates :slug, uniqueness: true
-  validates :place_name unless :default_site?
   validates :hero_text, length: { maximum: 120 }
 
   # ==== Scopes ====
@@ -110,18 +113,6 @@ class Site < ApplicationRecord
       .for_site(self)
       .published
       .count
-  end
-
-  # @return [Boolean]
-  def default_site?
-    slug == 'default-site'
-  end
-
-  alias directory_site? default_site?
-
-  # @return [Boolean] true for any non-default site
-  def local_site?
-    !default_site?
   end
 
   # @return [Boolean] whether neighbourhood badges should be shown
@@ -181,8 +172,6 @@ class Site < ApplicationRecord
   #   in that case we return nil so the page renders with the default styling
   #   instead of raising Propshaft::MissingAssetError (see issue #2936).
   def stylesheet_link
-    return nil if default_site?
-
     return "themes/#{theme}" unless theme == :custom
 
     custom_path = "themes/custom/#{slug}"
@@ -201,13 +190,11 @@ class Site < ApplicationRecord
 
   # @return [String] robots.txt content, blocking crawlers if unpublished
   def robots
-    config = File.read(Rails.root.join("config/robots/#{self.class.robots_config_filename}"))
-
     if is_published?
-      "#{config}\nSitemap: https://placecal.org/sitemap.xml\n"
+      self.class.published_robots
     else
       <<~TXT
-        #{config}
+        #{self.class.robots_config}
         User-agent: *
         Disallow: /
       TXT
@@ -228,6 +215,23 @@ class Site < ApplicationRecord
   # ==== Class methods ====
 
   class << self
+    # robots.txt for the nationwide directory at the apex domain. The directory
+    # has no Site row and is always publicly crawlable.
+    # @return [String]
+    def directory_robots
+      published_robots
+    end
+
+    # @return [String] the permissive robots.txt template plus sitemap reference
+    def published_robots
+      "#{robots_config}\nSitemap: #{DIRECTORY_URL}/sitemap.xml\n"
+    end
+
+    # @return [String] contents of the environment's robots.txt template
+    def robots_config
+      File.read(Rails.root.join("config/robots/#{robots_config_filename}"))
+    end
+
     # Selects the robots.txt template based on ALLOW_AI_SEARCH_BOTS env var.
     # In production, defaults to allowing search-AI bots (permissive template).
     # Set ALLOW_AI_SEARCH_BOTS=false to block all AI bots (strict template).
@@ -267,7 +271,8 @@ class Site < ApplicationRecord
     # Find the requested Site from information in the rails request object.
     #
     # @param request The request must expose the methods: host, subdomain, subdomains
-    # @return [Site]
+    # @return [Site, nil] nil for the apex / no-subdomain request (the
+    #   nationwide directory has no Site row)
     def find_by_request(request)
       # If there is a site with the domain in request.host, return it
       site = find_using_domain(request.host)
@@ -280,8 +285,7 @@ class Site < ApplicationRecord
           request.subdomain
         end
 
-      # No subdomain? Fall back to the default site.
-      site_slug ||= 'default-site'
+      return if site_slug.blank?
 
       Site.find_by(slug: site_slug)
     end

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -153,7 +153,7 @@ class EventsQuery
   # ===================
 
   def base_scope
-    @base_scope ||= if @site.nil? || @site.directory_site?
+    @base_scope ||= if @site.nil?
                       Event.includes(:place, :organiser)
                     else
                       events_for_site.includes(:place, :organiser)

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -211,7 +211,7 @@ class PartnersQuery
   end
 
   def build_base_scope
-    return Partner.visible if @site&.directory_site?
+    return Partner.visible if @site.nil?
     return Partner.none if site_neighbourhood_ids.empty?
 
     scope = Partner.visible

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -2,22 +2,24 @@
 
 class Views::Collections::Show < Views::Base
   prop :collection, Collection, reader: :private
-  prop :site, Site, reader: :private
+  prop :site, _Nilable(::Site), reader: :private
   prop :events, Hash, reader: :private
 
   def view_template
     content_for(:title) { collection.name }
     content_for(:description) { collection.description }
-    content_for(:permalink) { collection.permalink(base_url: site.url) }
+    content_for(:permalink) { collection.permalink(base_url: site&.url) }
     if collection.image?
       content_for(:image) { image_url(collection.image.standard.url) }
       content_for(:image_alt) { "Image for #{collection.name}" }
     end
 
-    Hero(collection.name, site.tagline)
+    Hero(collection.name, site&.tagline)
 
     div(class: 'container-public mb-32') do
-      Breadcrumb(trail: [[collection.name, collection.named_route]], site_name: site.name)
+      breadcrumb_args = { trail: [[collection.name, collection.named_route]] }
+      breadcrumb_args[:site_name] = site.name if site
+      Breadcrumb(**breadcrumb_args)
 
       hr
 
@@ -49,10 +51,10 @@ class Views::Collections::Show < Views::Base
   def render_events
     EventList(
       events: events,
-      primary_neighbourhood: site.primary_neighbourhood,
-      show_neighbourhoods: site.show_neighbourhoods?,
-      badge_zoom_level: site.badge_zoom_level&.to_s,
-      site_tagline: site.tagline
+      primary_neighbourhood: site&.primary_neighbourhood,
+      show_neighbourhoods: site ? site.show_neighbourhoods? : false,
+      badge_zoom_level: site&.badge_zoom_level&.to_s,
+      site_tagline: site&.tagline
     )
   end
 end

--- a/app/views/directory/events/index.rb
+++ b/app/views/directory/events/index.rb
@@ -4,7 +4,7 @@ class Views::Directory::Events::Index < Views::Base
   PERIOD_OPTIONS = [['This week', 'week'], ['Today', 'day'], ['This month', 'month'], ['All upcoming', 'future']].freeze
 
   prop :events, Hash
-  prop :site, ::Site
+  prop :site, _Nilable(::Site)
   prop :period, String, default: 'week'
   prop :current_day, Date
   prop :total_count, Integer, default: 0

--- a/app/views/directory/partners/index.rb
+++ b/app/views/directory/partners/index.rb
@@ -3,7 +3,7 @@
 class Views::Directory::Partners::Index < Views::Base
   prop :partners, _Interface(:each)
   prop :pagy, _Nilable(Pagy::Offset), default: nil
-  prop :site, ::Site
+  prop :site, _Nilable(::Site)
   prop :query, _Nilable(String), default: nil
   prop :categories, _Interface(:each), default: -> { [] }
   prop :partnerships_list, _Interface(:each), default: -> { [] }

--- a/app/views/directory/partners/show.rb
+++ b/app/views/directory/partners/show.rb
@@ -69,7 +69,7 @@ class Views::Directory::Partners::Show < Views::Partners::Show
       h2(class: 'udl udl--fw allcaps text-xl') { t('directory.partners.show.location') }
       p(class: 'mb-3') { t('directory.partners.show.serves', area: partner_service_area_text(partner)) } if partner.has_service_areas?
       div(class: 'grid grid-cols-[1fr_auto] gap-4 items-start') do
-        Map(points: map, site: site.slug, compact: true) if map
+        Map(points: map, site: site&.slug, compact: true) if map
         Address(address: partner.address) if partner.address
       end
     end

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -6,17 +6,17 @@ class Views::Events::Show < Views::Base
   register_value_helper :html_to_plaintext
 
   prop :event, ::Event, reader: :private
-  prop :site, Site, reader: :private
+  prop :site, _Nilable(::Site), reader: :private
   prop :map, _Nilable(Array), reader: :private
   prop :containing_sites, _Nilable(_Interface(:each)), reader: :private, default: nil
 
   def view_template
     content_for(:title) { event.og_title }
-    content_for(:image) { site.og_image }
+    content_for(:image) { site.og_image } if site
     content_for(:description) { html_to_plaintext(event.description_html) }
     content_for(:json_ld) { safe(event.to_json_ld(base_url: request.base_url).to_json) }
 
-    if site.default_site?
+    if site.nil?
       render_directory_layout
     else
       Event(
@@ -93,7 +93,7 @@ class Views::Events::Show < Views::Base
     return unless map
 
     div(class: 'py-4') do
-      Map(points: map, site: site.slug, style: :multi)
+      Map(points: map, site: site&.slug, style: :multi)
     end
   end
 

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -33,7 +33,7 @@ class Views::Events::Show < Views::Base
 
   private
 
-  # ── Directory layout (default site) ──
+  # ── Directory layout (nil site) ──
 
   def render_directory_layout
     Directory::PageHero(

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -37,7 +37,7 @@ class Views::Layouts::Application < Phlex::HTML
       body do
         div(class: [
               'page',
-              *(if site&.default_site?
+              *(if site.nil?
                   ['max-w-home bg-background border-none mx-auto']
                 else
                   [
@@ -54,7 +54,7 @@ class Views::Layouts::Application < Phlex::HTML
             Flash()
             yield
           end
-          if site&.default_site?
+          if site.nil?
             Directory::Footer()
           else
             Footer(site)
@@ -98,14 +98,15 @@ class Views::Layouts::Application < Phlex::HTML
     link(rel: 'canonical', href: request.original_url)
     meta(name: 'robots', content: 'noarchive')
 
-    script(type: 'application/ld+json') { raw safe(site.to_json_ld(base_url: request.base_url).to_json) } if site
+    json_ld = site ? site.to_json_ld(base_url: request.base_url) : Site.directory_json_ld(request.base_url)
+    script(type: 'application/ld+json') { raw safe(json_ld.to_json) }
     return unless content_for?(:json_ld)
 
     script(type: 'application/ld+json') { raw safe(content_for(:json_ld)) }
   end
 
   def compute_title
-    return 'PlaceCal | The Community Calendar' if current_page?(root_url) && site&.slug == 'default-site'
+    return 'PlaceCal | The Community Calendar' if current_page?(root_url) && site.nil?
     return "#{content_for(:title)} | #{site.name}" if content_for?(:title) && site&.name
     return content_for(:title).to_s if content_for?(:title)
 

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -4,7 +4,7 @@ class Views::Partners::Show < Views::Base
   register_value_helper :partner_service_area_text
 
   prop :partner, Partner, reader: :private
-  prop :site, Site, reader: :private
+  prop :site, _Nilable(::Site), reader: :private
   prop :current_day, Date, reader: :private
   prop :map, _Nilable(Array), reader: :private
   prop :events, _Interface(:each), reader: :private
@@ -29,7 +29,7 @@ class Views::Partners::Show < Views::Base
     content_for(:title) { partner.name }
     if partner.image.present?
       content_for(:image) { partner.image }
-    else
+    elsif site
       content_for(:image) { site.og_image }
     end
     content_for(:description) { partner.summary } if partner.summary

--- a/db/migrate/20260610090000_remove_default_site.rb
+++ b/db/migrate/20260610090000_remove_default_site.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# The nationwide directory is no longer backed by a magic 'default-site' Site
+# row: an apex request with no matching site now renders the directory. Remove
+# the legacy row (destroy! so dependent join rows and callbacks run).
+class RemoveDefaultSite < ActiveRecord::Migration[8.0]
+  def up
+    Site.find_by(slug: 'default-site')&.destroy!
+  end
+
+  def down
+    # Irreversible by design: the row is gone and nothing references it.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_080000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_10_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/seeds/004_sites.rb
+++ b/db/seeds/004_sites.rb
@@ -6,13 +6,6 @@ module SeedSites # rubocop:disable Metrics/ModuleLength
   IMAGES_DIR = Rails.root.join('db/seeds/images/sites')
 
   SITE_DATA = {
-    normal_island_default: {
-      place_name: 'Normal Island',
-      hero_text: 'Community events across Normal Island',
-      theme: :blue,
-      hero_image: 'normal_island_hero.jpg',
-      logo: 'normal_island_logo.svg'
-    },
     normal_island_country: {
       place_name: 'Normal Island (country)',
       hero_text: 'Everything happening across Normal Island',
@@ -94,16 +87,6 @@ module SeedSites # rubocop:disable Metrics/ModuleLength
 
   def self.run
     $stdout.puts 'Sites'
-
-    # Default site (fallback for no-subdomain requests)
-    create_site(
-      slug: 'default-site',
-      name: 'Normal Island Central',
-      tagline: 'Community events across Normal Island',
-      url: 'http://default-site.lvh.me:3000',
-      data_key: :normal_island_default,
-      published: false
-    )
 
     # Normal Island (country)
     create_site(

--- a/doc/testing-guide.md
+++ b/doc/testing-guide.md
@@ -143,7 +143,6 @@ RSpec.describe 'Admin Partners', type: :request do
   let(:admin) { create(:root_user) }
 
   before do
-    create_default_site
     sign_in admin
   end
 
@@ -408,7 +407,6 @@ create(:mobile_partner, service_area_wards: [ward1, ward2])
 
 ```ruby
 create(:site)                      # Generic site
-create(:site, slug: 'default-site') # Required for routing
 ```
 
 ### Events & Calendars
@@ -451,17 +449,17 @@ create(:service_area, partner: partner, neighbourhood: ward)
 
 ## Support Files
 
-| File                                 | Purpose                      |
-| ------------------------------------ | ---------------------------- |
-| `spec/rails_helper.rb`               | Main RSpec configuration     |
-| `spec/support/capybara.rb`           | Browser/Cuprite setup        |
-| `spec/support/tom_select_helpers.rb` | Tom Select dropdown helpers  |
-| `spec/support/system_helpers.rb`     | System test utilities        |
-| `spec/support/site_helpers.rb`       | `create_default_site` helper |
-| `spec/support/graphql_helpers.rb`    | GraphQL test utilities       |
-| `spec/support/vcr.rb`                | HTTP recording config        |
-| `spec/support/shared_examples/`      | Reusable test examples       |
-| `spec/support/shared_contexts/`      | Reusable test setup          |
+| File                                 | Purpose                     |
+| ------------------------------------ | --------------------------- |
+| `spec/rails_helper.rb`               | Main RSpec configuration    |
+| `spec/support/capybara.rb`           | Browser/Cuprite setup       |
+| `spec/support/tom_select_helpers.rb` | Tom Select dropdown helpers |
+| `spec/support/system_helpers.rb`     | System test utilities       |
+| `spec/support/site_helpers.rb`       | Site URL helpers            |
+| `spec/support/graphql_helpers.rb`    | GraphQL test utilities      |
+| `spec/support/vcr.rb`                | HTTP recording config       |
+| `spec/support/shared_examples/`      | Reusable test examples      |
+| `spec/support/shared_contexts/`      | Reusable test setup         |
 
 ---
 

--- a/lib/normal_island.rb
+++ b/lib/normal_island.rb
@@ -264,12 +264,6 @@ module NormalIsland
   # Seeds use the geographic-level keys (normal_island_country, coastshire_county, etc.)
   # Factories use the named keys (millbrook_community_calendar, ashdale_connect, etc.)
   SITES = {
-    normal_island_central: {
-      name: 'Normal Island Central',
-      slug: 'default-site',
-      tagline: 'Community events across Normal Island',
-      country: true
-    },
     normal_island_country: {
       name: 'Normal Island (country)',
       slug: 'normal-island',

--- a/spec/components/navigation_component_spec.rb
+++ b/spec/components/navigation_component_spec.rb
@@ -4,23 +4,22 @@ require "rails_helper"
 
 RSpec.describe Components::Navigation, type: :component do
   let(:navigation) { [["Home", "/"], ["Events", "/events"], ["Partners", "/partners"]] }
-  let(:default_site) { create(:default_site) }
 
   it "renders navigation links" do
-    render_inline(described_class.new(navigation: navigation, site: default_site))
+    render_inline(described_class.new(navigation: navigation, site: nil))
 
     expect(page).to have_link("Events", href: "/events")
     expect(page).to have_link("Partners", href: "/partners")
   end
 
   it "renders home link" do
-    render_inline(described_class.new(navigation: navigation, site: default_site))
+    render_inline(described_class.new(navigation: navigation, site: nil))
 
     expect(page).to have_link("Home")
   end
 
   it "renders header structure" do
-    render_inline(described_class.new(navigation: navigation, site: default_site))
+    render_inline(described_class.new(navigation: navigation, site: nil))
 
     expect(page).to have_css(".header")
     expect(page).to have_css("nav.nav")

--- a/spec/components/previews/map_preview.rb
+++ b/spec/components/previews/map_preview.rb
@@ -8,7 +8,7 @@ class MapPreview < Lookbook::Preview
       { lat: 53.4601, lon: -2.2480, name: "Moss Side Leisure Centre", url: "/partners/2" },
       { lat: 53.4650, lon: -2.2530, name: "Zion Arts Centre", url: "/partners/3" }
     ]
-    render Components::Map.new(points: points, site: "default-site")
+    render Components::Map.new(points: points, site: nil)
   end
 
   # @label Single point
@@ -16,11 +16,11 @@ class MapPreview < Lookbook::Preview
     points = [
       { lat: 53.4631, lon: -2.2496, name: "Hulme Community Garden", url: "/partners/1" }
     ]
-    render Components::Map.new(points: points, site: "default-site")
+    render Components::Map.new(points: points, site: nil)
   end
 
   # @label Empty (no points)
   def empty
-    render Components::Map.new(points: [], site: "default-site")
+    render Components::Map.new(points: [], site: nil)
   end
 end

--- a/spec/components/previews/navigation_preview.rb
+++ b/spec/components/previews/navigation_preview.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class NavigationPreview < Lookbook::Preview
-  # @label Default site
-  def default_site
+  # @label Directory (no site)
+  def directory
     render Components::Navigation.new(
       navigation: PreviewSupport.sample_navigation,
       site: nil

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -45,12 +45,6 @@ FactoryBot.define do
         create(:sites_neighbourhood, site: site, neighbourhood: county)
       end
     end
-
-    factory :default_site do
-      name { NormalIsland::SITES[:normal_island_central][:name] }
-      slug { NormalIsland::SITES[:normal_island_central][:slug] }
-      tagline { NormalIsland::SITES[:normal_island_central][:tagline] }
-    end
   end
 
   factory :sites_neighbourhood do

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -249,11 +249,11 @@ RSpec.describe PartnersQuery do
   end
 
   describe "#neighbourhood_tree" do
-    # Directory site so the scope is all visible partners, independent of which
-    # neighbourhoods the site owns — matching how the public directory uses it.
-    subject(:tree) { described_class.new(site: directory_site).neighbourhood_tree }
+    # Nil site (the directory) so the scope is all visible partners, independent
+    # of which neighbourhoods a site owns — matching how the public directory
+    # uses it.
+    subject(:tree) { described_class.new(site: nil).neighbourhood_tree }
 
-    let(:directory_site) { create(:default_site) }
     let(:district) { create(:millbrook_district) }
     let(:riverside) { create(:riverside_ward, parent: district) }
     let(:oldtown) { create(:oldtown_ward, parent: district) }
@@ -327,7 +327,7 @@ RSpec.describe PartnersQuery do
       end
 
       it "keeps the selected neighbourhood in the tree with a zero count" do
-        result = described_class.new(site: directory_site).neighbourhood_tree(selected_id: empty_ward.id)
+        result = described_class.new(site: nil).neighbourhood_tree(selected_id: empty_ward.id)
         node = find_node(result, empty_ward.id)
 
         expect(node).to be_present

--- a/spec/requests/admin/authentication_flash_spec.rb
+++ b/spec/requests/admin/authentication_flash_spec.rb
@@ -6,7 +6,6 @@ require "rails_helper"
 # shown when an unauthenticated user tries to access /admin must NOT persist
 # onto the next page they visit.
 RSpec.describe "Admin authentication flash", type: :request do
-  let!(:default_site) { create_default_site }
   let!(:published_site) { create(:site, is_published: true) }
 
   let(:warning_message) do

--- a/spec/requests/admin/home_spec.rb
+++ b/spec/requests/admin/home_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe "Admin::Home", type: :request do
 
   describe "GET /admin (dashboard)" do
     context "without authentication" do
-      before { create_default_site }
-
       it "redirects to login page" do
         get "http://#{admin_host}"
         expect(response).to redirect_to("http://#{admin_host}/users/sign_in")

--- a/spec/requests/devise_spec.rb
+++ b/spec/requests/devise_spec.rb
@@ -4,9 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Devise Pages", type: :request do
   # Devise auth pages redirect from subdomains to root domain (via devise_check_on_root_site).
-  # Access them on the root domain with a default site present.
-  let!(:default_site) { create(:default_site) }
-
+  # Access them on the root domain (the directory).
   describe "GET /users/sign_in (login)" do
     it "returns successful response" do
       get new_user_session_url(host: "lvh.me")

--- a/spec/requests/public/collections_spec.rb
+++ b/spec/requests/public/collections_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Public Collections", type: :request do
-  let!(:default_site) { create_default_site }
   let!(:collection) { create(:collection) }
 
   describe "GET /collections/:id" do
@@ -15,7 +14,7 @@ RSpec.describe "Public Collections", type: :request do
     it "displays collection name in title" do
       get collection_url(collection, host: "lvh.me")
       expect(response.body).to include(collection.name)
-      expect(response.body).to include(default_site.name)
+      expect(response.body).to include("PlaceCal")
     end
 
     it "displays collection name in hero" do

--- a/spec/requests/public/custom_theme_spec.rb
+++ b/spec/requests/public/custom_theme_spec.rb
@@ -7,7 +7,6 @@ require "rails_helper"
 # asset pipeline must not crash with Propshaft::MissingAssetError. The page
 # should render with the default styling instead.
 RSpec.describe "Custom theme with missing stylesheet", type: :request do
-  let!(:default_site) { create_default_site }
   let(:ward) { create(:riverside_ward) }
   let!(:site) do
     create(:site,

--- a/spec/requests/public/directory_partners_spec.rb
+++ b/spec/requests/public/directory_partners_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Directory Partners", type: :request do
-  let!(:default_site) { create(:default_site) }
   let(:ward) { create(:riverside_ward) }
 
   describe "GET /partners (directory index)" do

--- a/spec/requests/public/events_spec.rb
+++ b/spec/requests/public/events_spec.rb
@@ -239,8 +239,6 @@ RSpec.describe "Public Events", type: :request do
   end
 
   describe "GET /events/:id with bad ID" do
-    let!(:default_site) { create_default_site }
-
     it "returns not found for non-existent event" do
       get event_url(99_999, host: "lvh.me")
       expect(response).to have_http_status(:not_found)
@@ -248,9 +246,7 @@ RSpec.describe "Public Events", type: :request do
     end
   end
 
-  describe "default site directory" do
-    let!(:default_site) { create_default_site }
-
+  describe "directory events" do
     it "serves directory events page on base domain" do
       get events_url(host: "lvh.me")
       expect(response).to be_successful

--- a/spec/requests/public/joins_spec.rb
+++ b/spec/requests/public/joins_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Public Joins (Contact Form)", type: :request do
-  let!(:default_site) { create(:default_site) }
-
   describe "GET /get-in-touch" do
     it "returns successful response" do
       get "/get-in-touch", headers: { "Host" => "lvh.me" }

--- a/spec/requests/public/pages_spec.rb
+++ b/spec/requests/public/pages_spec.rb
@@ -46,10 +46,8 @@ RSpec.describe "Public Pages", type: :request do
     end
   end
 
-  describe "GET / (default site)" do
-    let!(:default_site) { create(:default_site) }
-
-    it "shows default site home page" do
+  describe "GET / (directory)" do
+    it "shows the directory home page" do
       get "http://lvh.me"
       expect(response).to be_successful
       expect(response.body).to include("<title>")
@@ -98,8 +96,6 @@ RSpec.describe "Public Pages", type: :request do
   end
 
   describe "GET /our-story" do
-    let!(:default_site) { create(:default_site) }
-
     it "returns successful response" do
       get "/our-story", headers: { "Host" => "lvh.me" }
       expect(response).to be_successful
@@ -112,8 +108,6 @@ RSpec.describe "Public Pages", type: :request do
   end
 
   describe "GET /find-placecal" do
-    let!(:default_site) { create(:default_site) }
-
     it "returns successful response" do
       get "/find-placecal", headers: { "Host" => "lvh.me" }
       expect(response).to be_successful
@@ -121,8 +115,6 @@ RSpec.describe "Public Pages", type: :request do
   end
 
   describe "GET /community-groups" do
-    let!(:default_site) { create(:default_site) }
-
     it "returns successful response" do
       get "/community-groups", headers: { "Host" => "lvh.me" }
       expect(response).to be_successful
@@ -136,8 +128,6 @@ RSpec.describe "Public Pages", type: :request do
 
   # Audience pages
   describe "GET /vcses" do
-    let!(:default_site) { create(:default_site) }
-
     it "returns successful response" do
       get "/vcses", headers: { "Host" => "lvh.me" }
       expect(response).to be_successful
@@ -145,8 +135,6 @@ RSpec.describe "Public Pages", type: :request do
   end
 
   describe "GET /housing-providers" do
-    let!(:default_site) { create(:default_site) }
-
     it "returns successful response" do
       get "/housing-providers", headers: { "Host" => "lvh.me" }
       expect(response).to be_successful
@@ -154,8 +142,6 @@ RSpec.describe "Public Pages", type: :request do
   end
 
   describe "GET /metropolitan-areas" do
-    let!(:default_site) { create(:default_site) }
-
     it "returns successful response" do
       get "/metropolitan-areas", headers: { "Host" => "lvh.me" }
       expect(response).to be_successful
@@ -163,8 +149,6 @@ RSpec.describe "Public Pages", type: :request do
   end
 
   describe "GET /culture-tourism" do
-    let!(:default_site) { create(:default_site) }
-
     it "returns successful response" do
       get "/culture-tourism", headers: { "Host" => "lvh.me" }
       expect(response).to be_successful
@@ -172,8 +156,6 @@ RSpec.describe "Public Pages", type: :request do
   end
 
   describe "GET /social-prescribers" do
-    let!(:default_site) { create(:default_site) }
-
     it "returns successful response" do
       get "/social-prescribers", headers: { "Host" => "lvh.me" }
       expect(response).to be_successful

--- a/spec/requests/public/partners_spec.rb
+++ b/spec/requests/public/partners_spec.rb
@@ -316,9 +316,7 @@ RSpec.describe "Public Partners", type: :request do
     end
   end
 
-  describe "default site directory" do
-    let!(:default_site) { create_default_site }
-
+  describe "directory partners index" do
     it "serves directory partners page on base domain" do
       get partners_url(host: "lvh.me")
       expect(response).to be_successful
@@ -373,8 +371,6 @@ RSpec.describe "Public Partners", type: :request do
   end
 
   describe "directory partner show page" do
-    let!(:default_site) { create_default_site }
-
     context "with full contact details" do
       let(:partner) { create(:riverside_partner) }
 

--- a/spec/requests/public/partnerships_spec.rb
+++ b/spec/requests/public/partnerships_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Public Partnerships", type: :request do
-  let!(:default_site) { create(:default_site) }
-
   let!(:partnerships) do
     Array.new(3) do |i|
       create(:site, slug: "partnership-#{i}", is_published: true, name: "Test Partnership #{i}")
@@ -27,11 +25,6 @@ RSpec.describe "Public Partnerships", type: :request do
     it "sets page title" do
       get partnerships_url(host: "lvh.me")
       expect(response.body).to include("<title>#{Partnership.model_name.human(count: 2)}")
-    end
-
-    it "excludes default-site from listings" do
-      get partnerships_url(host: "lvh.me")
-      expect(response.body).not_to include(">#{default_site.name}<")
     end
 
     it "shows hero with i18n title" do

--- a/spec/requests/public/sitemaps_spec.rb
+++ b/spec/requests/public/sitemaps_spec.rb
@@ -3,10 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "Public Sitemaps", type: :request do
-  let!(:default_site) { create(:default_site) }
   let!(:local_site) { create(:site, slug: "mossley", is_published: true, url: "https://mossley.placecal.org/") }
 
-  describe "on the default site" do
+  describe "on the apex (directory)" do
     let(:host) { "lvh.me" }
 
     describe "GET /sitemap.xml" do
@@ -88,6 +87,17 @@ RSpec.describe "Public Sitemaps", type: :request do
     it "includes sitemap directive for published sites" do
       get "/robots.txt", headers: { "Host" => "mossley.lvh.me" }
       expect(response.body).to include("Sitemap: https://placecal.org/sitemap.xml")
+    end
+
+    it "serves a crawlable robots.txt with sitemap on the apex" do
+      get "/robots.txt", headers: { "Host" => "lvh.me" }
+      expect(response.body).to include("Sitemap: https://placecal.org/sitemap.xml")
+      expect(response.body).not_to include("Disallow: /\n")
+    end
+
+    it "disallows everything on the admin subdomain" do
+      get "/robots.txt", headers: { "Host" => "admin.lvh.me" }
+      expect(response.body).to include("Disallow: /")
     end
   end
 end

--- a/spec/requests/public/sites_spec.rb
+++ b/spec/requests/public/sites_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Public Sites", type: :request do
-  let!(:default_site) { create_default_site }
   let(:site_admin) { create(:root_user) }
   let(:site) { create(:site, slug: "hulme", site_admin: site_admin, url: "https://hulme.lvh.me", place_name: "Hulme Community") }
   let(:ward) { create(:riverside_ward) }
@@ -13,12 +12,12 @@ RSpec.describe "Public Sites", type: :request do
   end
 
   describe "subdomain routing" do
-    it "shows default site for base domain" do
+    it "shows the directory for the base domain" do
       get "http://lvh.me"
       expect(response).to be_successful
     end
 
-    it "redirects non-existent site slug to default" do
+    it "redirects non-existent site slug to the apex" do
       get "http://no-site-set.lvh.me"
       expect(response).to redirect_to("http://lvh.me/")
     end

--- a/spec/support/shared_contexts/admin_login.rb
+++ b/spec/support/shared_contexts/admin_login.rb
@@ -4,7 +4,6 @@ RSpec.shared_context "admin login" do
   let(:admin_user) { create(:root_user, email: "admin@placecal.org", password: "password", password_confirmation: "password") }
 
   before do
-    create_default_site
     sign_in_as_admin
   end
 

--- a/spec/support/shared_contexts/normal_island_data.rb
+++ b/spec/support/shared_contexts/normal_island_data.rb
@@ -7,7 +7,6 @@
 # calendars, events, tags, and neighbourhoods.
 RSpec.shared_context "normal island data" do # rubocop:disable RSpec/MultipleMemoizedHelpers
   # Sites
-  let!(:default_site) { create(:default_site) }
   let!(:millbrook_site) { create(:millbrook_site, is_published: true) }
   let!(:ashdale_site) { create(:ashdale_site, is_published: true) }
   let!(:coastshire_site) { create(:coastshire_site, is_published: true) }

--- a/spec/support/site_helpers.rb
+++ b/spec/support/site_helpers.rb
@@ -2,11 +2,6 @@
 
 # Helpers for site-related testing
 module SiteHelpers
-  # Create the default site required for URL routing
-  def create_default_site
-    Site.find_by(slug: "default-site") || create(:site, slug: "default-site")
-  end
-
   # Generate a URL for a specific site subdomain
   def site_url(site, path)
     host = Rails.application.routes.default_url_options[:host]

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -11,7 +11,7 @@ VCR.configure do |c|
   c.allow_http_connections_when_no_cassette = false
 
   # Ignore lvh.me requests (used for subdomain testing in system specs)
-  c.ignore_hosts "lvh.me", "admin.lvh.me", "default-site.lvh.me"
+  c.ignore_hosts "lvh.me", "admin.lvh.me"
 
   # Ignore schema.org requests (JSON-LD context loading)
   c.ignore_hosts "schema.org", "www.schema.org"

--- a/spec/system/admin/partner_save_bar_spec.rb
+++ b/spec/system/admin/partner_save_bar_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe "Partner Save Bar", :slow, type: :system do
 
   let!(:partner) { create(:partner) }
 
-  before do
-    create_default_site
-  end
-
   def visit_partner_edit
     url = admin_url("/partners/#{partner.id}/edit")
     visit url

--- a/spec/system/admin/tags_spec.rb
+++ b/spec/system/admin/tags_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe "Admin Tags", :slow, type: :system do
   let!(:tag) { create(:tag) }
   let!(:system_tag) { create(:tag, system_tag: true) }
 
-  before do
-    create_default_site
-  end
-
   describe "system tag visibility" do
     it "shows system_tag option for root users" do
       sign_in_as(root_user)

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe "Authentication", :slow, type: :system do
            password_confirmation: "password")
   end
 
-  before do
-    create_default_site
-  end
-
   describe "login flow" do
     it "redirects user to admin site after login" do
       visit public_url("/users/sign_in")

--- a/spec/system/directory/partner_filtering_spec.rb
+++ b/spec/system/directory/partner_filtering_spec.rb
@@ -7,8 +7,6 @@ require "rails_helper"
 # level. This lives in a system spec because it depends on the custom-select and
 # neighbourhood-cascade Stimulus controllers running in a real browser.
 RSpec.describe "Directory partner filtering", :slow, type: :system do
-  let!(:default_site) { create(:default_site) }
-
   # Two partners in different regions so filtering by one is observable.
   let(:northvale_ward) { create(:riverside_ward) }
   let(:southmere_ward) { create(:cliffside_ward) }

--- a/spec/system/graphql/api_spec.rb
+++ b/spec/system/graphql/api_spec.rb
@@ -79,8 +79,6 @@ RSpec.describe "GraphQL API", :slow, type: :system do
     # Configure protocol for full URL generation
     Rails.application.default_url_options[:protocol] = "https"
 
-    create_default_site
-
     app_routes = Rails.application.routes
     app_routes.default_url_options[:host] = server.host
     app_routes.default_url_options[:port] = server.port

--- a/spec/system/user_invitation_spec.rb
+++ b/spec/system/user_invitation_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe "User Invitation Flow", :slow, type: :system do
   # Use unique email to avoid conflicts with other tests
   let(:invited_user_email) { "invited.user.#{SecureRandom.hex(4)}@placecal.org" }
 
-  before do
-    create_default_site
-  end
-
   it "allows admin to invite a user who can then set their password" do
     sign_in_as(admin_user)
 


### PR DESCRIPTION
## Context

Google Search Console reports `placecal.org/sitemap.xml` as blocked by robots.txt. Root cause: the nationwide directory was backed by a magic, **unpublished** `default-site` row, and `Site#robots` serves `Disallow: /` for unpublished sites — blocking the whole apex domain.

Rather than publishing the row, this removes the default-site mechanism entirely: the directory is now simply **the apex request with no site** (`current_site == nil`).

## Changes

- `Site.find_by_request` returns nil for apex/www requests (no more `'default-site'` slug fallback); `Site#default_site?` / `directory_site?` / `local_site?` are removed
- New `directory_request?` controller predicate replaces `default_site?`; `current_site` memoizes nil and only redirects unmatched **present** subdomains to the apex (no loop on the siteless apex)
- **The fix:** apex `/robots.txt` now serves the published template with `Sitemap: https://placecal.org/sitemap.xml` and no `Disallow: /`. Local sites keep per-site robots; admin keeps `Disallow: /`
- Views/components treat a nil site as the directory (nilable `site` props, directory JSON-LD preserved via `Site.directory_json_ld`)
- All `.where.not(slug: 'default-site')` scopes dropped; `Site.any?` placeholder branch removed (empty sites table is now a valid state)
- Apex `/events` with a wildcard `Accept: */*` header (curl/crawlers) previously fell into the local-site view — now treated as HTML and served the directory index
- Data migration destroys the `default-site` row (idempotent, `destroy!` so join rows cascade); seeds, `:default_site` factory, `create_default_site` helper and VCR host entry removed

## Pre-deploy checks

- Confirm no surviving site row owns `https://placecal.org` as its `url` — it would capture the apex via `find_using_domain`:
  ```sql
  SELECT id, slug, url FROM sites WHERE url IN ('https://placecal.org','https://placecal.org/');
  ```
- `www.placecal.org` now serves the directory without a canonical-host redirect (revisit if one is wanted)

## Testing

- Full suite green: 1778 request/unit specs + 111 system specs, 0 failures
- Manually verified in dev (row deleted): apex robots/sitemap, per-site robots, subdomain-sitemap 404, bogus-subdomain redirect, directory home/partners/events/event-show/partnerships, local site rendering and theme, directory WebSite JSON-LD

🤖 Generated with [Claude Code](https://claude.com/claude-code)