### PR TITLE
Directory: extract EmptyState & ToggleTabs components (#3246)

### DIFF
--- a/app/components/directory/empty_state.rb
+++ b/app/components/directory/empty_state.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Centered "nothing here" message shown when a directory listing or filter
+# returns no results, with an optional reset/clear link.
+class Components::Directory::EmptyState < Components::Directory::Base
+  prop :message, String
+  prop :link_text, _Nilable(String), default: nil
+  prop :link_href, _Nilable(String), default: nil
+
+  def view_template
+    div(class: 'py-10 text-center') do
+      p(class: 'text-tertiary text-lg') { @message }
+      render_link if @link_text && @link_href
+    end
+  end
+
+  private
+
+  def render_link
+    a(href: @link_href,
+      class: 'inline-flex items-center gap-2 mt-3 text-foreground font-bold no-underline hover:underline') do
+      plain @link_text
+    end
+  end
+end

--- a/app/components/directory/toggle_tabs.rb
+++ b/app/components/directory/toggle_tabs.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# A row of pill toggles (e.g. the events period filter, the partners sort
+# order). The selected tab renders as a static pill; the rest are links.
+#
+# @param items [Array<Hash>] each { label:, href:, active: }
+# @param aria_label [String] accessible label for the nav landmark
+class Components::Directory::ToggleTabs < Components::Directory::Base
+  prop :items, _Interface(:each)
+  prop :aria_label, String
+
+  def view_template
+    nav(class: 'flex gap-1 flex-wrap py-2', aria_label: @aria_label) do
+      @items.each do |item|
+        if item[:active]
+          span(class: active_class) { plain item[:label] }
+        else
+          a(href: item[:href], class: inactive_class) { plain item[:label] }
+        end
+      end
+    end
+  end
+
+  private
+
+  def active_class
+    'inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold bg-foreground text-background'
+  end
+
+  def inactive_class
+    'inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold bg-home-background-3 ' \
+      'text-foreground no-underline hover:bg-primary transition-colors'
+  end
+end

--- a/app/views/directory/events/index.rb
+++ b/app/views/directory/events/index.rb
@@ -102,20 +102,14 @@ class Views::Directory::Events::Index < Views::Base
   end
 
   def render_period_tabs
-    nav(class: 'flex gap-1 flex-wrap py-2', aria_label: t('directory.aria.time_period')) do
-      TAB_PERIODS.each do |value|
-        label = period_option_label(value)
-        params = current_filter_params.merge('period' => value)
-        if @period == value
-          span(class: 'inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold bg-foreground text-background') { label }
-        else
-          a(href: "#{events_path}?#{params.to_query}",
-            class: 'inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold bg-home-background-3 text-foreground no-underline hover:bg-primary transition-colors') do
-            plain label
-          end
-        end
-      end
+    items = TAB_PERIODS.map do |value|
+      {
+        label: period_option_label(value),
+        href: "#{events_path}?#{current_filter_params.merge('period' => value).to_query}",
+        active: @period == value
+      }
     end
+    Directory::ToggleTabs(items: items, aria_label: t('directory.aria.time_period'))
   end
 
   def render_results_header
@@ -153,15 +147,12 @@ class Views::Directory::Events::Index < Views::Base
   end
 
   def render_empty_state
-    div(class: 'py-10 text-center') do
-      p(class: 'text-tertiary text-lg mb-4') { t('directory.events.index.empty', period: period_phrase) }
-      unless @period == 'future'
-        a(href: "#{events_path}?period=future",
-          class: 'inline-flex items-center gap-2 text-foreground font-bold no-underline hover:underline') do
-          plain t('directory.events.index.show_all')
-        end
-      end
-    end
+    show_all = @period != 'future'
+    Directory::EmptyState(
+      message: t('directory.events.index.empty', period: period_phrase),
+      link_text: (t('directory.events.index.show_all') if show_all),
+      link_href: ("#{events_path}?period=future" if show_all)
+    )
   end
 
   def flat_events

--- a/app/views/directory/partners/index.rb
+++ b/app/views/directory/partners/index.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Views::Directory::Partners::Index < Views::Base
+  SORT_OPTIONS = %w[recent name].freeze
+
   prop :partners, _Interface(:each)
   prop :pagy, _Nilable(Pagy::Offset), default: nil
   prop :site, _Nilable(::Site)
@@ -68,19 +70,14 @@ class Views::Directory::Partners::Index < Views::Base
   end
 
   def render_sort_tabs
-    nav(class: 'flex gap-1 flex-wrap py-2', aria_label: t('directory.aria.sort_order')) do
-      [[t('directory.partners.index.sort.recent'), 'recent'], [t('directory.partners.index.sort.name'), 'name']].each do |label, value|
-        sort_params = current_filter_params.merge('sort' => value)
-        if @sort == value
-          span(class: 'inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold bg-foreground text-background') { label }
-        else
-          a(href: "#{partners_path}?#{sort_params.to_query}",
-            class: 'inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold bg-home-background-3 text-foreground no-underline hover:bg-primary transition-colors') do
-            plain label
-          end
-        end
-      end
+    items = SORT_OPTIONS.map do |value|
+      {
+        label: t("directory.partners.index.sort.#{value}"),
+        href: "#{partners_path}?#{current_filter_params.merge('sort' => value).to_query}",
+        active: @sort == value
+      }
     end
+    Directory::ToggleTabs(items: items, aria_label: t('directory.aria.sort_order'))
   end
 
   def render_partner_list
@@ -94,12 +91,11 @@ class Views::Directory::Partners::Index < Views::Base
 
     return unless partner_list.none?
 
-    div(class: 'py-10 text-center') do
-      p(class: 'text-tertiary text-lg') { t('directory.partners.index.empty') }
-      a(href: partners_path, class: 'inline-flex items-center gap-2 mt-3 text-foreground font-bold no-underline hover:underline') do
-        plain t('directory.partners.index.clear')
-      end
-    end
+    Directory::EmptyState(
+      message: t('directory.partners.index.empty'),
+      link_text: t('directory.partners.index.clear'),
+      link_href: partners_path
+    )
   end
 
   def partner_list

--- a/app/views/directory/partnerships/index.rb
+++ b/app/views/directory/partnerships/index.rb
@@ -52,14 +52,11 @@ class Views::Directory::Partnerships::Index < Views::Base
   end
 
   def render_empty_state
-    div(class: 'py-10 text-center') do
-      p(class: 'text-tertiary text-lg') { t('directory.partnerships.index.empty') }
-      if @query.present?
-        a(href: partnerships_path, class: 'inline-flex items-center gap-2 mt-3 text-foreground font-bold no-underline hover:underline') do
-          plain t('directory.partnerships.index.clear_search')
-        end
-      end
-    end
+    Directory::EmptyState(
+      message: t('directory.partnerships.index.empty'),
+      link_text: (t('directory.partnerships.index.clear_search') if @query.present?),
+      link_href: (partnerships_path if @query.present?)
+    )
   end
 
   def partnership_list

--- a/spec/components/directory/empty_state_component_spec.rb
+++ b/spec/components/directory/empty_state_component_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Directory::EmptyState, type: :component do
+  it "renders the message" do
+    render_inline(described_class.new(message: "No partners found"))
+
+    expect(page).to have_css("p", text: "No partners found")
+  end
+
+  it "renders a reset link when given both text and href" do
+    render_inline(described_class.new(message: "No partners found", link_text: "Clear filters", link_href: "/partners"))
+
+    expect(page).to have_link("Clear filters", href: "/partners")
+  end
+
+  it "omits the link when href is missing" do
+    render_inline(described_class.new(message: "No partners found", link_text: "Clear filters"))
+
+    expect(page).to have_no_link
+  end
+end

--- a/spec/components/directory/toggle_tabs_component_spec.rb
+++ b/spec/components/directory/toggle_tabs_component_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Directory::ToggleTabs, type: :component do
+  let(:items) do
+    [
+      { label: "This week", href: "/events?period=week", active: true },
+      { label: "Today", href: "/events?period=day", active: false }
+    ]
+  end
+
+  it "renders the active item as a static pill, not a link" do
+    render_inline(described_class.new(items: items, aria_label: "Time period"))
+
+    expect(page).to have_css("span", text: "This week")
+    expect(page).to have_no_link("This week")
+  end
+
+  it "renders inactive items as links" do
+    render_inline(described_class.new(items: items, aria_label: "Time period"))
+
+    expect(page).to have_link("Today", href: "/events?period=day")
+  end
+
+  it "labels the nav landmark" do
+    render_inline(described_class.new(items: items, aria_label: "Time period"))
+
+    expect(page).to have_css("nav[aria-label='Time period']")
+  end
+end


### PR DESCRIPTION
Part of #3246 (directory front-end cleanup) — the **Refactors → repeated markup → shared components** item.

> **Stacked on #3273** (separation of concerns). Review/merge that first; this branch is based on it and its base will retarget to `main` once #3273 lands.

## Changes
Two repeated markup blocks become shared Phlex components, with **no change to the rendered markup** (identical class strings, just relocated):

- **`Directory::EmptyState`** — the centered "no results" message + optional reset link, previously duplicated across the partners, partnerships and events index views.
- **`Directory::ToggleTabs`** — the pill toggle row (active `span` + inactive links), previously duplicated as the events period tabs and the partners sort tabs. Each view now builds a small `{label, href, active}` items array and hands it to the component.

Component specs added for both.

## Deliberately NOT here (follow-up)
The other two items from the audit — **Tailwind class extraction** and the **inline-SVG → icon** cleanup — are held back on purpose:
- The public CSS output (`app/assets/builds/public_tailwind.css`) is a committed, gitignored, minified build artifact; extracting classes into `_components.css` needs a rebuild of it (and interacts with the prettier pre-commit hook).
- The 3 inline SVGs (search ×2, chevron) would swap to the design-system icon helper, which uses different glyph paths — a visual change that warrants a Chrome pass.

Both will land in a follow-up PR with a CSS rebuild + visual verification.

## Verification
- New component specs + request specs across events/partners/partnerships/pages: **119 examples, 0 failures**. rubocop clean.
- Markup output is byte-identical, so no CSS rebuild or visual check is needed for this PR.