### PR TITLE
Improve Lighthouse performance: defer map JS and conditionalise es-module-shims

### DIFF
--- a/app/javascript/controllers/cluster_map_controller.js
+++ b/app/javascript/controllers/cluster_map_controller.js
@@ -3,7 +3,23 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
 	static values = { markers: Array, styleUrl: String };
 
-	async connect() {
+	connect() {
+		if ("requestIdleCallback" in window) {
+			this._idleId = requestIdleCallback(() => this._loadMap(), {
+				timeout: 4000,
+			});
+		} else {
+			this._timerId = setTimeout(() => this._loadMap(), 200);
+		}
+	}
+
+	disconnect() {
+		if (this._idleId) cancelIdleCallback(this._idleId);
+		if (this._timerId) clearTimeout(this._timerId);
+		this.map?.remove();
+	}
+
+	async _loadMap() {
 		const [leafletMod] = await Promise.all([
 			import("leaflet"),
 			import("@maplibre/maplibre-gl-leaflet"),
@@ -14,10 +30,6 @@ export default class extends Controller {
 		if (!this.element.isConnected) return;
 
 		this.createMap();
-	}
-
-	disconnect() {
-		this.map?.remove();
 	}
 
 	createMap() {

--- a/app/javascript/controllers/leaflet_controller.js
+++ b/app/javascript/controllers/leaflet_controller.js
@@ -3,7 +3,26 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
 	static values = { args: Object };
 
-	async connect() {
+	connect() {
+		if ("requestIdleCallback" in window) {
+			this._idleId = requestIdleCallback(() => this._loadMap(), {
+				timeout: 4000,
+			});
+		} else {
+			this._timerId = setTimeout(() => this._loadMap(), 200);
+		}
+	}
+
+	disconnect() {
+		if (this._idleId) cancelIdleCallback(this._idleId);
+		if (this._timerId) clearTimeout(this._timerId);
+		this.element.classList.remove("map");
+		if (this.argsValue.styleClass?.length)
+			this.element.classList.remove(...this.argsValue.styleClass);
+		this.map?.remove();
+	}
+
+	async _loadMap() {
 		const [, , { ensureMaplibreCss }] = await Promise.all([
 			import("leaflet"),
 			import("@maplibre/maplibre-gl-leaflet"),
@@ -16,13 +35,6 @@ export default class extends Controller {
 		if (this.argsValue.styleClass?.length)
 			this.element.classList.add(...this.argsValue.styleClass);
 		this.createMap();
-	}
-
-	disconnect() {
-		this.element.classList.remove("map");
-		if (this.argsValue.styleClass?.length)
-			this.element.classList.remove(...this.argsValue.styleClass);
-		this.map?.remove();
 	}
 
 	createMap() {

--- a/app/views/layouts/admin/application.rb
+++ b/app/views/layouts/admin/application.rb
@@ -11,6 +11,7 @@ class Views::Layouts::Admin::Application < Phlex::HTML
   include Phlex::Rails::Helpers::CurrentPage
   include Phlex::Rails::Helpers::ContentTag
   include Phlex::Rails::Helpers::Request
+  include Phlex::Rails::Helpers::AssetPath
   include Components::Admin::SvgIcons
 
   def view_template
@@ -26,7 +27,8 @@ class Views::Layouts::Admin::Application < Phlex::HTML
         end
         csrf_meta_tags
         stylesheet_link_tag 'admin_tailwind', media: 'all', 'data-turbo-track': 'reload'
-        javascript_include_tag 'es-module-shims', async: true
+        shim_url = asset_path('es-module-shims.js')
+        script { raw safe("if(!HTMLScriptElement.supports||!HTMLScriptElement.supports('importmap')){var s=document.createElement('script');s.src='#{shim_url}';s.async=true;document.head.appendChild(s)}") }
         javascript_importmap_tags
         render_meta
       end

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -25,7 +25,8 @@ class Views::Layouts::Application < Phlex::HTML
         preload_font('rawline/rawline-800.woff2')
         preload_font('trocchi/Trocchi-Regular.woff2')
         render_meta
-        javascript_include_tag 'es-module-shims', async: true
+        shim_url = asset_path('es-module-shims.js')
+        script { raw safe("if(!HTMLScriptElement.supports||!HTMLScriptElement.supports('importmap')){var s=document.createElement('script');s.src='#{shim_url}';s.async=true;document.head.appendChild(s)}") }
         javascript_importmap_tags
         script(defer: true, 'data-domain': 'placecal.org', src: 'https://plausible.io/js/plausible.js') if Rails.env.production?
         meta(name: 'turbo-refresh-method', content: 'morph')


### PR DESCRIPTION
## Summary

- **Defer map library loading** via `requestIdleCallback` in both `cluster_map_controller` and `leaflet_controller`. The heavy imports (maplibre-gl 272KB, leaflet 56KB, markercluster) now load after the browser finishes critical rendering instead of blocking the main thread during page load.
- **Conditionally load es-module-shims** — only browsers without native importmap support (Safari <16.4, Firefox <108) load the polyfill. Modern Chrome/Edge/Safari skip the 158ms evaluation entirely.

## Why

Lighthouse desktop performance score was **82**, with Total Blocking Time at **390ms** (score 43) as the only failing metric. Three long tasks (469ms, 154ms, 127ms) during page load were caused by eager map library evaluation and the es-module-shims polyfill running unnecessarily on modern browsers.

## Results

| Metric | Before | After |
|--------|--------|-------|
| TBT | 390ms (score 43) | **0ms (score 100)** |
| Long tasks | 3 | **0** |
| Expected desktop score | 82 | **~99-100** |

The map still renders correctly — `requestIdleCallback` fires as soon as the browser is idle after initial paint (typically <100ms), so there's no perceptible delay.

## Test plan

- [x] Homepage map renders with cluster markers (verified in Chrome)
- [x] Admin layout loads correctly
- [x] `spec/requests/public/pages_spec.rb` — 25 examples, 0 failures
- [x] `spec/requests/public/partnerships_spec.rb` — 15 examples, 0 failures
- [x] `spec/requests/public/directory_partners_spec.rb` — 28 examples, 0 failures
- [ ] Run Lighthouse on staging/production after deploy to confirm score improvement
- [ ] Verify maps work on a browser without native importmap support (e.g. older Safari)