### PR TITLE
Fix flaky tab spec with retryable CSS selector

### DIFF
--- a/spec/support/tab_helpers.rb
+++ b/spec/support/tab_helpers.rb
@@ -17,21 +17,20 @@ module TabHelpers
   end
 
   # Click a tab by its data-hash attribute and wait for it to be selected.
-  # Verifies the radio is checked rather than panel visibility, which avoids
-  # CI flakiness from CSS :checked rendering lag on daisyUI tabs.
+  # Uses a retryable CSS selector for the assertion instead of checking the
+  # already-resolved element — avoids CI flakiness where the checked state
+  # lags behind the click in headless Chrome.
   def click_tab(hash)
     wait_for_form_tabs
-    tab = find("input.tab[data-hash='#{hash}']")
-    tab.click
-    expect(tab).to be_checked
+    find("input.tab[data-hash='#{hash}']").click
+    expect(page).to have_css("input.tab[data-hash='#{hash}']:checked", wait: 5)
   end
 
   # Navigate to a partner form tab by its aria-label (includes emoji prefix)
   def go_to_partner_tab(tab_label)
     wait_for_form_tabs
-    tab = find("input.tab[aria-label='#{tab_label}']")
-    tab.click
-    expect(tab).to be_checked
+    find("input.tab[aria-label='#{tab_label}']").click
+    expect(page).to have_css("input.tab[aria-label='#{tab_label}']:checked", wait: 5)
   end
 
   def go_to_basic_info_tab = go_to_partner_tab("📋 Basic Info")


### PR DESCRIPTION
## Summary
- The `click_tab` / `go_to_partner_tab` helpers were checking `expect(tab).to be_checked` on an already-resolved Capybara element node, which doesn't re-query the DOM on retry
- In headless Chrome on CI, the radio's `:checked` state can lag behind the `.click()` — the previous fix (cfc7daab) moved from panel visibility to checked state but still hit the same timing issue
- Now uses `expect(page).to have_css("...:checked", wait: 5)` which re-queries the DOM on each Capybara retry, the standard pattern for waiting on async state changes

## Test plan
- [x] `tags_spec.rb:24` (the specific failing test) passes 3/3 runs locally
- [x] Full `tags_spec.rb` + `partner_save_bar_spec.rb` suite (19 examples) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)