### PR TITLE
Make Mossley header bar full-bleed

### DIFF
--- a/app/assets/stylesheets/themes/custom/mossley.scss
+++ b/app/assets/stylesheets/themes/custom/mossley.scss
@@ -69,6 +69,19 @@ a {
 	background-color: $mossley-primary;
 	padding-top: 1rem;
 
+	// The shared header component floats inside the page with side margins
+	// (mx-4 lg:mx-12), which exposes white bands of page background either
+	// side of Mossley's solid blue bar. Trade the margins for equivalent
+	// padding so the bar runs the full page width.
+	&.header__partner {
+		margin-inline: 0;
+		padding-inline: 1rem;
+
+		@include for-tablet-landscape-up {
+			padding-inline: 3rem;
+		}
+	}
+
 	&__branding {
 		width: 180px;
 		height: 61px;


### PR DESCRIPTION
## What

On the Mossley partner site, white bands of page background showed either side of the logo in the header.

<img width="500" alt="before" src="https://github.com/user-attachments/assets/placeholder">

## Why

The shared `Components::Navigation` header floats inside the `.page` container with side margins (`mx-4 lg:mx-12`). Mossley is the one partner site whose header has a solid blue background (`.header { background-color: $mossley-primary }`), so those transparent margins exposed the white page background as bands either side of the bar.

## How

In `mossley.scss`, override `.header.header__partner` to drop the inline margins and replace them with equivalent inline padding (`1rem` mobile = old `mx-4`, `3rem` desktop = old `lg:mx-12`). The blue bar now runs the full page width and the logo/nav keep their original spacing.

## Verification

Checked locally at desktop and mobile widths — pixel-probed both top corners, which now report the blue header element instead of the white page div.

🤖 Generated with [Claude Code](https://claude.com/claude-code)