### PR TITLE
Clean up and redesign the Get in touch / Join form (#3245)

### DIFF
--- a/app/components/flash.rb
+++ b/app/components/flash.rb
@@ -7,19 +7,19 @@ class Components::Flash < Components::Base
     messages = @flash_messages || flash
     return unless messages.any?
 
-    div(class: 'flashes') do
+    div(class: 'flashes flex flex-col gap-2 my-4') do
       messages.each do |key, value|
-        div(class: "alert #{alert_class(key)}", role: 'alert') { value }
+        div(class: "flash-message flash-message--#{state(key)}", role: 'alert') { value }
       end
     end
   end
 
   private
 
-  def alert_class(key)
+  def state(key)
     case key.to_sym
-    when :danger, :alert, :error then 'alert-danger'
-    else 'alert-success'
+    when :danger, :alert, :error then 'error'
+    else 'success'
     end
   end
 end

--- a/app/controllers/joins_controller.rb
+++ b/app/controllers/joins_controller.rb
@@ -13,9 +13,9 @@ class JoinsController < ApplicationController
     @join = Join.new(join_params)
 
     if @join.submit
-      redirect_to '/', notice: "Thank you for your interest in PlaceCal. We'll  be in touch with you shortly."
+      redirect_to '/', notice: t('directory.join.flash.success')
     else
-      flash[:error] = 'Please fill out the required fields below'
+      flash[:error] = t('directory.join.flash.error')
       render Views::Directory::Join.new(join: @join)
     end
   end

--- a/app/tailwind/public/_components.css
+++ b/app/tailwind/public/_components.css
@@ -283,17 +283,19 @@ textarea.join-control {
 	border-radius: var(--radius-card);
 	padding: 1.6rem 1.9rem;
 }
+/* Darker than --color-foreground (#5b4e46): brown text on the salmon card
+   only reaches 3.46:1, below WCAG AA 4.5:1 for body copy. This shade clears it. */
 .join-email-cta__heading {
 	font-family: var(--font-serif);
 	font-weight: 400;
 	font-size: 1.35rem;
 	line-height: 1.15;
-	color: var(--color-foreground);
+	color: #3d342e;
 	margin-bottom: 0.2rem;
 }
 .join-email-cta__body {
 	font-size: 0.95rem;
-	color: var(--color-foreground);
+	color: #3d342e;
 }
 .join-email-link {
 	display: inline-flex;

--- a/app/tailwind/public/_components.css
+++ b/app/tailwind/public/_components.css
@@ -92,6 +92,244 @@ a.btn-dark-outline:hover {
 	@apply no-underline;
 }
 
+/* "Get in touch" / Join enquiry form (app/views/directory/join.rb) */
+.join-card {
+	background: var(--color-background);
+	border: 2px solid var(--color-rules);
+	border-radius: var(--radius-card);
+	padding: 2rem 2.25rem 2.25rem;
+}
+.join-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 1.1rem 1.25rem;
+}
+@media (width >= theme(--breakpoint-md)) {
+	.join-grid {
+		grid-template-columns: 1fr 1fr;
+	}
+}
+.join-block {
+	margin-top: 1.4rem;
+}
+
+.join-field {
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+	min-width: 0;
+}
+.join-label {
+	display: flex;
+	align-items: center;
+	gap: 0.3rem;
+	font-weight: 700;
+	font-size: var(--text-detail);
+	color: var(--color-foreground);
+}
+.join-label .req {
+	color: var(--color-secondary-deep);
+	font-weight: 800;
+}
+.join-label .opt {
+	color: var(--color-tertiary);
+	font-weight: 600;
+	font-size: var(--text-xs);
+}
+
+.join-control {
+	width: 100%;
+	font-size: var(--text-base);
+	font-weight: 500;
+	color: var(--color-foreground);
+	background: var(--color-background);
+	border: 2px solid var(--color-rules-dark);
+	border-radius: 0.65rem;
+	padding: 0.72rem 0.9rem;
+	outline: none;
+	transition:
+		border-color 0.15s,
+		box-shadow 0.15s,
+		background 0.15s;
+}
+.join-control::placeholder {
+	color: var(--color-tertiary);
+}
+.join-control:hover {
+	border-color: var(--color-tertiary);
+}
+.join-control:focus {
+	border-color: var(--color-foreground);
+	background: #fff;
+	box-shadow: 0 0 0 3px rgb(91 78 70 / 0.12);
+}
+textarea.join-control {
+	min-height: 132px;
+	resize: vertical;
+	line-height: 1.5;
+}
+
+/* Custom checkbox "chips" for the "I'd like" choices */
+.join-choices {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.7rem;
+}
+.join-choice {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.6rem;
+	padding: 0.62rem 1.15rem 0.62rem 0.8rem;
+	border: 2px solid var(--color-rules-dark);
+	border-radius: 9999px;
+	background: var(--color-background);
+	cursor: pointer;
+	font-weight: 700;
+	font-size: 0.95rem;
+	color: var(--color-foreground);
+	user-select: none;
+	transition:
+		border-color 0.15s,
+		background 0.15s;
+}
+.join-choice:hover {
+	border-color: var(--color-tertiary);
+}
+.join-choice input {
+	position: absolute;
+	opacity: 0;
+	pointer-events: none;
+}
+.join-choice__box {
+	width: 22px;
+	height: 22px;
+	flex-shrink: 0;
+	border: 2px solid var(--color-rules-dark);
+	border-radius: 6px;
+	background: #fff;
+	display: grid;
+	place-items: center;
+	transition:
+		background 0.15s,
+		border-color 0.15s;
+}
+.join-choice__box svg {
+	color: var(--color-background);
+	opacity: 0;
+	transform: scale(0.6);
+	transition:
+		opacity 0.15s,
+		transform 0.15s;
+}
+.join-choice:has(input:checked) {
+	border-color: var(--color-foreground);
+	background: var(--color-home-background-3);
+}
+.join-choice:has(input:checked) .join-choice__box {
+	background: var(--color-foreground);
+	border-color: var(--color-foreground);
+}
+.join-choice:has(input:checked) .join-choice__box svg {
+	opacity: 1;
+	transform: scale(1);
+}
+.join-choice:has(input:focus-visible) {
+	box-shadow: 0 0 0 3px rgb(91 78 70 / 0.12);
+}
+
+/* Submit row */
+.join-actions {
+	display: flex;
+	align-items: center;
+	gap: 1.25rem;
+	flex-wrap: wrap;
+	margin-top: 1.85rem;
+}
+.join-submit {
+	display: inline-flex;
+	align-items: center;
+	background: var(--color-foreground);
+	color: var(--color-background);
+	font-weight: 700;
+	font-size: 1.02rem;
+	padding: 0.8rem 2.1rem;
+	border: 0;
+	border-radius: 9999px;
+	box-shadow: 0 0 0 2px var(--color-foreground);
+	cursor: pointer;
+	transition: 0.2s;
+}
+.join-submit:hover {
+	background: var(--color-background);
+	color: var(--color-foreground);
+}
+.join-note {
+	font-size: 0.86rem;
+	color: var(--color-tertiary);
+	max-width: 34ch;
+	line-height: 1.45;
+}
+
+/* Email fallback CTA card (sits below the form card) */
+.join-email-cta {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 1.25rem;
+	margin-top: 1.25rem;
+	background: var(--color-secondary);
+	border-radius: var(--radius-card);
+	padding: 1.6rem 1.9rem;
+}
+.join-email-cta__heading {
+	font-family: var(--font-serif);
+	font-weight: 400;
+	font-size: 1.35rem;
+	line-height: 1.15;
+	color: var(--color-foreground);
+	margin-bottom: 0.2rem;
+}
+.join-email-cta__body {
+	font-size: 0.95rem;
+	color: var(--color-foreground);
+}
+.join-email-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.55rem;
+	white-space: nowrap;
+	text-decoration: none;
+	background: var(--color-foreground);
+	color: var(--color-background);
+	font-weight: 700;
+	font-size: 1rem;
+	padding: 0.7rem 1.4rem;
+	border-radius: 9999px;
+	box-shadow: 0 0 0 2px var(--color-foreground);
+	transition: 0.2s;
+}
+.join-email-link:hover {
+	background: var(--color-background);
+	color: var(--color-foreground);
+}
+
+/* Flash messages — distinct success / error states (Components::Flash) */
+.flash-message {
+	border-radius: var(--radius-card);
+	padding: 0.75rem 1rem;
+	font-size: 0.9rem;
+	font-weight: 700;
+	color: var(--color-foreground);
+}
+.flash-message--success {
+	background: var(--color-primary);
+}
+.flash-message--error {
+	background: var(--color-secondary);
+}
+
 /* Override leaflet.markercluster default styles */
 .marker-cluster-small,
 .marker-cluster-medium,

--- a/app/tailwind/public/_components.css
+++ b/app/tailwind/public/_components.css
@@ -291,7 +291,7 @@ textarea.join-control {
 	font-size: 1.35rem;
 	line-height: 1.15;
 	color: #3d342e;
-	margin-bottom: 0.2rem;
+	margin: 0 0 0.2rem;
 }
 .join-email-cta__body {
 	font-size: 0.95rem;

--- a/app/views/directory/join.rb
+++ b/app/views/directory/join.rb
@@ -8,76 +8,125 @@ class Views::Directory::Join < Views::Base
   prop :join, Join, reader: :private
 
   def view_template
-    content_for(:title) { 'Get in touch' }
+    content_for(:title) { t('directory.join.hero.title') }
 
     Directory::PageHero(
-      title: 'Get in touch',
-      kicker: 'Join PlaceCal',
-      subtitle: 'Want to run PlaceCal in your community, group, or area? Contact us to discuss how you can join our not-for-profit social enterprise.',
-      breadcrumb_label: 'Get in touch'
+      title: t('directory.join.hero.title'),
+      kicker: t('directory.join.hero.kicker'),
+      subtitle: t('directory.join.hero.subtitle'),
+      breadcrumb_label: t('directory.join.hero.breadcrumb')
     )
 
-    div(class: 'container-public py-8') do
-      div(class: 'max-w-(--width-prose-lg) mx-auto') do
-        render_flash_messages
-        render_form
-        p(class: 'text-sm text-tertiary mt-6') do
-          plain 'Email us at '
-          mail_to 'info@placecal.org', class: 'text-foreground underline hover:decoration-primary'
-        end
-      end
+    div(class: 'container-editorial py-8') do
+      render_form
+      render_email_cta
     end
   end
 
   private
 
-  def render_flash_messages
-    return unless view_context.flash.any?
-
-    div(class: 'mb-4') do
-      view_context.flash.each do |_key, value|
-        div(class: 'rounded-card px-4 py-3 text-sm font-bold bg-primary text-foreground') { value }
-      end
-    end
-  end
-
+  # simple_form_for gives us the form tag, CSRF token and model binding. We
+  # render each control with the plain Rails form-builder helpers (text_field,
+  # check_box, submit, …) rather than simple_form's `f.input` wrappers so the
+  # bespoke label/grid/chip markup below is fully under our control. Those
+  # helpers return an ActiveSupport::SafeBuffer, which `raw` writes straight
+  # into the Phlex output buffer.
   def render_form
-    simple_form_for join, url: get_in_touch_path, html: { class: 'space-y-4' } do |f|
+    simple_form_for join, url: get_in_touch_path do |f|
       invisible_captcha
-      div(class: 'grid md:grid-cols-2 gap-4') do
-        raw f.input(:name, label: 'Name', input_html: { class: input_class })
-        raw f.input(:email, as: :email, label: 'Email address', input_html: { class: input_class })
-        raw f.input(:job_title, label: 'Job title', input_html: { class: input_class })
-        raw f.input(:phone, as: :tel, label: 'Phone number', input_html: { class: input_class })
-        raw f.input(:job_org, label: 'Organisation name', input_html: { class: input_class })
-        raw f.input(:area, label: 'The area it covers', input_html: { class: input_class })
-      end
 
-      div(class: 'bg-home-background-3 rounded-card p-4') do
-        p(class: 'font-bold text-sm text-foreground mb-3') { "I'd like:" }
-        div(class: 'flex flex-wrap gap-4') do
-          render_checkbox(f, :ringback, 'A ring back')
-          render_checkbox(f, :more_info, 'More information')
+      div(class: 'join-card') do
+        div(class: 'join-grid') do
+          render_field(f, :name, required: true)
+          render_field(f, :email, type: :email_field, required: true)
+          render_field(f, :job_title)
+          render_field(f, :phone, type: :telephone_field)
+          render_field(f, :job_org)
+          render_field(f, :area)
         end
+
+        render_choices(f)
+        render_why(f)
+        render_actions(f)
       end
-
-      raw f.input(:why, as: :text, label: 'Why I want PlaceCal',
-                        placeholder: "Enter information about why you'd like to join PlaceCal here",
-                        input_html: { class: "#{input_class} min-h-30", rows: 5 })
-
-      raw f.submit('Submit',
-                   class: 'bg-foreground text-background rounded-full px-6 py-3 text-sm font-bold border-0 cursor-pointer hover:bg-tertiary transition-colors')
     end
   end
 
-  def render_checkbox(form, field, label_text)
-    div(class: 'flex items-center gap-2') do
-      raw form.check_box(field, class: 'w-4 h-4 accent-primary')
-      label(for: "join_#{field}", class: 'text-sm text-foreground cursor-pointer') { label_text }
+  # A single labelled text input in the field grid.
+  def render_field(form, attribute, type: :text_field, required: false)
+    div(class: 'join-field') do
+      render_label(attribute, required:)
+      raw form.public_send(
+        type, attribute,
+        class: 'join-control',
+        required:,
+        placeholder: t("directory.join.placeholders.#{attribute}")
+      )
     end
   end
 
-  def input_class
-    'w-full border-2 border-rules rounded-card px-4 py-2 text-sm bg-background text-foreground outline-none focus:border-foreground transition-colors'
+  def render_why(form)
+    div(class: 'join-block join-field') do
+      render_label(:why, required: true)
+      raw form.text_area(
+        :why,
+        class: 'join-control',
+        rows: 5,
+        required: true,
+        placeholder: t('directory.join.placeholders.why')
+      )
+    end
+  end
+
+  def render_choices(form)
+    div(class: 'join-block') do
+      p(class: 'join-label mb-3') { t('directory.join.choices_legend') }
+      div(class: 'join-choices') do
+        render_choice(form, :ringback)
+        render_choice(form, :more_info)
+      end
+    end
+  end
+
+  def render_choice(form, attribute)
+    label(class: 'join-choice') do
+      raw form.check_box(attribute)
+      span(class: 'join-choice__box') { icon(:check, size: '4') }
+      plain Join.human_attribute_name(attribute)
+    end
+  end
+
+  def render_actions(form)
+    div(class: 'join-actions') do
+      raw form.submit(t('directory.join.submit'), class: 'join-submit')
+      p(class: 'join-note') { t('directory.join.note') }
+    end
+  end
+
+  # Field label with a required (*) or optional marker, matching the design.
+  def render_label(attribute, required: false)
+    label(for: "join_#{attribute}", class: 'join-label') do
+      plain Join.human_attribute_name(attribute)
+      if required
+        span(class: 'req', aria_hidden: 'true') { '*' }
+      else
+        span(class: 'opt') { t('directory.join.optional') }
+      end
+    end
+  end
+
+  def render_email_cta
+    address = t('directory.join.email_cta.address')
+
+    div(class: 'join-email-cta') do
+      div do
+        h3(class: 'join-email-cta__heading') { t('directory.join.email_cta.heading') }
+        p(class: 'join-email-cta__body') { t('directory.join.email_cta.body') }
+      end
+      a(href: "mailto:#{address}", class: 'join-email-link with-no-sass') do
+        icon(:mail, size: '4')
+        plain address
+      end
+    end
   end
 end

--- a/app/views/directory/join.rb
+++ b/app/views/directory/join.rb
@@ -120,7 +120,8 @@ class Views::Directory::Join < Views::Base
 
     div(class: 'join-email-cta') do
       div do
-        h3(class: 'join-email-cta__heading') { t('directory.join.email_cta.heading') }
+        # h2 (not h3) to keep the heading order correct after the hero's h1.
+        h2(class: 'join-email-cta__heading') { t('directory.join.email_cta.heading') }
         p(class: 'join-email-cta__body') { t('directory.join.email_cta.body') }
       end
       a(href: "mailto:#{address}", class: 'join-email-link with-no-sass') do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,6 +166,31 @@ en:
     contact:
       get_in_touch: "Get in touch"
       no_contact: "No contact information — let us know!"
+    join:
+      hero:
+        kicker: "Join PlaceCal"
+        title: "Get in touch"
+        subtitle: "Want PlaceCal for your community, group, or area? Contact us to discuss how you can join our not-for-profit and collectively owned community calendar."
+        breadcrumb: "Get in touch"
+      optional: "optional"
+      choices_legend: "I'd like"
+      placeholders:
+        name: "Your full name"
+        email: "you@organisation.org"
+        job_title: "e.g. Community coordinator"
+        phone: "So we can call you back"
+        job_org: "Who you're with"
+        area: "Neighbourhood, town or region"
+        why: "Tell us a little about your community and what you're hoping PlaceCal can do for it."
+      submit: "Submit"
+      note: "We read every message and usually reply within two working days."
+      email_cta:
+        heading: "Rather just email?"
+        body: "Drop us a line directly and we'll pick it up from there."
+        address: "info@placecal.org"
+      flash:
+        success: "Thank you for your interest in PlaceCal. We'll be in touch with you shortly."
+        error: "Please fill out the required fields below."
     footer:
       tagline: "An open, community-run directory of local events and services near you."
       browse: "Browse"
@@ -248,6 +273,26 @@ en:
   # ===========================================================================
   # ACTIVERECORD
   # ===========================================================================
+
+  # ===========================================================================
+  # ACTIVEMODEL (non-persisted models, e.g. the Join enquiry form)
+  # ===========================================================================
+  activemodel:
+    models:
+      join:
+        one: "Join enquiry"
+        other: "Join enquiries"
+    attributes:
+      join:
+        name: "Name"
+        email: "Email address"
+        job_title: "Job title"
+        phone: "Phone number"
+        job_org: "Organisation name"
+        area: "The area it covers"
+        ringback: "A ring back"
+        more_info: "More information"
+        why: "Why I want PlaceCal"
 
   activerecord:
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #3245

## Description

Rebuilds the **Get in touch / Join** enquiry form (`app/views/directory/join.rb`) to match the design handoff and resolves the cleanup points raised in the issue:

- **i18n** — all user-facing strings moved to `config/locales/en.yml`. Field labels come from `activemodel.attributes.join` model translations; page strings live under `directory.join`.
- **Extracted class strings** — the long inline Tailwind strings are now reusable component classes in `app/tailwind/public/_components.css` (form card, `.join-control` inputs, custom checkbox "chips", submit/email-CTA buttons, `.flash-message`), built from the existing theme CSS variables.
- **Clarified `raw`/simple_form usage** — `simple_form_for` still provides the form tag, CSRF token and model binding, but each control is rendered with the plain Rails form-builder helpers (`text_field`, `check_box`, `submit`, …) so the bespoke label/grid/chip markup is fully under our control. `raw` only wraps the `SafeBuffer` those helpers return (documented with a comment).
- **Flash styling** — distinct success (green) / error (salmon) states, applied in the shared public `Components::Flash` rendered by the layout. Removed the in-view flash the page used to render, which duplicated the layout's global flash.

Visually the form now has the cream card, two-column field grid (collapsing on mobile), required/optional label markers, custom checkbox chips for the *I'd like* options, the submit row with helper note, and the salmon *Rather just email?* CTA card.

### Motivation and Context

The form worked but contained hardcoded strings, long inline class strings, awkward `raw f.input(...)` calls, and undifferentiated flash styling. This brings it onto the directory design system and the project's i18n/Tailwind conventions.

### Type of change

- [x] Bug fix / cleanup (non-breaking)
- [x] Style/redesign change

### How Has This Been Tested?

Manually verified in Chrome at `lvh.me:3000/get-in-touch`:
- All fields, optional/required markers, custom chips (incl. checked state), submit row and email CTA render per the design.
- Submit/email buttons share the same invert-on-hover state.
- Error path shows the distinct salmon flash; `invisible_captcha` still rejects too-fast submits.
- Valid submission delivers the mail and redirects home with the green success flash — **end-to-end submission preserved**.

rubocop and prettier pass (via lint-staged). No existing tests assert public-site flash classes (all flash assertions target the admin `Alert` component), so the shared-component class rename is safe.

### How Will This Be Deployed?

Standard deploy. Public Tailwind CSS is rebuilt via `yarn css-public` as part of the normal asset build — no infra or manual config changes.