### PR TITLE
Show staging and production deployments in the GitHub UI

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -205,6 +205,9 @@ jobs:
     concurrency:
       group: deploy-${{ github.event_name == 'release' && 'production' || github.event.inputs.destination || 'staging' }}
       cancel-in-progress: false
+    environment:
+      name: ${{ github.event_name == 'release' && 'production' || github.event.inputs.destination || 'staging' }}
+      url: ${{ (github.event_name == 'release' || github.event.inputs.destination == 'production') && 'https://placecal.org' || 'https://placecal-staging.org' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What

Adds an `environment:` declaration to the `deploy` job in `test-and-deploy.yml`, reusing the same destination expression as the existing `concurrency` group, with a `url` pointing at the live site for each destination.

## Why

GitHub automatically records a deployment whenever a job declares an environment. This gives us:

- An **Environments** panel on the repo homepage showing the latest staging/production deploy status
- Full deploy history per environment at [/deployments](https://github.com/geeksforsocialchange/PlaceCal/deployments), with "View deployment" links to placecal.org / placecal-staging.org
- "Deployed to staging/production" events on commit and PR timelines

## Notes for reviewers

- The `staging` and `production` environments are auto-created on first deploy — no setup required. Once they exist, **Settings → Environments** can optionally add required reviewers (manual approval gates), environment-scoped secrets, or branch restrictions.
- No token permission changes needed: Actions records the deployment itself when `environment:` is declared, so the job's restricted `permissions:` block is untouched.
- `environment:` is evaluated before steps run, so it can't use the `steps.dest` output — hence the inline expression, identical to the one already used for `concurrency`.
- The job's success/failure becomes the deployment status automatically (a failed Kamal deploy shows as a failed deployment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)