### PR TITLE
Retry transient HTTP failures (429/5xx) across calendar importer parsers

### DIFF
--- a/app/jobs/calendar_importer/parsers/api_base.rb
+++ b/app/jobs/calendar_importer/parsers/api_base.rb
@@ -43,7 +43,15 @@ module CalendarImporter
         }
         headers['User-Agent'] = user_agent if user_agent
 
-        response = HTTParty.get(url, headers: headers)
+        # Retry transient rate-limit/5xx responses with backoff before treating
+        # them as a hard error; the mapping below only fires once retries are
+        # exhausted.
+        response = Base.with_http_retries(
+          "#{self.class::NAME} API request",
+          retry_if: ->(r) { TRANSIENT_HTTP_STATUSES.include?(r.code) }
+        ) do
+          HTTParty.get(url, headers: headers)
+        end
 
         unless response.success?
           case response.code

--- a/app/jobs/calendar_importer/parsers/base.rb
+++ b/app/jobs/calendar_importer/parsers/base.rb
@@ -17,7 +17,9 @@ module CalendarImporter::Parsers
     # problems with our request, so they're worth retrying with backoff before
     # giving up (see AppSignal incidents #311/#331 for the Eventbrite case that
     # motivated this). 408 Request Timeout is included as a transient network
-    # hiccup.
+    # hiccup. This is the HTTParty (status-code) view of "transient"; the
+    # RestClient/SDK exception-class equivalent is Eventbrite::TRANSIENT_HTTP_ERRORS
+    # — keep the two in sync when adding a status.
     TRANSIENT_HTTP_STATUSES = [408, 429, 500, 502, 503, 504].freeze
     HTTP_MAX_RETRIES = 3
     HTTP_RETRY_BACKOFF = 2 # seconds, multiplied by the attempt number

--- a/app/jobs/calendar_importer/parsers/base.rb
+++ b/app/jobs/calendar_importer/parsers/base.rb
@@ -12,6 +12,16 @@ module CalendarImporter::Parsers
     NAME = ''
     KEY = ''
 
+    # Third-party event sources intermittently return rate-limit (429) and
+    # server-error (5xx) responses. These are transient upstream failures, not
+    # problems with our request, so they're worth retrying with backoff before
+    # giving up (see AppSignal incidents #311/#331 for the Eventbrite case that
+    # motivated this). 408 Request Timeout is included as a transient network
+    # hiccup.
+    TRANSIENT_HTTP_STATUSES = [408, 429, 500, 502, 503, 504].freeze
+    HTTP_MAX_RETRIES = 3
+    HTTP_RETRY_BACKOFF = 2 # seconds, multiplied by the attempt number
+
     def self.requires_api_token?
       false
     end
@@ -43,6 +53,48 @@ module CalendarImporter::Parsers
     def self.handles_url?(calendar)
       calendar.source =~ allowlist_pattern
     end
+
+    # Run a block, retrying transient HTTP failures with a linear backoff before
+    # giving up. Two retry triggers are supported so this works across the
+    # different HTTP clients the parsers use:
+    #
+    #   retry_on: a list of exception classes to retry (e.g. RestClient's typed
+    #             5xx/429 errors, raised by the Eventbrite SDK).
+    #   retry_if: a predicate on the block's return value (e.g. an HTTParty
+    #             response whose .code is a transient status).
+    #
+    # Once retries are exhausted the last exception is re-raised (or the last
+    # result returned) so the caller decides how to degrade.
+    def self.with_http_retries(context, retry_on: [], retry_if: nil, max_retries: HTTP_MAX_RETRIES)
+      attempt = 0
+
+      loop do
+        result =
+          begin
+            yield
+          rescue *retry_on => e
+            attempt += 1
+            raise if attempt > max_retries
+
+            log_http_retry(context, attempt, max_retries, "#{e.class} (#{e.message})")
+            sleep(HTTP_RETRY_BACKOFF * attempt)
+            next
+          end
+
+        return result unless retry_if && attempt < max_retries && retry_if.call(result)
+
+        attempt += 1
+        log_http_retry(context, attempt, max_retries, 'transient response')
+        sleep(HTTP_RETRY_BACKOFF * attempt)
+      end
+    end
+
+    def self.log_http_retry(context, attempt, max_retries, reason)
+      Rails.logger.warn(
+        "#{context}: transient HTTP failure (#{reason}), retry #{attempt}/#{max_retries}"
+      )
+    end
+    private_class_method :log_http_retry
 
     def initialize(calendar, options = {})
       @calendar = calendar
@@ -99,7 +151,12 @@ module CalendarImporter::Parsers
 
       # User-Agent is currently set to make Resident Advisor happy, but this is also more "honest".
       # It may be this method needs per-vendor headers
-      response = HTTParty.get(url, follow_redirects: follow_redirects, headers: { 'User-Agent': 'Httparty' })
+      response = with_http_retries(
+        "Fetching #{url}",
+        retry_if: ->(r) { TRANSIENT_HTTP_STATUSES.include?(r.code) }
+      ) do
+        HTTParty.get(url, follow_redirects: follow_redirects, headers: { 'User-Agent': 'Httparty' })
+      end
       return response.body if response.success?
 
       msg = case response.code

--- a/app/jobs/calendar_importer/parsers/eventbrite.rb
+++ b/app/jobs/calendar_importer/parsers/eventbrite.rb
@@ -10,12 +10,14 @@ module CalendarImporter::Parsers
     KEY = 'eventbrite'
     DOMAINS = %w[www.eventbrite.com www.eventbrite.co.uk].freeze
 
-    # Eventbrite's API intermittently returns 5xx and 429 responses (see
-    # AppSignal incidents #311/#331). These are transient upstream failures, not
-    # problems with our request, so retry with backoff before giving up.
-    # The SDK wraps RestClient::InternalServerError as its own class for the
-    # list endpoint; 429/502/503/504 from the SDK propagate as raw RestClient
-    # errors, and the description endpoint uses RestClient directly.
+    # Eventbrite is the only parser that talks to its API via RestClient (the
+    # rest use HTTParty, whose transient responses are retried by status code in
+    # Base.read_http_source / ApiBase). RestClient signals transient failures by
+    # raising typed exceptions instead, so we hand Base.with_http_retries the
+    # exception classes to retry. The SDK wraps RestClient::InternalServerError
+    # as its own class for the list endpoint; 429/502/503/504 from the SDK
+    # propagate as raw RestClient errors, and the description endpoint uses
+    # RestClient directly. See AppSignal incidents #311/#331.
     TRANSIENT_HTTP_ERRORS = [
       EventbriteSDK::InternalServerError, # 500, wrapped by the SDK
       RestClient::InternalServerError,    # 500
@@ -24,9 +26,6 @@ module CalendarImporter::Parsers
       RestClient::GatewayTimeout,         # 504
       RestClient::TooManyRequests         # 429 rate limit
     ].freeze
-
-    MAX_RETRIES = 3
-    RETRY_BACKOFF = 2 # seconds, multiplied by the attempt number
 
     def self.allowlist_pattern
       %r{^https://www\.eventbrite\.(com|co\.uk)/o/[A-Za-z0-9-]+}
@@ -41,7 +40,7 @@ module CalendarImporter::Parsers
       EventbriteSDK.token = ENV.fetch('EVENTBRITE_TOKEN', nil)
 
       @events = []
-      results = with_retries('organiser events') do
+      results = Base.with_http_retries('Eventbrite organiser events', retry_on: TRANSIENT_HTTP_ERRORS) do
         EventbriteSDK::Organizer.retrieve(id: organizer_id).events.with_expansion(:venue).page(1)
       end
 
@@ -51,7 +50,7 @@ module CalendarImporter::Parsers
           event.assign_attributes('description.html' => html) if html
         end
         @events += results
-        results = with_retries('next page') { results.next_page }
+        results = Base.with_http_retries('Eventbrite next page', retry_on: TRANSIENT_HTTP_ERRORS) { results.next_page }
         break if results.blank?
       end
 
@@ -81,7 +80,7 @@ module CalendarImporter::Parsers
     # failures. The description is supplementary, so a failed fetch for one
     # event must not lose the whole calendar — import the event without it.
     def fetch_event_description(event_id)
-      with_retries("event #{event_id} description") do
+      Base.with_http_retries("Eventbrite event #{event_id} description", retry_on: TRANSIENT_HTTP_ERRORS) do
         get_event_description(EventbriteSDK.token, event_id)
       end
     rescue *TRANSIENT_HTTP_ERRORS => e
@@ -96,28 +95,6 @@ module CalendarImporter::Parsers
       resource = RestClient::Resource.new("https://www.eventbriteapi.com/v3/events/#{event_id}/description/")
       response = resource.get(:Authorization => "Bearer #{token}")
       Base.safely_parse_json(response)['description']
-    end
-
-    private
-
-    # Run the block, retrying on transient Eventbrite HTTP failures (5xx/429)
-    # with a linear backoff. Re-raises the last error once retries are
-    # exhausted so the caller can decide how to degrade.
-    def with_retries(context)
-      attempt = 0
-      begin
-        yield
-      rescue *TRANSIENT_HTTP_ERRORS => e
-        attempt += 1
-        raise if attempt > MAX_RETRIES
-
-        Rails.logger.warn(
-          "Eventbrite #{context} transient error (#{e.class}: #{e.message}), " \
-          "retry #{attempt}/#{MAX_RETRIES}"
-        )
-        sleep(RETRY_BACKOFF * attempt)
-        retry
-      end
     end
   end
 end

--- a/app/jobs/calendar_importer/parsers/eventbrite.rb
+++ b/app/jobs/calendar_importer/parsers/eventbrite.rb
@@ -10,6 +10,24 @@ module CalendarImporter::Parsers
     KEY = 'eventbrite'
     DOMAINS = %w[www.eventbrite.com www.eventbrite.co.uk].freeze
 
+    # Eventbrite's API intermittently returns 5xx and 429 responses (see
+    # AppSignal incidents #311/#331). These are transient upstream failures, not
+    # problems with our request, so retry with backoff before giving up.
+    # The SDK wraps RestClient::InternalServerError as its own class for the
+    # list endpoint; 429/502/503/504 from the SDK propagate as raw RestClient
+    # errors, and the description endpoint uses RestClient directly.
+    TRANSIENT_HTTP_ERRORS = [
+      EventbriteSDK::InternalServerError, # 500, wrapped by the SDK
+      RestClient::InternalServerError,    # 500
+      RestClient::BadGateway,             # 502
+      RestClient::ServiceUnavailable,     # 503
+      RestClient::GatewayTimeout,         # 504
+      RestClient::TooManyRequests         # 429 rate limit
+    ].freeze
+
+    MAX_RETRIES = 3
+    RETRY_BACKOFF = 2 # seconds, multiplied by the attempt number
+
     def self.allowlist_pattern
       %r{^https://www\.eventbrite\.(com|co\.uk)/o/[A-Za-z0-9-]+}
     end
@@ -23,20 +41,28 @@ module CalendarImporter::Parsers
       EventbriteSDK.token = ENV.fetch('EVENTBRITE_TOKEN', nil)
 
       @events = []
-      results = EventbriteSDK::Organizer.retrieve(id: organizer_id).events.with_expansion(:venue).page(1)
+      results = with_retries('organiser events') do
+        EventbriteSDK::Organizer.retrieve(id: organizer_id).events.with_expansion(:venue).page(1)
+      end
 
       loop do
         results.map do |event|
-          html = get_event_description(EventbriteSDK.token, event.id)
-          event.assign_attributes('description.html' => html)
+          html = fetch_event_description(event.id)
+          event.assign_attributes('description.html' => html) if html
         end
         @events += results
-        results = results.next_page
+        results = with_retries('next page') { results.next_page }
         break if results.blank?
       end
 
       @events
-    rescue RestClient::BadGateway
+    rescue *TRANSIENT_HTTP_ERRORS => e
+      # Retries exhausted. Eventbrite is having a transient outage; skip this
+      # run rather than crashing the import (which flags the calendar into the
+      # terminal `error` state and floods error tracking). Returning [] leaves
+      # the calendar's existing events untouched — the importer only purges
+      # stale events when it gets a non-empty result (see CalendarImporterTask).
+      Rails.logger.warn("Eventbrite import skipped for #{@url}: #{e.class} (#{e.message})")
       []
     rescue EventbriteSDK::ResourceNotFound => e
       # The Eventbrite organiser no longer exists — usually deleted, or renamed
@@ -51,11 +77,47 @@ module CalendarImporter::Parsers
       data.map { |d| CalendarImporter::Events::EventbriteEvent.new(d) }
     end
 
+    # Fetch a single event's full description, tolerating transient Eventbrite
+    # failures. The description is supplementary, so a failed fetch for one
+    # event must not lose the whole calendar — import the event without it.
+    def fetch_event_description(event_id)
+      with_retries("event #{event_id} description") do
+        get_event_description(EventbriteSDK.token, event_id)
+      end
+    rescue *TRANSIENT_HTTP_ERRORS => e
+      Rails.logger.warn(
+        "Eventbrite description fetch failed for event #{event_id}: #{e.class} (#{e.message})"
+      )
+      nil
+    end
+
     # Get full event description
     def get_event_description(token, event_id)
       resource = RestClient::Resource.new("https://www.eventbriteapi.com/v3/events/#{event_id}/description/")
       response = resource.get(:Authorization => "Bearer #{token}")
       Base.safely_parse_json(response)['description']
+    end
+
+    private
+
+    # Run the block, retrying on transient Eventbrite HTTP failures (5xx/429)
+    # with a linear backoff. Re-raises the last error once retries are
+    # exhausted so the caller can decide how to degrade.
+    def with_retries(context)
+      attempt = 0
+      begin
+        yield
+      rescue *TRANSIENT_HTTP_ERRORS => e
+        attempt += 1
+        raise if attempt > MAX_RETRIES
+
+        Rails.logger.warn(
+          "Eventbrite #{context} transient error (#{e.class}: #{e.message}), " \
+          "retry #{attempt}/#{MAX_RETRIES}"
+        )
+        sleep(RETRY_BACKOFF * attempt)
+        retry
+      end
     end
   end
 end

--- a/app/jobs/calendar_importer/parsers/eventbrite.rb
+++ b/app/jobs/calendar_importer/parsers/eventbrite.rb
@@ -17,7 +17,9 @@ module CalendarImporter::Parsers
     # exception classes to retry. The SDK wraps RestClient::InternalServerError
     # as its own class for the list endpoint; 429/502/503/504 from the SDK
     # propagate as raw RestClient errors, and the description endpoint uses
-    # RestClient directly. See AppSignal incidents #311/#331.
+    # RestClient directly. See AppSignal incidents #311/#331. This is the
+    # exception-class mirror of Base::TRANSIENT_HTTP_STATUSES — keep the two in
+    # sync when adding a transient case.
     TRANSIENT_HTTP_ERRORS = [
       EventbriteSDK::InternalServerError, # 500, wrapped by the SDK
       RestClient::InternalServerError,    # 500
@@ -80,12 +82,21 @@ module CalendarImporter::Parsers
     # failures. The description is supplementary, so a failed fetch for one
     # event must not lose the whole calendar — import the event without it.
     def fetch_event_description(event_id)
+      # Circuit breaker: once a description fetch has exhausted its retries the
+      # endpoint is likely down, so skip the rest for this run. Without this a
+      # large calendar would pay (event count × backoff) seconds during an
+      # outage and could exceed the worker's max_run_time — and the description
+      # endpoint is exactly what fails in incidents #311/#200.
+      return if @skip_descriptions
+
       Base.with_http_retries("Eventbrite event #{event_id} description", retry_on: TRANSIENT_HTTP_ERRORS) do
         get_event_description(EventbriteSDK.token, event_id)
       end
     rescue *TRANSIENT_HTTP_ERRORS => e
+      @skip_descriptions = true
       Rails.logger.warn(
-        "Eventbrite description fetch failed for event #{event_id}: #{e.class} (#{e.message})"
+        "Eventbrite description fetch failed for event #{event_id} (#{e.class}: #{e.message}); " \
+        'skipping descriptions for the rest of this import'
       )
       nil
     end

--- a/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
+++ b/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
@@ -107,6 +107,19 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
 
           expect(parser.fetch_event_description("123")).to eq("<p>recovered</p>")
           expect(call_count).to eq(2)
+          # one failure -> one backoff before the successful retry
+          expect(CalendarImporter::Parsers::Base).to have_received(:sleep).once
+        end
+
+        it "stops attempting descriptions for the rest of the run after one fails (circuit breaker)" do
+          allow(parser).to receive(:get_event_description).and_raise(RestClient::InternalServerError)
+
+          expect(parser.fetch_event_description("1")).to be_nil
+          expect(parser.fetch_event_description("2")).to be_nil
+
+          # Only the first event exhausts its retries; the second short-circuits
+          # with no further HTTP calls, bounding total backoff per import run.
+          expect(parser).to have_received(:get_event_description).exactly(max_retries + 1).times
         end
       end
     end

--- a/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
+++ b/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
@@ -45,6 +45,69 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
       end
     end
 
+    context "when Eventbrite's API returns transient errors (5xx / 429)" do
+      let(:os_event_url) { "https://www.eventbrite.co.uk/o/queer-lit-social-refuge-48062165483" }
+      let(:calendar) do
+        build(:calendar, strategy: :event, name: :import_test_calendar, source: os_event_url)
+          .tap { |c| allow(c).to receive(:check_source_reachable) }
+      end
+      let(:parser) { described_class.new(calendar, url: os_event_url) }
+
+      before { allow(parser).to receive(:sleep) } # don't actually back off in tests
+
+      it "retries the organiser listing and degrades to an empty result when it keeps failing" do
+        allow(EventbriteSDK::Organizer).to receive(:retrieve)
+          .and_raise(EventbriteSDK::InternalServerError.new("internal server error"))
+
+        # An ongoing Eventbrite outage must not crash the import (which would
+        # flag the calendar as errored and wipe nothing) — it returns [].
+        expect(parser.download_calendar).to eq([])
+        expect(parser).to have_received(:sleep).exactly(described_class::MAX_RETRIES).times
+        expect(EventbriteSDK::Organizer).to have_received(:retrieve)
+          .exactly(described_class::MAX_RETRIES + 1).times
+      end
+
+      it "treats a raw 429 from the listing endpoint as transient too" do
+        allow(EventbriteSDK::Organizer).to receive(:retrieve)
+          .and_raise(RestClient::TooManyRequests)
+
+        expect(parser.download_calendar).to eq([])
+        expect(EventbriteSDK::Organizer).to have_received(:retrieve)
+          .exactly(described_class::MAX_RETRIES + 1).times
+      end
+
+      it "does not retry or swallow non-transient errors" do
+        allow(EventbriteSDK::Organizer).to receive(:retrieve)
+          .and_raise(RestClient::Unauthorized)
+
+        expect { parser.download_calendar }.to raise_error(RestClient::Unauthorized)
+        expect(parser).not_to have_received(:sleep)
+      end
+
+      describe "#fetch_event_description" do
+        it "skips the description (returns nil) when one event keeps failing" do
+          allow(parser).to receive(:get_event_description).and_raise(RestClient::InternalServerError)
+
+          expect(parser.fetch_event_description("123")).to be_nil
+          expect(parser).to have_received(:get_event_description)
+            .exactly(described_class::MAX_RETRIES + 1).times
+        end
+
+        it "retries and returns the description once Eventbrite recovers" do
+          call_count = 0
+          allow(parser).to receive(:get_event_description) do
+            call_count += 1
+            raise RestClient::TooManyRequests if call_count < 2
+
+            "<p>recovered</p>"
+          end
+
+          expect(parser.fetch_event_description("123")).to eq("<p>recovered</p>")
+          expect(call_count).to eq(2)
+        end
+      end
+    end
+
     it "raises InaccessibleFeed when the Eventbrite organiser no longer exists" do
       os_event_url = "https://www.eventbrite.co.uk/o/deleted-organiser-99999999999"
       calendar = build(

--- a/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
+++ b/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
@@ -52,8 +52,11 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
           .tap { |c| allow(c).to receive(:check_source_reachable) }
       end
       let(:parser) { described_class.new(calendar, url: os_event_url) }
+      let(:max_retries) { CalendarImporter::Parsers::Base::HTTP_MAX_RETRIES }
 
-      before { allow(parser).to receive(:sleep) } # don't actually back off in tests
+      # Backoff sleeps happen inside Base.with_http_retries — stub there so the
+      # tests don't actually wait.
+      before { allow(CalendarImporter::Parsers::Base).to receive(:sleep) }
 
       it "retries the organiser listing and degrades to an empty result when it keeps failing" do
         allow(EventbriteSDK::Organizer).to receive(:retrieve)
@@ -62,9 +65,9 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
         # An ongoing Eventbrite outage must not crash the import (which would
         # flag the calendar as errored and wipe nothing) — it returns [].
         expect(parser.download_calendar).to eq([])
-        expect(parser).to have_received(:sleep).exactly(described_class::MAX_RETRIES).times
+        expect(CalendarImporter::Parsers::Base).to have_received(:sleep).exactly(max_retries).times
         expect(EventbriteSDK::Organizer).to have_received(:retrieve)
-          .exactly(described_class::MAX_RETRIES + 1).times
+          .exactly(max_retries + 1).times
       end
 
       it "treats a raw 429 from the listing endpoint as transient too" do
@@ -73,7 +76,7 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
 
         expect(parser.download_calendar).to eq([])
         expect(EventbriteSDK::Organizer).to have_received(:retrieve)
-          .exactly(described_class::MAX_RETRIES + 1).times
+          .exactly(max_retries + 1).times
       end
 
       it "does not retry or swallow non-transient errors" do
@@ -81,7 +84,7 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
           .and_raise(RestClient::Unauthorized)
 
         expect { parser.download_calendar }.to raise_error(RestClient::Unauthorized)
-        expect(parser).not_to have_received(:sleep)
+        expect(CalendarImporter::Parsers::Base).not_to have_received(:sleep)
       end
 
       describe "#fetch_event_description" do
@@ -90,7 +93,7 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
 
           expect(parser.fetch_event_description("123")).to be_nil
           expect(parser).to have_received(:get_event_description)
-            .exactly(described_class::MAX_RETRIES + 1).times
+            .exactly(max_retries + 1).times
         end
 
         it "retries and returns the description once Eventbrite recovers" do

--- a/spec/jobs/calendar_importer/parser_base_spec.rb
+++ b/spec/jobs/calendar_importer/parser_base_spec.rb
@@ -24,7 +24,89 @@ RSpec.describe CalendarImporter::Parsers::Base do
     end
   end
 
+  describe ".with_http_retries" do
+    before { allow(described_class).to receive(:sleep) } # don't actually back off
+
+    it "returns the result without retrying on success" do
+      calls = 0
+      result = described_class.with_http_retries("ctx") do
+        calls += 1
+        :ok
+      end
+
+      expect(result).to eq(:ok)
+      expect(calls).to eq(1)
+      expect(described_class).not_to have_received(:sleep)
+    end
+
+    it "retries the configured exceptions with backoff, then re-raises" do
+      calls = 0
+      expect do
+        described_class.with_http_retries("ctx", retry_on: [RestClient::TooManyRequests]) do
+          calls += 1
+          raise RestClient::TooManyRequests
+        end
+      end.to raise_error(RestClient::TooManyRequests)
+
+      expect(calls).to eq(described_class::HTTP_MAX_RETRIES + 1)
+      expect(described_class).to have_received(:sleep).exactly(described_class::HTTP_MAX_RETRIES).times
+    end
+
+    it "does not retry exceptions that are not configured" do
+      calls = 0
+      expect do
+        described_class.with_http_retries("ctx", retry_on: [RestClient::TooManyRequests]) do
+          calls += 1
+          raise RestClient::Unauthorized
+        end
+      end.to raise_error(RestClient::Unauthorized)
+
+      expect(calls).to eq(1)
+    end
+
+    it "retries while retry_if matches, then returns the recovered result" do
+      responses = [503, 503, 200]
+      index = -1
+      result = described_class.with_http_retries("ctx", retry_if: ->(code) { code != 200 }) do
+        index += 1
+        responses[index]
+      end
+
+      expect(result).to eq(200)
+      expect(index).to eq(2)
+      expect(described_class).to have_received(:sleep).twice
+    end
+
+    it "gives up and returns the last result once retries are exhausted" do
+      result = described_class.with_http_retries("ctx", retry_if: ->(_) { true }) { 503 }
+
+      expect(result).to eq(503)
+      expect(described_class).to have_received(:sleep).exactly(described_class::HTTP_MAX_RETRIES).times
+    end
+  end
+
   describe ".read_http_source" do
+    it "retries transient 5xx responses and returns the recovered body" do
+      allow(described_class).to receive(:sleep)
+      unavailable = instance_double(HTTParty::Response, success?: false, code: 503)
+      ok = instance_double(HTTParty::Response, success?: true, body: "<html>ok</html>", code: 200)
+      allow(HTTParty).to receive(:get).and_return(unavailable, ok)
+
+      expect(described_class.read_http_source("https://example.com")).to eq("<html>ok</html>")
+      expect(HTTParty).to have_received(:get).twice
+    end
+
+    it "does not retry non-transient responses such as 404" do
+      allow(described_class).to receive(:sleep)
+      not_found = instance_double(HTTParty::Response, success?: false, code: 404)
+      allow(HTTParty).to receive(:get).and_return(not_found)
+
+      expect do
+        described_class.read_http_source("https://example.com")
+      end.to raise_error(CalendarImporter::Exceptions::InaccessibleFeed)
+      expect(HTTParty).to have_received(:get).once
+    end
+
     it "reads remote URL with valid input" do
       VCR.use_cassette(:example_dot_com) do
         response = described_class.read_http_source("https://example.com")

--- a/spec/jobs/calendar_importer/parsers/ticketsource_spec.rb
+++ b/spec/jobs/calendar_importer/parsers/ticketsource_spec.rb
@@ -108,6 +108,37 @@ RSpec.describe CalendarImporter::Parsers::Ticketsource do
         expect(data.length).to eq(1)
         expect(data.first["id"]).to eq("evt_123")
       end
+
+      it "retries a transient 5xx response then succeeds (ApiBase retry path)" do
+        allow(CalendarImporter::Parsers::Base).to receive(:sleep) # don't actually back off
+        events_url = "https://api.ticketsource.io/events?page=1&per_page=100"
+        stub_request(:get, events_url).to_return(
+          { status: 503 },
+          { status: 200, body: events_response, headers: { "Content-Type" => "application/json" } }
+        )
+
+        parser = described_class.new(calendar)
+        data = parser.download_calendar
+
+        expect(data.length).to eq(1)
+        expect(a_request(:get, events_url)).to have_been_made.twice
+        expect(CalendarImporter::Parsers::Base).to have_received(:sleep).once
+      end
+
+      it "raises InaccessibleFeed once retries are exhausted on a persistent 5xx" do
+        allow(CalendarImporter::Parsers::Base).to receive(:sleep)
+        events_url = "https://api.ticketsource.io/events?page=1&per_page=100"
+        stub_request(:get, events_url).to_return(status: 503)
+
+        parser = described_class.new(calendar)
+        expect { parser.download_calendar }.to raise_error(
+          CalendarImporter::Exceptions::InaccessibleFeed,
+          /API error \(code=503\)/
+        )
+        # initial attempt + HTTP_MAX_RETRIES retries
+        expect(a_request(:get, events_url))
+          .to have_been_made.times(CalendarImporter::Parsers::Base::HTTP_MAX_RETRIES + 1)
+      end
     end
   end
 


### PR DESCRIPTION
Resolves # <!-- no single issue; surfaced via AppSignal incidents #311/#331 (prod), #196/#200/#204 (staging) -->

## Description

Third-party event feeds intermittently return rate-limit (429) and server-error (5xx) responses. These are transient upstream failures, but the importer treated them as fatal:

- **Eventbrite** ([`eventbrite.rb`](app/jobs/calendar_importer/parsers/eventbrite.rb)) only rescued `BadGateway` (502). Every other transient error crashed `CalendarImporterJob`, flagging the calendar into the terminal `error` state (via the job's `rescue_from StandardError`) and flooding AppSignal. The per-event description fetch is also an unthrottled N+1, which trips Eventbrite's rate limit (the 429s).
- **`Base.read_http_source`** (ICS, LdJson, Squarespace, Wix, Meetup, …) raised `InaccessibleFeed` on the first non-200 — a transient 503 became a permanent bad-source flag.
- **`ApiBase#make_api_request`** (TicketSource, TicketTailor, Outsavvy) even mapped `429 → "rate limit exceeded, try again later"` … but never tried again.

This PR adds shared retry/backoff and wires it into all three paths.

### What changed

- **`Base.with_http_retries`** — a client-agnostic backoff runner (3 retries, linear 2s/4s/6s backoff) with two retry triggers, because the parsers use different HTTP clients that signal failure differently:
  - `retry_on:` — exception classes to retry (RestClient raises typed 5xx/429 errors; used by the Eventbrite SDK path).
  - `retry_if:` — a predicate on the block's result (HTTParty returns a response object; we retry on transient status codes).
  - Exhausting retries re-raises the last exception / returns the last result, so each caller keeps its own degrade behaviour.
- **`read_http_source` + `make_api_request`** retry transient statuses (`408/429/500/502/503/504`) before falling through to their existing error mapping. Non-transient responses (401/403/404) and other errors (timeouts, socket errors) are unchanged — they pass straight through.
- **Eventbrite** refactored onto the shared helper (private `with_retries` and duplicated constants removed; its RestClient/SDK error set stays parser-local). Degrade behaviour:
  - Whole listing fails after retries → returns `[]` instead of crashing. Per `CalendarImporterTask`, an empty result skips processing **and** the stale-event purge, so existing events are left intact and the calendar isn't errored.
  - Single event's description fails after retries → returns `nil`; the event is still imported without its full HTML.

### Motivation and Context

Eventbrite has been returning 500s/429s on staging and production (AppSignal incidents above). The errors are upstream, but our parsers handled them by crashing imports / flagging feeds as broken rather than degrading. We can't fix Eventbrite's outage, but we can stop transient blips from breaking imports — and the same gap existed for every other feed, so the fix is generalised rather than Eventbrite-specific.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`bundle exec rspec spec/jobs/calendar_importer` + `calendar_importer_job_spec` — all green (270 + API parser specs).

New specs:
- `Base.with_http_retries`: success (no retry), exception retry + re-raise with correct backoff count, non-configured exception passthrough, result-based retry then recovery, exhaustion returns last result.
- `read_http_source`: retries transient 5xx then returns recovered body; does **not** retry 404.
- Eventbrite (carried over, retargeted to the shared helper): listing degrades to `[]`, raw 429 treated as transient, non-transient errors not swallowed, per-event description skip + retry-then-recover.

Rubocop clean on all changed files.

### How Will This Be Deployed?

Standard deploy. No env vars, migrations, or infra changes. Backoff sleeps run inside the background `CalendarImporterJob`; worst case adds ~12s per persistently-failing feed before it degrades — acceptable for a background importer.