### PR TITLE
Directory: OverflowToggle, Tailwind extraction, partner-list N+1 (#3246)

### DIFF
--- a/app/components/directory/overflow_toggle.rb
+++ b/app/components/directory/overflow_toggle.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Progressive "show more" disclosure: renders the items in batches, each batch
+# behind a <details> whose summary reveals the next batch (and, recursively,
+# another toggle for the batch after that). Each item is rendered by the block
+# passed to the component.
+#
+# @example
+#   Directory::OverflowToggle(items: extra_events, label_key: "directory.partners.show.show_more_events") do |event|
+#     Directory::EventRow(event: event)
+#   end
+class Components::Directory::OverflowToggle < Components::Directory::Base
+  prop :items, _Interface(:each)
+  # i18n key for the summary label; receives a `count:` interpolation.
+  prop :label_key, String
+  prop :batch_size, Integer, default: 10
+
+  def view_template(&block)
+    @render_item = block
+    render_batch(@items.to_a)
+  end
+
+  private
+
+  def render_batch(remaining)
+    return if remaining.empty?
+
+    batch = remaining.first(@batch_size)
+    details(class: 'group') do
+      summary(class: 'list-none pt-3 border-t border-rules cursor-pointer [&::-webkit-details-marker]:hidden') do
+        span(class: 'inline-flex items-center gap-1.5 text-sm font-bold text-foreground group-open:hidden') do
+          plain t(@label_key, count: [@batch_size, remaining.size].min)
+          span(class: 'text-tertiary') { safe('&#9660;') }
+        end
+      end
+      batch.each { |item| @render_item.call(item) }
+      render_batch(remaining.drop(@batch_size))
+    end
+  end
+end

--- a/app/components/directory/partner_card.rb
+++ b/app/components/directory/partner_card.rb
@@ -29,7 +29,7 @@ class Components::Directory::PartnerCard < Components::Directory::Base
 
     div(class: 'flex flex-wrap gap-1 mt-2.5') do
       chips.each do |label|
-        span(class: 'inline-flex items-center bg-home-background-3 text-tertiary text-2xs font-bold rounded-full px-2 py-0.5') do
+        span(class: 'badge badge--tight bg-home-background-3 text-tertiary') do
           plain label
         end
       end

--- a/app/components/directory/partner_card.rb
+++ b/app/components/directory/partner_card.rb
@@ -3,6 +3,9 @@
 class Components::Directory::PartnerCard < Components::Directory::Base
   prop :partner, ::Partner
   prop :site, _Nilable(::Site)
+  # Neighbourhood breadcrumb, precomputed by PartnersQuery.area_labels so the
+  # card doesn't walk the neighbourhood ancestry itself (avoids an N+1 in lists).
+  prop :area, _Nilable(String), default: nil
 
   def view_template
     a(href: partner_path(@partner),
@@ -17,7 +20,7 @@ class Components::Directory::PartnerCard < Components::Directory::Base
   def render_info
     div do
       div(class: 'font-bold text-xl leading-tight border-b-[3px] border-rules group-hover:border-tertiary/20 pb-1.5 mb-1.5') { @partner.name }
-      div(class: 'text-sm text-tertiary font-bold mb-0.5') { area_text } if area_text.present?
+      div(class: 'text-sm text-tertiary font-bold mb-0.5') { @area } if @area.present?
       div(class: 'text-foreground leading-snug mt-1 line-clamp-2') { @partner.summary.truncate(120) } if @partner.summary.present?
       render_chips
     end
@@ -34,13 +37,5 @@ class Components::Directory::PartnerCard < Components::Directory::Base
         end
       end
     end
-  end
-
-  def area_text
-    return @area_text if defined?(@area_text)
-
-    hood = @partner.address&.neighbourhood
-    hood ||= @partner.service_area_neighbourhoods.first if @partner.has_service_areas?
-    @area_text = hood && hood.hierarchy_path.last(3).map(&:shortname).join(' › ')
   end
 end

--- a/app/components/directory/partner_mini.rb
+++ b/app/components/directory/partner_mini.rb
@@ -25,7 +25,7 @@ class Components::Directory::PartnerMini < Components::Directory::Base
   def render_event_badge
     return unless @event_count.positive?
 
-    span(class: 'inline-flex items-center bg-primary text-foreground text-2xs font-bold rounded-full px-2 py-0.5 whitespace-nowrap shrink-0') do
+    span(class: 'badge badge--tight bg-primary text-foreground whitespace-nowrap shrink-0') do
       plain "#{@event_count} #{'event'.pluralize(@event_count)}"
     end
   end
@@ -36,7 +36,7 @@ class Components::Directory::PartnerMini < Components::Directory::Base
 
     div(class: 'flex flex-wrap gap-1 mt-1.5') do
       chips.each do |label|
-        span(class: 'inline-flex items-center bg-home-background-3 text-tertiary text-2xs font-bold rounded-full px-2 py-0.5') do
+        span(class: 'badge badge--tight bg-home-background-3 text-tertiary') do
           plain label
         end
       end

--- a/app/components/directory/partner_row.rb
+++ b/app/components/directory/partner_row.rb
@@ -39,7 +39,7 @@ class Components::Directory::PartnerRow < Components::Directory::Base
     return unless @event_count.positive?
 
     div(class: 'text-right') do
-      span(class: 'inline-flex items-center bg-primary-light text-foreground text-2xs font-bold rounded-full px-2.5 py-0.5') do
+      span(class: 'badge bg-primary-light text-foreground') do
         plain "#{@event_count} #{'event'.pluralize(@event_count)}"
       end
     end

--- a/app/components/directory/partnership_card.rb
+++ b/app/components/directory/partnership_card.rb
@@ -30,12 +30,12 @@ class Components::Directory::PartnershipCard < Components::Directory::Base
     div(class: 'bg-home-background-3 px-5 py-4 flex-1') do
       div(class: 'flex flex-wrap gap-1.5 mb-2') do
         if @partnership.primary_neighbourhood
-          span(class: 'inline-flex items-center gap-1 bg-rules-dark text-foreground text-2xs font-bold rounded-full px-2.5 py-0.5') do
+          span(class: 'badge gap-1 bg-rules-dark text-foreground') do
             raw(view_context.icon(:neighbourhood, size: nil, css_class: 'w-3 h-3'))
             plain @partnership.primary_neighbourhood.name
           end
         end
-        span(class: 'inline-flex items-center gap-1 bg-primary-light text-foreground text-2xs font-bold rounded-full px-2.5 py-0.5') do
+        span(class: 'badge gap-1 bg-primary-light text-foreground') do
           raw(view_context.icon(:partner, size: nil, css_class: 'w-3 h-3'))
           plain "#{@partnership.partners_count} #{Partner.model_name.human(count: @partnership.partners_count).downcase}"
         end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -132,6 +132,7 @@ class PartnersController < ApplicationController
     render Views::Directory::Partners::Index.new(
       partners: @partners, pagy: @pagy, site: @site, query: params[:q], sort: @sort,
       az_letters: @az_letters, selected_letter: @selected_letter,
+      area_labels: PartnersQuery.area_labels(@partners),
       total_count: Partner.visible.count,
       partnership_count: Site.where(is_published: true).count,
       categories: query.categories_with_counts(scope: category_scope).map { |c| { id: c[:category].id, name: c[:category].name, count: c[:count] } },

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -12,6 +12,39 @@
 #   )
 #
 class PartnersQuery
+  # Area-breadcrumb label per partner id for the directory cards
+  # (e.g. "Manchester › Hulme › Moss Side"). Each partner's neighbourhood is
+  # its address neighbourhood, falling back to its first service area. Ancestors
+  # are batch-loaded so the partner index doesn't fire an ancestors query per
+  # card (the partner_card used to call hierarchy_path itself — an N+1).
+  #
+  # @param partners [Enumerable<Partner>] partners eager-loaded with their
+  #   address neighbourhood and service areas
+  # @return [Hash{Integer=>String,nil}] partner id => breadcrumb label (or nil)
+  def self.area_labels(partners)
+    partners = partners.to_a
+    return {} if partners.empty?
+
+    # Resolving service_area_neighbourhoods.first below would query per partner;
+    # preload the through-association once.
+    ActiveRecord::Associations::Preloader.new(records: partners, associations: :service_area_neighbourhoods).call
+
+    neighbourhoods = partners.to_h do |partner|
+      hood = partner.address&.neighbourhood
+      hood ||= partner.service_area_neighbourhoods.first if partner.has_service_areas?
+      [partner.id, hood]
+    end
+
+    ancestors = Neighbourhood.where(id: neighbourhoods.values.compact.flat_map(&:ancestor_ids).uniq).index_by(&:id)
+
+    neighbourhoods.transform_values do |hood|
+      next unless hood
+
+      path = hood.ancestor_ids.filter_map { |id| ancestors[id] } + [hood]
+      path.last(3).map(&:shortname).join(' › ')
+    end
+  end
+
   def initialize(site:)
     @site = site
   end

--- a/app/tailwind/public/_components.css
+++ b/app/tailwind/public/_components.css
@@ -343,6 +343,23 @@ textarea.join-control {
 	@apply inline-flex items-center justify-center min-w-9 h-9 px-2 rounded-full text-sm font-bold text-background no-underline bg-foreground;
 }
 
+/* Small rounded pill badge (event counts, category chips on partner/partnership
+   cards). Colours stay inline at the call site; --tight trims the padding. */
+.badge {
+	@apply inline-flex items-center text-2xs font-bold rounded-full px-2.5 py-0.5;
+}
+.badge--tight {
+	@apply px-2;
+}
+
+/* Inverting outline button on cream sections (e.g. Our Story "show more"). */
+a.btn-home-outline {
+	@apply inline-flex items-center gap-2 rounded-full border-2 border-home-background bg-home-background px-6 py-[0.7rem] text-base font-bold text-foreground no-underline transition-colors;
+}
+a.btn-home-outline:hover {
+	@apply border-foreground bg-foreground text-background;
+}
+
 /* Override leaflet.markercluster default styles */
 .marker-cluster-small,
 .marker-cluster-medium,

--- a/app/views/directory/our_story.rb
+++ b/app/views/directory/our_story.rb
@@ -151,7 +151,7 @@ class Views::Directory::OurStory < Views::Base
             t("#{T}.cta.heading")
           end
           link_to get_in_touch_path,
-                  class: 'with-no-sass inline-flex items-center gap-2 rounded-full border-2 border-home-background bg-home-background px-6 py-[0.7rem] text-base font-bold text-foreground no-underline transition-colors hover:border-foreground hover:bg-foreground hover:text-background' do
+                  class: 'with-no-sass btn-home-outline' do
             plain t("#{T}.cta.button")
             span(aria_hidden: 'true') { safe('→') }
           end

--- a/app/views/directory/partners/index.rb
+++ b/app/views/directory/partners/index.rb
@@ -18,6 +18,7 @@ class Views::Directory::Partners::Index < Views::Base
   prop :sort, String, default: 'recent'
   prop :az_letters, _Interface(:include?), default: -> { Set.new }
   prop :selected_letter, _Nilable(String), default: nil
+  prop :area_labels, Hash, default: -> { {} }
 
   def view_template
     content_for(:title) { ::Partner.model_name.human(count: 2) }
@@ -85,7 +86,7 @@ class Views::Directory::Partners::Index < Views::Base
       if @sort == 'name'
         render_alphabetical_list
       else
-        partner_list.each { |partner| Directory::PartnerCard(partner: partner, site: @site) }
+        partner_list.each { |partner| Directory::PartnerCard(partner: partner, site: @site, area: @area_labels[partner.id]) }
       end
     end
 
@@ -111,7 +112,7 @@ class Views::Directory::Partners::Index < Views::Base
         h2(id: "letter-#{letter}",
            class: '[column-span:all] font-serif text-2xl text-foreground mt-8 mb-3 pt-3 border-t-2 border-rules scroll-mt-4') { letter }
       end
-      Directory::PartnerCard(partner: partner, site: @site)
+      Directory::PartnerCard(partner: partner, site: @site, area: @area_labels[partner.id])
     end
   end
 

--- a/app/views/directory/partners/show.rb
+++ b/app/views/directory/partners/show.rb
@@ -39,26 +39,9 @@ class Views::Directory::Partners::Show < Views::Partners::Show
       flat.first(10).each do |event|
         Directory::EventRow(event: event, context_partner: partner)
       end
-      render_event_overflow(flat.drop(10))
-    end
-  end
-
-  def render_event_overflow(remaining)
-    return if remaining.empty?
-
-    batch = remaining.first(10)
-    rest = remaining.drop(10)
-    details(class: 'group') do
-      summary(class: 'list-none pt-3 border-t border-rules cursor-pointer [&::-webkit-details-marker]:hidden') do
-        span(class: 'inline-flex items-center gap-1.5 text-sm font-bold text-foreground group-open:hidden') do
-          plain t('directory.partners.show.show_more_events', count: [10, remaining.size].min)
-          span(class: 'text-tertiary') { safe('&#9660;') }
-        end
-      end
-      batch.each do |event|
+      Directory::OverflowToggle(items: flat.drop(10), label_key: 'directory.partners.show.show_more_events') do |event|
         Directory::EventRow(event: event, context_partner: partner)
       end
-      render_event_overflow(rest)
     end
   end
 

--- a/app/views/directory/partnerships/show.rb
+++ b/app/views/directory/partnerships/show.rb
@@ -87,27 +87,10 @@ class Views::Directory::Partnerships::Show < Views::Base
       flat_events.first(10).each do |event|
         Directory::EventRow(event: event)
       end
-      render_event_overflow(flat_events.drop(10))
-      render_see_all_button(t('directory.partnerships.show.see_all_events'), "#{partnership_base_url}/events")
-    end
-  end
-
-  def render_event_overflow(remaining)
-    return if remaining.empty?
-
-    batch = remaining.first(10)
-    rest = remaining.drop(10)
-    details(class: 'group') do
-      summary(class: 'list-none pt-3 border-t border-rules cursor-pointer [&::-webkit-details-marker]:hidden') do
-        span(class: 'inline-flex items-center gap-1.5 text-sm font-bold text-foreground group-open:hidden') do
-          plain t('directory.partnerships.show.show_more_events', count: [10, remaining.size].min)
-          span(class: 'text-tertiary') { safe('&#9660;') }
-        end
-      end
-      batch.each do |event|
+      Directory::OverflowToggle(items: flat_events.drop(10), label_key: 'directory.partnerships.show.show_more_events') do |event|
         Directory::EventRow(event: event)
       end
-      render_event_overflow(rest)
+      render_see_all_button(t('directory.partnerships.show.see_all_events'), "#{partnership_base_url}/events")
     end
   end
 

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -430,4 +430,21 @@ RSpec.describe PartnersQuery do
       expect(results).to include(partner_both_tags, partner_site_tag_only)
     end
   end
+
+  describe ".area_labels" do
+    it "builds the neighbourhood breadcrumb from the partner's address" do
+      region = create(:neighbourhood, name: "Greater Riverside", unit: "region")
+      district = create(:neighbourhood, name: "Riverdale", unit: "district", parent: region)
+      ward = create(:neighbourhood, name: "Riverside", unit: "ward", parent: district)
+      partner = create(:partner, address: create(:address, neighbourhood: ward))
+
+      labels = described_class.area_labels(Partner.where(id: partner.id))
+
+      expect(labels[partner.id]).to eq("#{region.shortname} › #{district.shortname} › #{ward.shortname}")
+    end
+
+    it "returns an empty hash for no partners" do
+      expect(described_class.area_labels(Partner.none)).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
Closes out the remaining **Refactors** items and the **Separation of concerns** "data-fetching in components" item on #3246.

## Changes

**`Directory::OverflowToggle`** — the recursive "show more events" `<details>` disclosure was duplicated in the partner and partnership show pages; now a shared component that renders each item via a block.

**Tailwind extraction** (`_components.css`):
- `.badge` / `.badge--tight` — the event-count and category chips across `partner_row`, `partner_mini`, `partner_card`, `partnership_card`.
- `a.btn-home-outline` — the Our Story "show more" button (was a 14-utility inline string).
- Faithful extractions: same utilities, no visual change.

**Partner-list N+1** — `PartnerCard` resolved its own neighbourhood breadcrumb via `Neighbourhood#hierarchy_path`, which runs an `ancestors` query **per card** across the paginated partner index. The label is now precomputed once by `PartnersQuery.area_labels` (batch-loading ancestors) and passed as an `area` prop, so the card just renders. Output is unchanged.

## Verification
- New query spec for `area_labels`; `OverflowToggle` covered by the existing partner/partnership show specs.
- Request + query specs green (98 examples in the final sweep, 0 failures); directory axe suite still 11/0; rubocop clean.
- Visually confirmed in Chrome: overflow toggles, badge chips, Our Story button, and the partner-index area breadcrumbs all render identically.

Public `public_tailwind.css` is rebuilt by `yarn build:all` in CI, so only the source is committed.

## Note on #3246
This leaves only the **Copy** section. The directory copy reviewed as consistent and current; the one open question (the "thousands of events from hundreds of organisations" scale claim) needs a product call and will be handled separately.