### PR TITLE
Directory front-end i18n sweep + i18n-tasks guard (#3246)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem 'paper_trail'                 # Event version tracking and audit log
 group :development, :test do
   gem 'byebug'                    # Debugger
   gem 'dotenv-rails'              # Load .env files
+  gem 'i18n-tasks', require: false # Find missing/unused locale keys (CLI + guard spec)
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,6 +365,8 @@ GEM
     groupdate (6.8.0)
       activesupport (>= 7.2)
     hashdiff (1.2.1)
+    highline (3.1.2)
+      reline
     htmlbeautifier (1.4.3)
     htmlentities (4.4.2)
     http-accept (1.7.0)
@@ -376,6 +378,18 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.1.2)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 3.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      prism
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.8, >= 1.8.1)
+      terminal-table (>= 1.5.1)
     icalendar (2.12.3)
       base64
       ice_cube (~> 0.16)
@@ -607,6 +621,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -782,6 +799,8 @@ GEM
     sys-uname (1.5.1)
       ffi (~> 1.1)
       memoist3 (~> 1.0.0)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
     thread_safe (0.3.6)
     timecop (0.9.11)
@@ -872,6 +891,7 @@ DEPENDENCIES
   graphql-client
   groupdate
   httparty
+  i18n-tasks
   icalendar
   icalendar-recurrence
   image_processing

--- a/app/components/directory/az_jump_bar.rb
+++ b/app/components/directory/az_jump_bar.rb
@@ -8,7 +8,7 @@ class Components::Directory::AzJumpBar < Components::Directory::Base
   prop :filter_params, Hash, default: -> { {} }
 
   def view_template
-    nav(class: 'flex gap-0.5 flex-wrap py-3', aria_label: 'Filter by letter') do
+    nav(class: 'flex gap-0.5 flex-wrap py-3', aria_label: t('directory.aria.filter_by_letter')) do
       render_all_link
       LETTERS.each do |letter|
         if @active_letters.include?(letter)
@@ -28,9 +28,9 @@ class Components::Directory::AzJumpBar < Components::Directory::Base
 
   def render_all_link
     if @selected_letter.nil?
-      span(class: "#{letter_base} #{letter_selected} w-auto px-2") { plain 'All' }
+      span(class: "#{letter_base} #{letter_selected} w-auto px-2") { plain t('directory.filters.all') }
     else
-      a(href: all_path, class: "#{letter_base} #{letter_active} w-auto px-2") { plain 'All' }
+      a(href: all_path, class: "#{letter_base} #{letter_active} w-auto px-2") { plain t('directory.filters.all') }
     end
   end
 

--- a/app/components/directory/custom_select.rb
+++ b/app/components/directory/custom_select.rb
@@ -108,7 +108,10 @@ class Components::Directory::CustomSelect < Components::Directory::Base
   end
 
   def placeholder
-    @default_label || (@label_text.present? ? "All #{@label_text.downcase.pluralize}" : 'All')
+    return @default_label if @default_label
+    return t('directory.filters.all') if @label_text.blank?
+
+    t('directory.filters.all_plural', label: @label_text.downcase.pluralize)
   end
 
   def selected_label

--- a/app/components/directory/event_row.rb
+++ b/app/components/directory/event_row.rb
@@ -83,7 +83,7 @@ class Components::Directory::EventRow < Components::Directory::Base
   def render_meta_online
     span(class: 'inline-flex items-center gap-1') do
       render_icon(:event_online)
-      plain 'Online'
+      plain t('directory.event_row.online')
     end
   end
 

--- a/app/components/directory/hero.rb
+++ b/app/components/directory/hero.rb
@@ -37,12 +37,12 @@ class Components::Directory::Hero < Components::Directory::Base
       end
       input(
         type: 'text', name: 'q',
-        placeholder: 'Search partners…',
+        placeholder: t('directory.hero.search_placeholder'),
         class: 'flex-1 border-0 bg-transparent py-2 text-foreground text-detail outline-none placeholder:text-tertiary'
       )
       button(type: 'submit',
              class: 'bg-primary text-foreground rounded-full px-5 py-2 text-detail font-bold border-0 cursor-pointer hover:bg-primary/80 transition-colors') do
-        plain 'Search'
+        plain t('directory.hero.search_button')
       end
     end
   end
@@ -52,7 +52,7 @@ class Components::Directory::Hero < Components::Directory::Base
     return if links.none?
 
     div(class: 'flex items-center gap-6 mt-6 flex-wrap') do
-      span(class: 'text-sm') { 'Jump to:' }
+      span(class: 'text-sm') { t('directory.hero.jump_to') }
       links.each do |link|
         a(href: partners_path(neighbourhood: link[:neighbourhood_id]),
           class: 'font-bold text-detail no-underline hover:underline hover:decoration-primary',
@@ -82,7 +82,7 @@ class Components::Directory::Hero < Components::Directory::Base
         )
       else
         div(class: 'bg-primary/20 rounded-tl-card h-full min-h-(--height-map-lg) flex items-center justify-center') do
-          div(class: 'text-foreground/40 text-sm font-bold') { 'Map coming soon' }
+          div(class: 'text-foreground/40 text-sm font-bold') { t('directory.map_coming_soon') }
         end
       end
     end

--- a/app/components/directory/neighbourhood_cascade.rb
+++ b/app/components/directory/neighbourhood_cascade.rb
@@ -68,12 +68,12 @@ class Components::Directory::NeighbourhoodCascade < Components::Directory::Base
         options: nodes.map { |n| option_for(n) },
         selected: selected_node && selected_node[:id].to_s,
         include_blank: true,
-        default_label: t('directory.partners.index.filters.all_neighbourhoods')
+        default_label: t('directory.filters.all_neighbourhoods')
       }
     else
       parent = path[depth - 1]
       {
-        options: [{ id: parent[:id], name: t('directory.partners.index.filters.all_of', name: parent[:name]) }] + nodes.map { |n| option_for(n) },
+        options: [{ id: parent[:id], name: t('directory.filters.all_of', name: parent[:name]) }] + nodes.map { |n| option_for(n) },
         selected: (selected_node || parent)[:id].to_s,
         include_blank: false,
         default_label: nil

--- a/app/components/directory/page_hero.rb
+++ b/app/components/directory/page_hero.rb
@@ -38,7 +38,7 @@ class Components::Directory::PageHero < Components::Directory::Base
   end
 
   def render_breadcrumb
-    nav(class: 'text-sm mb-2', style: 'color: var(--color-background)', aria_label: 'Breadcrumb') do
+    nav(class: 'text-sm mb-2', style: 'color: var(--color-background)', aria_label: t('directory.aria.breadcrumb')) do
       a(href: root_path, class: 'no-underline hover:underline', style: 'color: inherit') { t('directory.breadcrumbs.root') }
       span(class: 'mx-1.5 opacity-60') { safe('›') }
       if @breadcrumb_path

--- a/app/components/directory/paginator.rb
+++ b/app/components/directory/paginator.rb
@@ -6,7 +6,7 @@ class Components::Directory::Paginator < Components::Directory::Base
   def view_template
     return unless @pagy.pages > 1
 
-    nav(class: 'flex items-center justify-center gap-1 py-6', aria_label: 'Pagination') do
+    nav(class: 'flex items-center justify-center gap-1 py-6', aria_label: t('directory.aria.pagination')) do
       render_prev
       render_pages
       render_next

--- a/app/components/directory/partner_filter.rb
+++ b/app/components/directory/partner_filter.rb
@@ -18,11 +18,11 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
          class: 'bg-home-background-3 rounded-card p-4 mb-4 text-sm') do
       div(class: 'flex flex-wrap lg:flex-nowrap gap-3 items-end') do
         render_search_field
-        Directory::CustomSelect(name: 'category', label_text: t('directory.partners.index.filters.category'), default_label: t('directory.partners.index.filters.all_categories'), options: @categories, selected: @selected_category) if @categories.any?
-        Directory::CustomSelect(name: 'partnership', label_text: t('directory.partners.index.filters.partnership'), default_label: t('directory.partners.index.filters.all_partnerships'), options: @partnerships_list, selected: @selected_partnership) if @partnerships_list.any?
+        Directory::CustomSelect(name: 'category', label_text: t('directory.filters.category'), default_label: t('directory.filters.all_categories'), options: @categories, selected: @selected_category) if @categories.any?
+        Directory::CustomSelect(name: 'partnership', label_text: t('directory.filters.partnership'), default_label: t('directory.filters.all_partnerships'), options: @partnerships_list, selected: @selected_partnership) if @partnerships_list.any?
       end
       div(class: 'flex flex-wrap gap-3 items-end mt-3') do
-        Directory::NeighbourhoodCascade(tree: @neighbourhoods_tree, selected: @selected_neighbourhood, label_text: t('directory.partners.index.filters.neighbourhood')) if @neighbourhoods_tree.any?
+        Directory::NeighbourhoodCascade(tree: @neighbourhoods_tree, selected: @selected_neighbourhood, label_text: t('directory.filters.neighbourhood')) if @neighbourhoods_tree.any?
         render_buttons
       end
     end
@@ -34,10 +34,10 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
     # Full width on its own line when wrapped, so Category and Partnership get a
     # roomy half each instead of three cramped columns; shares the row on lg.
     div(class: 'flex-1 basis-full lg:basis-auto min-w-35') do
-      label(for: 'q', class: 'block allcaps-label text-tertiary mb-1') { t('directory.partners.index.filters.search') }
+      label(for: 'q', class: 'block allcaps-label text-tertiary mb-1') { t('directory.filters.search') }
       input(
         type: 'text', name: 'q', id: 'q', value: @query,
-        placeholder: t('directory.partners.index.filters.search_placeholder'),
+        placeholder: t('directory.filters.search_placeholder'),
         class: 'w-full h-[42px] border-2 border-rules rounded-sm px-4 text-sm bg-background text-foreground outline-none focus:border-foreground transition-colors'
       )
     end
@@ -47,12 +47,12 @@ class Components::Directory::PartnerFilter < Components::Directory::Base
     div(class: 'flex gap-2 items-end') do
       button(type: 'submit',
              class: 'inline-flex items-center justify-center h-[42px] bg-foreground text-background rounded-sm px-5 text-sm font-bold border-2 border-foreground cursor-pointer hover:bg-tertiary hover:border-tertiary transition-colors') do
-        plain t('directory.partners.index.filters.apply')
+        plain t('directory.filters.apply')
       end
       if any_filter_active?
         a(href: partners_path,
           class: 'with-no-sass inline-flex items-center justify-center h-[42px] rounded-sm px-4 text-sm font-bold bg-background text-foreground border-2 border-foreground no-underline hover:bg-foreground hover:text-background transition-colors') do
-          plain t('directory.partners.index.filters.clear')
+          plain t('directory.filters.clear')
         end
       end
     end

--- a/app/views/directory/events/index.rb
+++ b/app/views/directory/events/index.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Views::Directory::Events::Index < Views::Base
-  PERIOD_OPTIONS = [['This week', 'week'], ['Today', 'day'], ['This month', 'month'], ['All upcoming', 'future']].freeze
+  # Period values in the order they appear in the filter dropdown and the tab bar
+  # respectively. Labels come from the `directory.events.index.periods` locale.
+  SELECT_PERIODS = %w[week day month future].freeze
+  TAB_PERIODS = %w[day week month future].freeze
 
   prop :events, Hash
   prop :site, _Nilable(::Site)
@@ -14,14 +17,14 @@ class Views::Directory::Events::Index < Views::Base
   prop :pagy, _Nilable(Pagy::Offset), default: nil
 
   def view_template
-    content_for(:title) { 'Events' }
-    content_for(:description) { "Discover #{@total_count} upcoming events and activities from community organisations across the UK on PlaceCal." }
+    content_for(:title) { ::Event.model_name.human(count: 2) }
+    content_for(:description) { t('directory.events.index.description', count: @total_count) }
 
     Directory::PageHero(
-      title: 'Events on PlaceCal',
+      title: t('directory.events.index.hero_title'),
       kicker: kicker_text,
-      subtitle: 'A nationwide event feed is a lot. Narrow down by place, interest, or partnership to see what\'s coming up near you.',
-      breadcrumb_label: 'Events'
+      subtitle: t('directory.events.index.hero_subtitle'),
+      breadcrumb_label: ::Event.model_name.human(count: 2)
     )
 
     div(class: 'container-public py-6') do
@@ -36,7 +39,7 @@ class Views::Directory::Events::Index < Views::Base
   private
 
   def kicker_text
-    "#{@total_count} upcoming events across the UK"
+    t('directory.events.index.kicker', count: @total_count)
   end
 
   def render_filters
@@ -53,10 +56,10 @@ class Views::Directory::Events::Index < Views::Base
 
   def render_search_field
     div(class: 'flex-1 min-w-50') do
-      label(for: 'q', class: 'block allcaps-label text-tertiary mb-1') { 'Search' }
+      label(for: 'q', class: 'block allcaps-label text-tertiary mb-1') { t('directory.filters.search') }
       input(
         type: 'text', name: 'q', id: 'q', value: @query,
-        placeholder: 'Event name or keyword…',
+        placeholder: t('directory.events.index.search_placeholder'),
         class: 'w-full border-2 border-rules rounded-full px-4 py-2 text-sm bg-background text-foreground outline-none focus:border-foreground transition-colors'
       )
     end
@@ -67,7 +70,7 @@ class Views::Directory::Events::Index < Views::Base
 
     Directory::CustomSelect(
       name: 'partnership',
-      label_text: 'Partnership',
+      label_text: t('directory.filters.partnership'),
       options: @partnerships_list.map { |item| { id: item[:slug], name: item[:name] } },
       selected: @selected_partnership
     )
@@ -76,8 +79,8 @@ class Views::Directory::Events::Index < Views::Base
   def render_period_select
     Directory::CustomSelect(
       name: 'period',
-      label_text: 'Time range',
-      options: PERIOD_OPTIONS.map { |label, value| { id: value, name: label } },
+      label_text: t('directory.events.index.period_label'),
+      options: SELECT_PERIODS.map { |value| { id: value, name: period_option_label(value) } },
       selected: @period,
       include_blank: false
     )
@@ -87,20 +90,21 @@ class Views::Directory::Events::Index < Views::Base
     div(class: 'flex gap-2 items-end') do
       button(type: 'submit',
              class: 'bg-foreground text-background rounded-full px-5 py-2 text-sm font-bold border-0 cursor-pointer hover:bg-tertiary transition-colors') do
-        plain 'Filter'
+        plain t('directory.filters.apply')
       end
       if any_filter_active?
         a(href: events_path,
           class: 'inline-flex items-center rounded-full px-4 py-2 text-sm font-bold text-tertiary border-2 border-rules no-underline hover:border-foreground transition-colors') do
-          plain 'Clear'
+          plain t('directory.filters.clear')
         end
       end
     end
   end
 
   def render_period_tabs
-    nav(class: 'flex gap-1 flex-wrap py-2', aria_label: 'Time period') do
-      [['Today', 'day'], ['This week', 'week'], ['This month', 'month'], ['All upcoming', 'future']].each do |label, value|
+    nav(class: 'flex gap-1 flex-wrap py-2', aria_label: t('directory.aria.time_period')) do
+      TAB_PERIODS.each do |value|
+        label = period_option_label(value)
         params = current_filter_params.merge('period' => value)
         if @period == value
           span(class: 'inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold bg-foreground text-background') { label }
@@ -118,9 +122,9 @@ class Views::Directory::Events::Index < Views::Base
     count = flat_events.size
     div(class: 'text-sm text-tertiary py-2') do
       if count.zero?
-        plain "No events #{period_label}"
+        plain t('directory.events.index.results.none', period: period_phrase)
       else
-        plain "#{count} #{'event'.pluralize(count)} #{period_label}"
+        plain t('directory.events.index.results.count', count: count, period: period_phrase)
       end
     end
   end
@@ -150,11 +154,11 @@ class Views::Directory::Events::Index < Views::Base
 
   def render_empty_state
     div(class: 'py-10 text-center') do
-      p(class: 'text-tertiary text-lg mb-4') { "No events found #{period_label}." }
+      p(class: 'text-tertiary text-lg mb-4') { t('directory.events.index.empty', period: period_phrase) }
       unless @period == 'future'
         a(href: "#{events_path}?period=future",
           class: 'inline-flex items-center gap-2 text-foreground font-bold no-underline hover:underline') do
-          plain 'Show all upcoming events'
+          plain t('directory.events.index.show_all')
         end
       end
     end
@@ -164,13 +168,14 @@ class Views::Directory::Events::Index < Views::Base
     @flat_events ||= @events.values.flatten
   end
 
-  def period_label
-    case @period
-    when 'day' then 'today'
-    when 'week' then 'this week'
-    when 'month' then 'this month'
-    else ''
-    end
+  def period_option_label(value)
+    t("directory.events.index.periods.#{value}")
+  end
+
+  # Sentence fragment (with a leading space) appended to the results header,
+  # e.g. " this week". Blank for the "future" period.
+  def period_phrase
+    t("directory.events.index.period_phrases.#{@period}", default: '')
   end
 
   def any_filter_active?

--- a/app/views/directory/home.rb
+++ b/app/views/directory/home.rb
@@ -12,21 +12,21 @@ class Views::Directory::Home < Views::Base
   prop :jump_neighbourhoods, _Interface(:each), default: -> { [] }
 
   def view_template
-    content_for(:description) { 'Find community groups, venues and events near you. PlaceCal aggregates thousands of events from hundreds of local organisations across the UK.' }
+    content_for(:description) { t('directory.home.description') }
 
     Directory::Hero(
-      title: 'Find community groups, venues and events near you.',
-      subtitle: 'PlaceCal aggregates thousands of events and activities from hundreds of local community organisations across the UK. This is the directory for all of it — search by place, by interest, or browse the map.',
+      title: t('directory.home.hero_title'),
+      subtitle: t('directory.home.hero_subtitle'),
       search_path: partners_path,
       partner_locations: @partner_locations,
       jump_neighbourhoods: @jump_neighbourhoods
     )
 
     Directory::StatsStrip(stats: [
-                            { value: @stats[:partnerships], label: 'Partnerships', icon: :partnership },
-                            { value: @stats[:partners], label: 'Partners', icon: :partner },
-                            { value: @stats[:events], label: 'Events this month', icon: :event },
-                            { value: @stats[:neighbourhoods], label: 'Neighbourhoods', icon: :neighbourhood }
+                            { value: @stats[:partnerships], label: ::Partnership.model_name.human(count: 2), icon: :partnership },
+                            { value: @stats[:partners], label: ::Partner.model_name.human(count: 2), icon: :partner },
+                            { value: @stats[:events], label: t('directory.home.stats.events'), icon: :event },
+                            { value: @stats[:neighbourhoods], label: ::Neighbourhood.model_name.human(count: 2), icon: :neighbourhood }
                           ])
 
     render_partnerships_section
@@ -41,12 +41,12 @@ class Views::Directory::Home < Views::Base
       div(class: 'container-public') do
         div(class: 'flex justify-between items-baseline flex-wrap gap-2') do
           div do
-            div(class: 'allcaps-label text-tertiary') { 'Partnerships' }
-            h2(class: 'font-serif font-regular text-section text-foreground') { 'Community hubs running on PlaceCal' }
+            div(class: 'allcaps-label text-tertiary') { t('directory.home.partnerships.kicker') }
+            h2(class: 'font-serif font-regular text-section text-foreground') { t('directory.home.partnerships.heading') }
           end
           a(href: partnerships_path,
             class: 'btn-primary-outline transition-colors') do
-            plain 'See all partnerships'
+            plain t('directory.home.partnerships.see_all')
             span { safe('&rarr;') }
           end
         end
@@ -72,8 +72,8 @@ class Views::Directory::Home < Views::Base
 
   def render_recent_partners
     div do
-      div(class: 'allcaps-label text-tertiary') { 'Activity' }
-      h2(class: 'font-serif font-regular text-section text-foreground mb-4') { 'Recently joined PlaceCal' }
+      div(class: 'allcaps-label text-tertiary') { t('directory.home.activity.kicker') }
+      h2(class: 'font-serif font-regular text-section text-foreground mb-4') { t('directory.home.activity.heading') }
       div(class: 'flex flex-col gap-2') do
         partners = @recent_partners.first(5)
         partners.each do |partner|
@@ -83,7 +83,7 @@ class Views::Directory::Home < Views::Base
       div(class: 'mt-4') do
         a(href: partners_path,
           class: 'inline-flex items-center gap-2 bg-home-background border-2 border-primary rounded-full px-5 py-2 text-detail font-bold text-foreground no-underline hover:bg-primary transition-colors') do
-          plain 'Browse all partners'
+          plain t('directory.home.activity.browse_all')
           span { safe('&rarr;') }
         end
       end
@@ -92,8 +92,8 @@ class Views::Directory::Home < Views::Base
 
   def render_upcoming_events
     div do
-      div(class: 'allcaps-label text-tertiary') { 'Tonight & this week' }
-      h2(class: 'font-serif font-regular text-section text-foreground mb-4') { 'Happening around the UK' }
+      div(class: 'allcaps-label text-tertiary') { t('directory.home.events.kicker') }
+      h2(class: 'font-serif font-regular text-section text-foreground mb-4') { t('directory.home.events.heading') }
       div do
         flat_events.first(5).each do |event|
           Directory::EventRow(event: event)
@@ -102,7 +102,7 @@ class Views::Directory::Home < Views::Base
       div(class: 'mt-4') do
         a(href: events_path,
           class: 'inline-flex items-center gap-2 bg-home-background border-2 border-primary rounded-full px-5 py-2 text-detail font-bold text-foreground no-underline hover:bg-primary transition-colors') do
-          plain 'Filter events by place'
+          plain t('directory.home.events.filter_by_place')
           span { safe('&rarr;') }
         end
       end
@@ -113,16 +113,16 @@ class Views::Directory::Home < Views::Base
     section(class: 'py-10') do
       div(class: 'container-public grid md:grid-cols-2 gap-4') do
         render_cta_card(
-          heading: 'What is PlaceCal?',
-          body: 'PlaceCal is an online calendar which lists events and activities by and for members of local communities, curated around interests and locality.',
-          link_text: 'Our story',
+          heading: t('directory.home.cta.what_is.heading'),
+          body: t('directory.home.cta.what_is.body'),
+          link_text: t('directory.home.cta.what_is.link'),
           link_path: our_story_path,
           head_class: 'bg-secondary'
         )
         render_cta_card(
-          heading: 'Run PlaceCal in your community',
-          body: 'Setting up a PlaceCal means a dedicated website for your community, connected to the directory. We work with you on the ground to build partnerships with local venues and organisers.',
-          link_text: 'Get in touch',
+          heading: t('directory.home.cta.run.heading'),
+          body: t('directory.home.cta.run.body'),
+          link_text: t('directory.home.cta.run.link'),
           link_path: get_in_touch_path,
           head_class: 'bg-primary'
         )

--- a/app/views/directory/partners/index.rb
+++ b/app/views/directory/partners/index.rb
@@ -18,14 +18,14 @@ class Views::Directory::Partners::Index < Views::Base
   prop :selected_letter, _Nilable(String), default: nil
 
   def view_template
-    content_for(:title) { 'Partners' }
-    content_for(:description) { "Browse #{@total_count} community partners across the UK on PlaceCal. Search by name, category, partnership or neighbourhood." }
+    content_for(:title) { ::Partner.model_name.human(count: 2) }
+    content_for(:description) { t('directory.partners.index.description', count: @total_count) }
 
     Directory::PageHero(
-      title: 'All partners on PlaceCal',
+      title: t('directory.partners.index.hero_title'),
       kicker: kicker_text,
-      subtitle: 'Every community group, venue, library and organisation publishing their events on PlaceCal, UK-wide.',
-      breadcrumb_label: 'Partners'
+      subtitle: t('directory.partners.index.hero_subtitle'),
+      breadcrumb_label: ::Partner.model_name.human(count: 2)
     )
 
     div(class: 'container-public py-6') do
@@ -50,7 +50,7 @@ class Views::Directory::Partners::Index < Views::Base
   private
 
   def kicker_text
-    "#{@total_count} partners across #{@partnership_count} partnerships"
+    t('directory.partners.index.kicker', count: @total_count, partnerships: @partnership_count)
   end
 
   def render_results_header
@@ -58,18 +58,18 @@ class Views::Directory::Partners::Index < Views::Base
     div(class: 'flex justify-between items-baseline flex-wrap gap-2 py-3') do
       div(class: 'text-sm text-tertiary') do
         if any_filter_active?
-          plain "Showing #{partner_list.size} of #{filtered_total} partners"
+          plain t('directory.partners.index.results.filtered', shown: partner_list.size, total: filtered_total)
         else
-          plain "#{@total_count} partners"
+          plain t('directory.partners.index.results.total', count: @total_count)
         end
-        plain " — page #{@pagy.page} of #{@pagy.pages}" if @pagy&.pages && @pagy.pages > 1
+        plain t('directory.partners.index.results.page', page: @pagy.page, pages: @pagy.pages) if @pagy&.pages && @pagy.pages > 1
       end
     end
   end
 
   def render_sort_tabs
-    nav(class: 'flex gap-1 flex-wrap py-2', aria_label: 'Sort order') do
-      [['Recently updated', 'recent'], ['A–Z', 'name']].each do |label, value|
+    nav(class: 'flex gap-1 flex-wrap py-2', aria_label: t('directory.aria.sort_order')) do
+      [[t('directory.partners.index.sort.recent'), 'recent'], [t('directory.partners.index.sort.name'), 'name']].each do |label, value|
         sort_params = current_filter_params.merge('sort' => value)
         if @sort == value
           span(class: 'inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold bg-foreground text-background') { label }
@@ -95,9 +95,9 @@ class Views::Directory::Partners::Index < Views::Base
     return unless partner_list.none?
 
     div(class: 'py-10 text-center') do
-      p(class: 'text-tertiary text-lg') { 'No partners found matching your filters.' }
+      p(class: 'text-tertiary text-lg') { t('directory.partners.index.empty') }
       a(href: partners_path, class: 'inline-flex items-center gap-2 mt-3 text-foreground font-bold no-underline hover:underline') do
-        plain 'Clear filters'
+        plain t('directory.partners.index.clear')
       end
     end
   end

--- a/app/views/directory/partnerships/show.rb
+++ b/app/views/directory/partnerships/show.rb
@@ -151,7 +151,7 @@ class Views::Directory::Partnerships::Show < Views::Base
         )
       else
         div(class: 'h-(--height-map) flex items-center justify-center') do
-          div(class: 'text-tertiary text-sm font-bold') { t('directory.partnerships.show.map_coming_soon') }
+          div(class: 'text-tertiary text-sm font-bold') { t('directory.map_coming_soon') }
         end
       end
     end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,60 @@
+# i18n-tasks configuration
+# Finds missing and unused translations. Run `bundle exec i18n-tasks health`.
+# A guard spec (spec/i18n_keys_spec.rb) fails the build on missing keys.
+
+base_locale: en
+locales: [en]
+
+data:
+  # PlaceCal splits its locale data across several files. The default reader
+  # only loads `en.yml`, so the namespaced files must be listed explicitly or
+  # every key in them looks "missing".
+  read:
+    - config/locales/%{locale}.yml
+    - config/locales/*.%{locale}.yml
+  # New keys added by `i18n-tasks add-missing` land in the matching file.
+  write:
+    - ["config/locales/admin.%{locale}.yml", "admin.*"]
+    - ["config/locales/devise.%{locale}.yml", "devise.*"]
+    - config/locales/%{locale}.yml
+
+search:
+  paths:
+    - app/
+    - lib/
+
+ignore_missing:
+  # Devise/Rails supply these from the gems' own locale files at runtime.
+  - "devise.*"
+  - "errors.messages.*"
+  - "date.day_names" # provided by rails-i18n / ActiveSupport
+  # OpenGraph card services (app/services/og_image/*) look these up through a
+  # private `t(key)` helper that injects `scope: 'og_image'`, so the real keys
+  # live under `og_image.*` but appear here unscoped.
+  - "powered_by"
+  - "generic.statement"
+  - "labels.{event,partner,partnership,community_site}"
+  - "upcoming_events"
+  - "partner_organisations"
+  - "events_this_month"
+
+ignore_unused:
+  # Resolved dynamically (e.g. Model.model_name.human, attr_label,
+  # interpolated keys) so static analysis can't see the call sites.
+  - "activerecord.*"
+  - "activemodel.*"
+  - "enumerize.*"
+  - "simple_form.*"
+  - "devise.*"
+  - "neighbourhoods.*"
+  - "time.formats.*"
+  - "date.formats.*"
+  - "errors.messages.*" # Devise/Rails runtime messages
+  # Built from interpolated values in code:
+  - "directory.events.index.periods.*" # period_option_label("#{value}")
+  - "directory.events.index.period_phrases.*" # period_phrase("#{@period}")
+  # OurStory builds every key from `T = 'directory.pages.our_story'` and
+  # interpolated section names (see app/views/directory/our_story.rb).
+  - "directory.pages.our_story.*"
+  # OG card services resolve keys through a scoped `t` helper (scope: 'og_image').
+  - "og_image.*"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,90 @@ en:
   directory:
     breadcrumbs:
       root: "Directory"
+    aria:
+      breadcrumb: "Breadcrumb"
+      time_period: "Time period"
+      sort_order: "Sort order"
+      filter_by_letter: "Filter by letter"
+      pagination: "Pagination"
+    # Shared filter chrome, used by both the partner filter and the events
+    # filter form (app/components/directory/partner_filter.rb,
+    # neighbourhood_cascade.rb and app/views/directory/events/index.rb).
+    filters:
+      all: "All"
+      all_plural: "All %{label}"
+      search: "Search"
+      search_placeholder: "Name or keyword…"
+      apply: "Filter"
+      clear: "Clear"
+      category: "Category"
+      partnership: "Partnership"
+      neighbourhood: "Neighbourhood"
+      all_categories: "All categories"
+      all_partnerships: "All partnerships"
+      all_neighbourhoods: "All neighbourhoods"
+      all_of: "All of %{name}"
+    map_coming_soon: "Map coming soon"
+    hero:
+      search_placeholder: "Search partners…"
+      search_button: "Search"
+      jump_to: "Jump to:"
+    event_row:
+      online: "Online"
+    home:
+      description: "Find community groups, venues and events near you. PlaceCal aggregates thousands of events from hundreds of local organisations across the UK."
+      hero_title: "Find community groups, venues and events near you."
+      hero_subtitle: "PlaceCal aggregates thousands of events and activities from hundreds of local community organisations across the UK. This is the directory for all of it — search by place, by interest, or browse the map."
+      stats:
+        # Partner/Partnership/Neighbourhood labels come from model_name.human;
+        # only the non-model "this month" label lives here.
+        events: "Events this month"
+      partnerships:
+        kicker: "Partnerships"
+        heading: "Community hubs running on PlaceCal"
+        see_all: "See all partnerships"
+      activity:
+        kicker: "Activity"
+        heading: "Recently joined PlaceCal"
+        browse_all: "Browse all partners"
+      events:
+        kicker: "Tonight & this week"
+        heading: "Happening around the UK"
+        filter_by_place: "Filter events by place"
+      cta:
+        what_is:
+          heading: "What is PlaceCal?"
+          body: "PlaceCal is an online calendar which lists events and activities by and for members of local communities, curated around interests and locality."
+          link: "Our story"
+        run:
+          heading: "Run PlaceCal in your community"
+          body: "Setting up a PlaceCal means a dedicated website for your community, connected to the directory. We work with you on the ground to build partnerships with local venues and organisers."
+          link: "Get in touch"
+    events:
+      index:
+        description: "Discover %{count} upcoming events and activities from community organisations across the UK on PlaceCal."
+        hero_title: "Events on PlaceCal"
+        hero_subtitle: "A nationwide event feed is a lot. Narrow down by place, interest, or partnership to see what's coming up near you."
+        kicker: "%{count} upcoming events across the UK"
+        search_placeholder: "Event name or keyword…"
+        period_label: "Time range"
+        periods:
+          day: "Today"
+          week: "This week"
+          month: "This month"
+          future: "All upcoming"
+        period_phrases:
+          day: " today"
+          week: " this week"
+          month: " this month"
+          future: ""
+        results:
+          none: "No events%{period}"
+          count:
+            one: "%{count} event%{period}"
+            other: "%{count} events%{period}"
+        empty: "No events found%{period}."
+        show_all: "Show all upcoming events"
     pages:
       privacy:
         title: "PlaceCal Privacy Policy"
@@ -104,18 +188,19 @@ en:
           button: "Get in touch"
     partners:
       index:
-        filters:
-          search: "Search"
-          search_placeholder: "Name or keyword…"
-          category: "Category"
-          partnership: "Partnership"
-          neighbourhood: "Neighbourhood"
-          apply: "Filter"
-          clear: "Clear"
-          all_categories: "All categories"
-          all_partnerships: "All partnerships"
-          all_neighbourhoods: "All neighbourhoods"
-          all_of: "All of %{name}"
+        description: "Browse %{count} community partners across the UK on PlaceCal. Search by name, category, partnership or neighbourhood."
+        hero_title: "All partners on PlaceCal"
+        hero_subtitle: "Every community group, venue, library and organisation publishing their events on PlaceCal, UK-wide."
+        kicker: "%{count} partners across %{partnerships} partnerships"
+        results:
+          filtered: "Showing %{shown} of %{total} partners"
+          total: "%{count} partners"
+          page: " — page %{page} of %{pages}"
+        sort:
+          recent: "Recently updated"
+          name: "A–Z"
+        empty: "No partners found matching your filters."
+        clear: "Clear filters"
       show:
         upcoming_events: "Upcoming events"
         location: "Location"
@@ -146,7 +231,6 @@ en:
         events_this_month:
           one: "%{count} event this month"
           other: "%{count} events this month"
-        map_coming_soon: "Map coming soon"
         get_involved: "Get involved"
         cta_text: "Running a community group%{area}? Join this partnership to list your events."
         cta_area: " in %{name}"

--- a/spec/i18n_keys_spec.rb
+++ b/spec/i18n_keys_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "i18n/tasks"
+
+# Guards against broken `t('...')` calls: every translation key referenced in
+# the codebase must exist in config/locales. Configuration (which files to read,
+# which dynamic keys to ignore) lives in config/i18n-tasks.yml.
+#
+# Unused keys are intentionally NOT asserted here. Several namespaces (notably
+# admin.*) are looked up through interpolated keys that static analysis cannot
+# follow, so a strict gate would produce false positives. Review them manually
+# with `bundle exec i18n-tasks unused`.
+RSpec.describe "I18n translations" do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+
+  it "does not have missing keys" do
+    expect(missing_keys).to be_empty,
+                            "#{missing_keys.leaves.count} i18n keys are missing.\n" \
+                            "Run `bundle exec i18n-tasks missing` to list them, or " \
+                            "`bundle exec i18n-tasks add-missing` to stub them out.\n\n" \
+                            "#{missing_keys}"
+  end
+end


### PR DESCRIPTION
Part of #3246 (directory front-end cleanup). Tackles the **Locales / i18n** section of the checklist, plus a couple of adjacent refactor/a11y items.

## What this does

Moves ~60 hardcoded user-facing strings out of the public directory views and components into `config/locales/en.yml`, following the existing `directory.*` convention established by the partnerships pages.

**Views:** `home`, `events/index`, `partners/index`, `join` — hero copy, section headings, stat/filter/sort labels, results headers, empty states, the Get in touch form, and `aria-label`s.

**Components:** `hero`, `custom_select`, `event_row`, `az_jump_bar`, `page_hero`, `paginator` — search placeholders, "All" labels, "Online", "Map coming soon", "Jump to:", and pagination/breadcrumb aria-labels.

## Refactors picked up along the way
- **Model names via `model_name.human`** — page titles/breadcrumbs and the home stats strip now derive "Events"/"Partners"/"Partnerships"/"Neighbourhoods" from `::Model.model_name.human` rather than literals (the `::` prefix avoids resolving to the Phlex `Components::*`).
- **Deduped filter chrome** — generic filter labels (search / filter / clear / field labels / "All …") were defined twice (partner filter *and* events filter). Consolidated into one shared `directory.filters` namespace. "Map coming soon" likewise deduped into `directory.map_coming_soon`.
- **Events period labels** were duplicated in a constant and an inline tab array; consolidated to read from a single locale block.

## New: i18n-tasks guard
Adds the `i18n-tasks` gem (`development, :test`), a `config/locales`-aware `config/i18n-tasks.yml`, and a guard spec (`spec/i18n_keys_spec.rb`) that **fails the build on any missing translation key** — protecting this work and catching future hardcoded-string regressions. The config documents ignores for keys resolved dynamically (the `og_image` scoped `t` helper, OurStory's interpolated keys, Rails/Devise runtime messages).

Unused-key checking is left to the CLI (`bundle exec i18n-tasks unused`) — it flags 38 pre-existing `admin.*` keys that are out of scope for this directory-focused PR.

## Verification
- `bundle exec i18n-tasks missing` → **0 missing**; no directory keys reported unused.
- Guard spec passes, and was confirmed to **fail** when a deliberately-missing key was introduced (then reverted).
- Request specs (events, partners, partnerships, joins, pages, directory_partners) + filter component specs + guard: **150 examples, 0 failures**. rubocop clean.
- No CSS/class changes; locale values are identical to the originals (modulo a couple of stray-trailing-space fixes), so rendered output is unchanged.