### PR TITLE
Fix flaky directory neighbourhood-cascade filter spec

### DIFF
--- a/app/javascript/controllers/custom_select_controller.js
+++ b/app/javascript/controllers/custom_select_controller.js
@@ -9,11 +9,16 @@ export default class extends Controller {
 		this.keydownHandler = this.handleKeydown.bind(this);
 		document.addEventListener("click", this.outsideClickHandler);
 		document.addEventListener("keydown", this.keydownHandler);
+		// Signal readiness so system specs can wait for connect() before
+		// clicking the trigger. The toggle action is silently dropped if the
+		// trigger is clicked before JS boots (notably in CI).
+		this.element.dataset.customSelectConnected = "true";
 	}
 
 	disconnect() {
 		document.removeEventListener("click", this.outsideClickHandler);
 		document.removeEventListener("keydown", this.keydownHandler);
+		delete this.element.dataset.customSelectConnected;
 	}
 
 	toggle(event) {

--- a/spec/system/directory/partner_filtering_spec.rb
+++ b/spec/system/directory/partner_filtering_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe "Directory partner filtering", :slow, type: :system do
     expect(page).to have_content("Southern Partner")
 
     within("[data-controller='neighbourhood-cascade']") do
+      # Wait for the custom-select controller to connect; clicking the trigger
+      # before connect() leaves the toggle a no-op and the panel never opens.
+      expect(page).to have_css("[data-custom-select-connected]")
       find("[data-custom-select-target='trigger']").click
       click_button("Northvale (1)")
     end


### PR DESCRIPTION
## What & why

`main` was red on CI: the `spec/system/directory/partner_filtering_spec.rb` system spec intermittently failed with `Capybara::ElementNotFound: Unable to find visible button "Northvale (1)"`.

**Root cause — a JS-timing race, not a code regression.** The spec opened the directory's custom-select dropdown with a single, non-retrying click:

```ruby
find("[data-custom-select-target='trigger']").click
click_button("Northvale (1)")
```

If the `custom-select` Stimulus controller hadn't `connect()`ed yet — common in CI where JS boots slower — the `toggle` action was silently dropped, the panel stayed `display:none`, and the follow-up `click_button` timed out waiting for an option that never appeared. (The page itself rendered fine; the earlier `have_content` assertions passed.) The spec passes reliably locally once assets are built, confirming it's flakiness rather than a deterministic break.

## Fix

Apply the readiness pattern already established in this codebase for exactly this class of flake (see `spec/support/tab_helpers.rb`, introduced by the recent save-bar flaky-spec fix): the controller signals connection via a data attribute, and the spec waits for it before interacting.

- `app/javascript/controllers/custom_select_controller.js` — set `data-custom-select-connected="true"` in `connect()`, remove it in `disconnect()`.
- `spec/system/directory/partner_filtering_spec.rb` — `expect(page).to have_css("[data-custom-select-connected]")` before clicking the trigger.

## Verification

- Spec passes 3/3 locally after the change (and the pre-existing behaviour is unchanged).
- `prettier --check` and `rubocop` both clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)