### PR TITLE
Directory separation of concerns: extract query objects (#3246)

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -83,7 +83,6 @@ class PagesController < ApplicationController
     end
   end
 
-  NEIGHBOURHOOD_UNIT_RANK = %w[ward district county region].freeze
   DIRECTORY_CACHE_TTL = 1.day
 
   # ONS GSS codes for the places featured as homepage "jump" links, in display
@@ -109,7 +108,9 @@ class PagesController < ApplicationController
     end
 
     @partner_locations = Rails.cache.fetch('directory/partner_locations', expires_in: DIRECTORY_CACHE_TTL) do
-      build_partner_locations
+      PartnerLocationsQuery.new.call.map do |location|
+        { lat: location[:lat], lon: location[:lon], name: location[:name], url: partner_path(location[:slug]) }
+      end
     end
 
     @jump_neighbourhoods = Rails.cache.fetch('directory/jump_neighbourhoods', expires_in: DIRECTORY_CACHE_TTL) do
@@ -132,12 +133,7 @@ class PagesController < ApplicationController
     end
 
     @partner_event_counts = Rails.cache.fetch('directory/partner_event_counts', expires_in: DIRECTORY_CACHE_TTL) do
-      ids = @recent_partners.map(&:id)
-      Event.future(Time.zone.today)
-           .where(place_id: ids)
-           .or(Event.future(Time.zone.today).where(organiser_id: ids))
-           .group(:place_id)
-           .count
+      EventsQuery.upcoming_counts_by_partner(@recent_partners.map(&:id))
     end
 
     render Views::Directory::Home.new(
@@ -156,47 +152,5 @@ class PagesController < ApplicationController
                          .where(unit_code_value: JUMP_NEIGHBOURHOOD_CODES)
                          .index_by(&:unit_code_value)
     JUMP_NEIGHBOURHOOD_CODES.filter_map { |code| found[code] }
-  end
-
-  def build_partner_locations
-    locations = Partner.visible.joins(:address)
-                       .where.not(addresses: { latitude: nil })
-                       .pluck(:name, :slug, 'addresses.latitude', 'addresses.longitude')
-                       .map { |name, slug, lat, lon| { lat: lat, lon: lon, name: name, url: partner_path(slug) } }
-
-    addressless = Partner.visible.where(address_id: nil).includes(service_areas: :neighbourhood)
-    return locations if addressless.none?
-
-    sa_nhood_ids = addressless.flat_map { |p| p.service_areas.map(&:neighbourhood_id) }.compact.uniq
-    centroid_cache = neighbourhood_centroids(sa_nhood_ids)
-
-    addressless.find_each do |p|
-      best = p.service_areas.filter_map(&:neighbourhood)
-              .select { |n| NEIGHBOURHOOD_UNIT_RANK.include?(n.unit) }
-              .min_by { |n| NEIGHBOURHOOD_UNIT_RANK.index(n.unit) }
-      next unless best
-
-      coords = centroid_cache[best.id]
-      next unless coords
-
-      locations << { lat: coords[0], lon: coords[1], name: p.name, url: partner_path(p.slug) }
-    end
-
-    locations
-  end
-
-  def neighbourhood_centroids(neighbourhood_ids)
-    cache = {}
-    Neighbourhood.where(id: neighbourhood_ids).find_each do |n|
-      addrs = Address.where(neighbourhood_id: n.id).where.not(latitude: nil)
-      unless addrs.exists?
-        desc_ids = n.descendant_ids
-        addrs = Address.where(neighbourhood_id: desc_ids).where.not(latitude: nil) if desc_ids.any?
-      end
-      next unless addrs.exists?
-
-      cache[n.id] = [addrs.average(:latitude).to_f, addrs.average(:longitude).to_f]
-    end
-    cache
   end
 end

--- a/app/controllers/partnerships_controller.rb
+++ b/app/controllers/partnerships_controller.rb
@@ -5,11 +5,13 @@ class PartnershipsController < ApplicationController
   before_action :set_site
 
   def index
-    @partnerships = Site.where(is_published: true)
-                        .order(partners_count: :desc)
-    @total_partners = Partner.visible.count
-
-    render Views::Directory::Partnerships::Index.new(partnerships: @partnerships, site: @site, query: params[:q], total_partners: @total_partners)
+    render Views::Directory::Partnerships::Index.new(
+      partnerships: PartnershipsQuery.new.call(query: params[:q]),
+      site: @site,
+      query: params[:q],
+      partnership_count: Site.published.count,
+      total_partners: Partner.visible.count
+    )
   end
 
   def show
@@ -17,13 +19,7 @@ class PartnershipsController < ApplicationController
     @partners = PartnersQuery.new(site: @partnership).call
     @upcoming_events = EventsQuery.new(site: @partnership).call(period: 'future')
 
-    partner_ids = Array(@partners.respond_to?(:each_pair) ? @partners.values.flatten : @partners).map(&:id)
-    @partner_event_counts = Event.future(Time.current)
-                                 .where(place_id: partner_ids)
-                                 .or(Event.future(Time.current).where(organiser_id: partner_ids))
-                                 .group(:place_id)
-                                 .count
-
+    flat_partners = Array(@partners.respond_to?(:each_pair) ? @partners.values.flatten : @partners)
     @event_count = EventsQuery.new(site: @partnership).scope
                               .where(dtstart: Time.zone.today..30.days.from_now)
                               .count
@@ -32,9 +28,21 @@ class PartnershipsController < ApplicationController
       partnership: @partnership,
       partners: @partners,
       upcoming_events: @upcoming_events,
-      partner_event_counts: @partner_event_counts,
+      partner_event_counts: EventsQuery.upcoming_counts_by_partner(flat_partners.map(&:id)),
+      partner_locations: partner_map_locations(flat_partners),
       event_count: @event_count,
       site: @site
     )
+  end
+
+  private
+
+  # Map markers for the partnership's partners that have geocoded addresses.
+  def partner_map_locations(partners)
+    partners.filter_map do |partner|
+      next unless partner.address&.latitude
+
+      { lat: partner.address.latitude, lon: partner.address.longitude, name: partner.name, url: partner_path(partner) }
+    end
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -96,6 +96,19 @@ class Site < ApplicationRecord
     "#{id}: #{name}"
   end
 
+  # The site's public URL, falling back to its conventional placecal.org
+  # subdomain when no explicit url is set.
+  #
+  # @return [String]
+  def directory_url
+    url.presence || "https://#{slug}.placecal.org"
+  end
+
+  # @return [String] directory_url without the scheme or trailing slash, for display
+  def display_url
+    directory_url.sub(%r{\Ahttps?://}, '').chomp('/')
+  end
+
   # @return [Boolean] whether FriendlyId should generate a new slug
   # Regenerates from the name whenever the slug is blank (e.g. left empty on
   # the new-site form), mirroring Partner so the slug auto-populates on create.

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -23,6 +23,21 @@ class EventsQuery
   UPCOMING_LIMIT = 10
   WEEKLY_DENSITY_THRESHOLD = 10
 
+  # Upcoming-event counts keyed by partner id, counting events a partner either
+  # hosts (place) or organises. Used to badge partner rows/cards in the directory.
+  #
+  # @param partner_ids [Array<Integer>] partners to count events for
+  # @return [Hash{Integer=>Integer}] partner id => upcoming event count
+  def self.upcoming_counts_by_partner(partner_ids)
+    return {} if partner_ids.blank?
+
+    future = Event.future(Time.current)
+    future.where(place_id: partner_ids)
+          .or(future.where(organiser_id: partner_ids))
+          .group(:place_id)
+          .count
+  end
+
   def initialize(site:, day: Time.zone.today)
     @site = site
     @day = day

--- a/app/queries/partner_locations_query.rb
+++ b/app/queries/partner_locations_query.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Builds the marker data for the directory's nationwide partner map.
+#
+# Partners with a geocoded address are plotted at their own coordinates.
+# Address-less partners are plotted at the centroid of their most specific
+# service-area neighbourhood (falling back to that neighbourhood's descendants),
+# so service-only partners still appear on the map.
+#
+# Returns plain hashes with a partner +slug+ rather than a URL — building the
+# route belongs to the controller/view layer, not the query.
+#
+# @example
+#   PartnerLocationsQuery.new.call
+#   # => [{ lat: 53.4, lon: -2.2, name: "Some Partner", slug: "some-partner" }, ...]
+#
+class PartnerLocationsQuery
+  # Service-area neighbourhood units from most to least specific. A partner is
+  # placed at its smallest available unit.
+  NEIGHBOURHOOD_UNIT_RANK = %w[ward district county region].freeze
+
+  # @return [Array<Hash>] { lat:, lon:, name:, slug: } for each mappable partner
+  def call
+    located_partners + service_area_partners
+  end
+
+  private
+
+  def located_partners
+    Partner.visible.joins(:address)
+           .where.not(addresses: { latitude: nil })
+           .pluck(:name, :slug, 'addresses.latitude', 'addresses.longitude')
+           .map { |name, slug, lat, lon| { lat: lat, lon: lon, name: name, slug: slug } }
+  end
+
+  def service_area_partners
+    addressless = Partner.visible.where(address_id: nil).includes(service_areas: :neighbourhood)
+    return [] if addressless.none?
+
+    centroids = neighbourhood_centroids(service_area_neighbourhood_ids(addressless))
+
+    addressless.filter_map do |partner|
+      neighbourhood = best_service_area_neighbourhood(partner)
+      next unless neighbourhood
+
+      coords = centroids[neighbourhood.id]
+      next unless coords
+
+      { lat: coords[0], lon: coords[1], name: partner.name, slug: partner.slug }
+    end
+  end
+
+  def service_area_neighbourhood_ids(partners)
+    partners.flat_map { |p| p.service_areas.map(&:neighbourhood_id) }.compact.uniq
+  end
+
+  # The most specific service-area neighbourhood we know how to place.
+  def best_service_area_neighbourhood(partner)
+    partner.service_areas.filter_map(&:neighbourhood)
+           .select { |n| NEIGHBOURHOOD_UNIT_RANK.include?(n.unit) }
+           .min_by { |n| NEIGHBOURHOOD_UNIT_RANK.index(n.unit) }
+  end
+
+  # Average address coordinates per neighbourhood, falling back to descendant
+  # neighbourhoods when a neighbourhood has no addresses of its own.
+  def neighbourhood_centroids(neighbourhood_ids)
+    cache = {}
+    Neighbourhood.where(id: neighbourhood_ids).find_each do |n|
+      addrs = Address.where(neighbourhood_id: n.id).where.not(latitude: nil)
+      unless addrs.exists?
+        desc_ids = n.descendant_ids
+        addrs = Address.where(neighbourhood_id: desc_ids).where.not(latitude: nil) if desc_ids.any?
+      end
+      next unless addrs.exists?
+
+      cache[n.id] = [addrs.average(:latitude).to_f, addrs.average(:longitude).to_f]
+    end
+    cache
+  end
+end

--- a/app/queries/partnerships_query.rb
+++ b/app/queries/partnerships_query.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Query object for the directory partnerships index.
+#
+# Partnerships are published Sites, ordered by partner count, optionally
+# filtered by a keyword search over name and description.
+#
+# @example
+#   PartnershipsQuery.new.call(query: "manchester")
+#
+class PartnershipsQuery
+  # @param query [String] keyword search on name/description
+  # @return [ActiveRecord::Relation<Site>]
+  def call(query: nil)
+    partnerships = Site.published.order(partners_count: :desc)
+    partnerships = filter_by_query(partnerships, query) if query.present?
+    partnerships
+  end
+
+  private
+
+  def filter_by_query(partnerships, query)
+    partnerships.where('sites.name ILIKE :q OR sites.description ILIKE :q', q: "%#{query}%")
+  end
+end

--- a/app/views/directory/partnerships/index.rb
+++ b/app/views/directory/partnerships/index.rb
@@ -4,15 +4,16 @@ class Views::Directory::Partnerships::Index < Views::Base
   prop :partnerships, _Interface(:each)
   prop :site, _Nilable(::Site), default: nil
   prop :query, _Nilable(String), default: nil
+  prop :partnership_count, Integer, default: 0
   prop :total_partners, Integer, default: 0
 
   def view_template
     content_for(:title) { Partnership.model_name.human(count: 2) }
-    content_for(:description) { "Explore #{partnership_list.size} partnerships serving #{@total_partners} partners on PlaceCal." }
+    content_for(:description) { "Explore #{@partnership_count} partnerships serving #{@total_partners} partners on PlaceCal." }
 
     Directory::PageHero(
       title: t('directory.partnerships.index.hero_title'),
-      kicker: t('directory.partnerships.index.hero_kicker', count: partnership_list.size, partners: @total_partners),
+      kicker: t('directory.partnerships.index.hero_kicker', count: @partnership_count, partners: @total_partners),
       subtitle: t('directory.partnerships.index.hero_subtitle'),
       breadcrumb_label: Partnership.model_name.human(count: 2)
     )
@@ -20,11 +21,11 @@ class Views::Directory::Partnerships::Index < Views::Base
     div(class: 'container-public py-6') do
       render_search
       div(class: 'lg:columns-2 gap-x-4') do
-        filtered_partnerships.each do |partnership|
+        partnership_list.each do |partnership|
           Directory::PartnershipCard(partnership: partnership)
         end
       end
-      render_empty_state if filtered_partnerships.empty?
+      render_empty_state if partnership_list.empty?
     end
   end
 
@@ -63,14 +64,5 @@ class Views::Directory::Partnerships::Index < Views::Base
 
   def partnership_list
     @partnership_list ||= Array(@partnerships)
-  end
-
-  def filtered_partnerships
-    @filtered_partnerships ||= if @query.present?
-                                 q = @query.downcase
-                                 partnership_list.select { |p| p.name.downcase.include?(q) || p.description&.downcase&.include?(q) }
-                               else
-                                 partnership_list
-                               end
   end
 end

--- a/app/views/directory/partnerships/show.rb
+++ b/app/views/directory/partnerships/show.rb
@@ -7,6 +7,7 @@ class Views::Directory::Partnerships::Show < Views::Base
   prop :partners, _Interface(:each)
   prop :upcoming_events, _Interface(:each)
   prop :partner_event_counts, Hash, default: -> { {} }
+  prop :partner_locations, _Interface(:each), default: -> { [] }
   prop :event_count, Integer, default: 0
   prop :site, _Nilable(::Site), default: nil
 
@@ -46,12 +47,10 @@ class Views::Directory::Partnerships::Show < Views::Base
   private
 
   def render_visit_button
-    href = @partnership.url.presence || "https://#{@partnership.slug}.placecal.org"
-    display_url = href.sub(%r{\Ahttps?://}, '').chomp('/')
-    a(href: href,
+    a(href: @partnership.directory_url,
       class: 'inline-flex items-center gap-2 bg-primary text-foreground font-bold rounded-full px-5 py-2 no-underline hover:brightness-110 transition-all') do
       raw(view_context.icon(:external_link, size: nil, css_class: 'w-4 h-4'))
-      plain t('directory.partnerships.show.visit', url: display_url)
+      plain t('directory.partnerships.show.visit', url: @partnership.display_url)
     end
   end
 
@@ -134,18 +133,12 @@ class Views::Directory::Partnerships::Show < Views::Base
 
   def render_map_card
     div(class: 'rounded-card overflow-hidden bg-home-background-3') do
-      partner_locations = partner_list.filter_map do |p|
-        next unless p.address&.latitude
-
-        { lat: p.address.latitude, lon: p.address.longitude, name: p.name, url: partner_path(p) }
-      end
-
-      if partner_locations.any?
+      if @partner_locations.any?
         div(
           class: 'h-(--height-map-lg)',
           data: {
             controller: 'cluster-map',
-            cluster_map_markers_value: partner_locations.to_json,
+            cluster_map_markers_value: @partner_locations.to_json,
             cluster_map_style_url_value: '/map-styles/pink.json'
           }
         )
@@ -190,7 +183,7 @@ class Views::Directory::Partnerships::Show < Views::Base
   end
 
   def partnership_base_url
-    @partnership_base_url ||= @partnership.url.presence || "https://#{@partnership.slug}.placecal.org"
+    @partnership.directory_url
   end
 
   def partner_list

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -75,6 +75,25 @@ RSpec.describe Site, type: :model do
     end
   end
 
+  describe "#directory_url" do
+    it "returns the url when present" do
+      site = build(:site, url: "https://example.org")
+      expect(site.directory_url).to eq("https://example.org")
+    end
+
+    it "falls back to the placecal.org subdomain when the url is blank" do
+      site = build(:site, slug: "manchester", url: "")
+      expect(site.directory_url).to eq("https://manchester.placecal.org")
+    end
+  end
+
+  describe "#display_url" do
+    it "strips the scheme and trailing slash" do
+      site = build(:site, url: "https://example.org/")
+      expect(site.display_url).to eq("example.org")
+    end
+  end
+
   describe "#owned_neighbourhood_ids" do
     let(:site) { create(:site) }
     let(:ward) { create(:riverside_ward) }

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -663,4 +663,24 @@ RSpec.describe EventsQuery do
       end
     end
   end
+
+  describe ".upcoming_counts_by_partner" do
+    it "returns an empty hash for blank ids" do
+      expect(described_class.upcoming_counts_by_partner([])).to eq({})
+    end
+
+    it "counts upcoming events hosted at the partner" do
+      partner = create(:partner)
+      create(:future_event, place: partner)
+
+      expect(described_class.upcoming_counts_by_partner([partner.id])).to eq(partner.id => 1)
+    end
+
+    it "excludes past events" do
+      partner = create(:partner)
+      create(:past_event, place: partner)
+
+      expect(described_class.upcoming_counts_by_partner([partner.id])).to eq({})
+    end
+  end
 end

--- a/spec/queries/partner_locations_query_spec.rb
+++ b/spec/queries/partner_locations_query_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PartnerLocationsQuery do
+  describe "#call" do
+    # The service-area centroid fallback (for address-less partners) is exercised
+    # end-to-end by the directory home request spec, which renders this query.
+    it "includes visible partners with geocoded addresses" do
+      partner = create(:partner)
+
+      entry = described_class.new.call.find { |l| l[:slug] == partner.slug }
+
+      expect(entry).to include(
+        name: partner.name,
+        lat: partner.address.latitude,
+        lon: partner.address.longitude
+      )
+    end
+
+    it "excludes hidden partners" do
+      partner = create(:partner, hidden: true, hidden_reason: "Test", hidden_blame_id: 1)
+
+      slugs = described_class.new.call.map { |l| l[:slug] }
+      expect(slugs).not_to include(partner.slug)
+    end
+
+    it "excludes partners whose address has no coordinates" do
+      partner = create(:partner)
+      partner.address.update!(latitude: nil, longitude: nil)
+
+      slugs = described_class.new.call.map { |l| l[:slug] }
+      expect(slugs).not_to include(partner.slug)
+    end
+  end
+end

--- a/spec/queries/partnerships_query_spec.rb
+++ b/spec/queries/partnerships_query_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PartnershipsQuery do
+  describe "#call" do
+    it "returns only published sites" do
+      published = create(:site, is_published: true)
+      create(:site, is_published: false)
+
+      expect(described_class.new.call).to contain_exactly(published)
+    end
+
+    it "orders by partner count, most partners first" do
+      few = create(:site, is_published: true, partners_count: 1)
+      many = create(:site, is_published: true, partners_count: 9)
+
+      expect(described_class.new.call.to_a).to eq([many, few])
+    end
+
+    context "with a search query" do
+      it "matches on name" do
+        match = create(:site, is_published: true, name: "Manchester Calendar")
+        create(:site, is_published: true, name: "Leeds Calendar")
+
+        expect(described_class.new.call(query: "manchester")).to contain_exactly(match)
+      end
+
+      it "matches on description" do
+        match = create(:site, is_published: true, description: "Covers the whole of Yorkshire")
+        create(:site, is_published: true, description: "Somewhere else entirely")
+
+        expect(described_class.new.call(query: "yorkshire")).to contain_exactly(match)
+      end
+
+      it "ignores a blank query" do
+        site = create(:site, is_published: true)
+
+        expect(described_class.new.call(query: "")).to contain_exactly(site)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of #3246 (directory front-end cleanup) — the **Separation of concerns** section. Moves data/query logic out of the Phlex views and controllers into query objects and model methods. Behaviour-preserving.

## Changes

- **`PartnerLocationsQuery`** — extracts the ~40-line partner-map marker building (geocoded addresses + the service-area neighbourhood-centroid fallback) out of `PagesController`. Returns plain data keyed by partner `slug`; the controller builds the route (routing stays in the controller layer).
- **`PartnershipsQuery`** — the partnerships index search now filters in **SQL** via a query object instead of an in-memory `select` in the view. The view drops `filtered_partnerships`; the hero kicker/description take a `partnership_count` prop so they still show the *total*, not the filtered count.
- **`EventsQuery.upcoming_counts_by_partner`** — shared class method replacing the identical upcoming-event-count aggregation that was duplicated in `PagesController` and `PartnershipsController`.
- **`Site#directory_url` / `#display_url`** — model methods replacing the `url`-or-slug-fallback + display-stripping logic duplicated in `partnerships/show`.
- **Partnership map markers** are built in `PartnershipsController` and passed to the view as a prop, instead of being assembled inside `render_map_card`.

## Scope notes
This is the first of the 1–3 cleanup split — **separation of concerns only**. Shared components / Tailwind extraction / `raw()` cleanup (sections 2–3 of the audit) will follow in a separate PR.

Deliberately left for now (out of this PR's scope): the legacy *homepage* `Site.published.select { … Partnership tag }` filtering (not directory code), the `FlattensEvents` concern, and the A–Z grouping (borderline-presentational).

## Verification
- New specs for both query objects, the new `EventsQuery` method, and the `Site` URL helpers (90 examples in the touched query/model specs, 0 failures).
- Request specs across pages/partnerships/partners/events/joins/sites + the i18n guard: **128 examples, 0 failures**. rubocop clean.
- No template/markup output changes — purely where the logic lives.