### PR TITLE
Fix flaky save bar system tests blocking deploys

### DIFF
--- a/app/javascript/controllers/form_tabs_controller.js
+++ b/app/javascript/controllers/form_tabs_controller.js
@@ -25,6 +25,10 @@ export default class extends Controller {
 
 		// Check for saved tab after form submission
 		this.restoreTabAfterSave();
+
+		// Marker for tests: tab clicks before connect() can be reverted by
+		// restoreTabAfterSave(), so helpers wait for this before clicking
+		this.element.dataset.formTabsConnected = "true";
 	}
 
 	disconnect() {

--- a/app/javascript/controllers/save_bar_controller.js
+++ b/app/javascript/controllers/save_bar_controller.js
@@ -69,6 +69,10 @@ export default class extends Controller {
 					setTimeout(() => this.updateButtons(), 10);
 				});
 			});
+
+		// Marker for tests: button visibility only updates once the tab click
+		// listeners above are attached, so helpers wait for this before clicking
+		this.element.dataset.saveBarConnected = "true";
 	}
 
 	disconnect() {

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -21,8 +21,15 @@ Capybara.app_host = "http://lvh.me"
 Capybara.server_host = "127.0.0.1"
 
 RSpec.configure do |config|
-  # Clean up after each system test
+  # Clean up after each system test. reset_sessions! clears cookies but not
+  # sessionStorage, so leftover keys (e.g. partnerTabAfterSave from save-bar)
+  # can leak into the next test and silently switch tabs on page load.
   config.after(type: :system) do
+    begin
+      page.execute_script("window.sessionStorage.clear()")
+    rescue StandardError
+      nil # browser may not have a page loaded
+    end
     Capybara.reset_sessions!
   end
 

--- a/spec/support/tab_helpers.rb
+++ b/spec/support/tab_helpers.rb
@@ -2,16 +2,30 @@
 
 # Helpers for interacting with daisyUI tabs in system/feature specs
 module TabHelpers
+  # Wait for the form-tabs Stimulus controller to be connected, not just for
+  # the data-controller attribute (present in the raw HTML before JS boots).
+  # Clicking a tab before connect() can be silently reverted by
+  # restoreTabAfterSave().
+  def wait_for_form_tabs
+    expect(page).to have_css("[data-form-tabs-connected]")
+  end
+
+  # Wait for the save-bar Stimulus controller to be connected. Button
+  # visibility only updates via listeners attached in its connect().
+  def wait_for_save_bar
+    expect(page).to have_css("[data-save-bar-connected]")
+  end
+
   # Click a tab by its data-hash attribute and wait for the panel to be visible
   def click_tab(hash)
-    expect(page).to have_css("[data-controller*='form-tabs']")
+    wait_for_form_tabs
     find("input.tab[data-hash='#{hash}']").click
     expect(page).to have_css("[data-section='#{hash}']", visible: true)
   end
 
   # Navigate to a partner form tab by its aria-label (includes emoji prefix)
   def go_to_partner_tab(tab_label)
-    expect(page).to have_css("[data-controller*='form-tabs']")
+    wait_for_form_tabs
     tab = find("input.tab[aria-label='#{tab_label}']")
     tab.click
     tab_hash = tab["data-hash"]

--- a/spec/system/admin/partner_save_bar_spec.rb
+++ b/spec/system/admin/partner_save_bar_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe "Partner Save Bar", :slow, type: :system do
       Rails.logger.warn "Retrying partner edit page load (attempt #{attempts})"
       visit url
     end
+
+    # Wait for the Stimulus controllers to connect before interacting —
+    # clicks before connect() are reverted or ignored (flaky in CI)
+    wait_for_form_tabs
+    wait_for_save_bar
   end
 
   # Helper to modify form fields in a way that triggers JavaScript input events
@@ -64,9 +69,6 @@ RSpec.describe "Partner Save Bar", :slow, type: :system do
     end
 
     it "shows Back, Save, and Continue buttons on middle tabs" do
-      # Wait for Stimulus save-bar controller to connect
-      expect(page).to have_css('[data-controller="save-bar"]')
-
       # Go to Location tab
       find('input[aria-label="📍 Location"]').click
 
@@ -112,9 +114,6 @@ RSpec.describe "Partner Save Bar", :slow, type: :system do
     end
 
     it "changes button text to include Save when dirty" do
-      # Wait for Stimulus save-bar controller to connect
-      expect(page).to have_css('[data-controller="save-bar"]')
-
       # Go to a middle tab first
       find('input[aria-label="📍 Location"]').click
 
@@ -183,8 +182,6 @@ RSpec.describe "Partner Save Bar", :slow, type: :system do
     end
 
     it "navigates to next tab when clicking Continue without changes" do
-      # Wait for Stimulus save-bar controller to connect and show the Continue button
-      expect(page).to have_css('[data-controller="save-bar"]')
       expect(page).to have_button("Continue", visible: :visible)
       click_button "Continue"
 
@@ -193,9 +190,6 @@ RSpec.describe "Partner Save Bar", :slow, type: :system do
     end
 
     it "navigates to previous tab when clicking Back without changes" do
-      # Wait for Stimulus save-bar controller to connect
-      expect(page).to have_css('[data-controller="save-bar"]')
-
       # Go to Location tab first
       find('input[aria-label="📍 Location"]').click
       expect(page).to have_button("Back", visible: :visible)


### PR DESCRIPTION
## What

Deploys on main are blocked by intermittent failures in `spec/system/admin/partner_save_bar_spec.rb` — most recently [run 27385727501](https://github.com/geeksforsocialchange/PlaceCal/actions/runs/27385727501) (only change was a setup-ruby bump), and [run 27096511974](https://github.com/geeksforsocialchange/PlaceCal/actions/runs/27096511974) before it (a different example in the same file).

## Root cause

The spec helpers waited for `[data-controller=...]` **attribute presence**, which is in the server-rendered HTML before Stimulus boots. On slow CI runs the tab click landed before `connect()` ran, causing two failure modes:

1. `form-tabs`'s `restoreTabAfterSave()` ran *after* the test clicked the Settings tab and reverted it to Basic Info, using a leftover `partnerTabAfterSave` sessionStorage key from an earlier test (`Capybara.reset_sessions!` clears cookies but **not** sessionStorage). The CI failure screenshot shows exactly this state.
2. `save-bar`'s tab click listeners weren't attached yet, so `updateButtons()` never ran and the Back button stayed hidden (the earlier failure).

## Fix

- Both controllers set a `data-*-connected` marker at the end of `connect()`
- `click_tab`/`go_to_partner_tab` and the save bar specs wait for the marker, not the attribute
- sessionStorage is cleared between system tests to stop cross-test pollution

## Testing

- Full `RUN_SLOW_TESTS=true rspec spec/system` locally: 111 examples, 0 failures
- rubocop + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)