### PR TITLE
Stabilise flaky admin multi-step form specs (#3278)

### DIFF
--- a/app/javascript/controllers/calendar_wizard_controller.js
+++ b/app/javascript/controllers/calendar_wizard_controller.js
@@ -12,6 +12,7 @@ import {
 	showInputSuccess,
 	clearInputStyling,
 	setContinueButtonEnabled,
+	markWizardConnected,
 } from "controllers/mixins/wizard";
 
 /**
@@ -62,6 +63,8 @@ export default class extends Controller {
 			this.setupPartnerListener();
 			this.updateContinueButton();
 		}, 100);
+
+		markWizardConnected(this);
 	}
 
 	// Step navigation

--- a/app/javascript/controllers/mixins/wizard.js
+++ b/app/javascript/controllers/mixins/wizard.js
@@ -48,6 +48,17 @@ export const wizardValues = {
 };
 
 /**
+ * Mark the wizard as connected for tests. A "Continue"/step click before the
+ * controller connects is silently dropped (no Stimulus action listener yet),
+ * so the step transition never happens. Specs wait for this marker before
+ * interacting, mirroring the form-tabs/save-bar connected markers.
+ * @param {Controller} controller - Stimulus controller
+ */
+export function markWizardConnected(controller) {
+	controller.element.dataset.wizardConnected = "true";
+}
+
+/**
  * Common Stimulus targets for wizard controllers
  */
 export const wizardTargets = [

--- a/app/javascript/controllers/partner_wizard_controller.js
+++ b/app/javascript/controllers/partner_wizard_controller.js
@@ -11,6 +11,7 @@ import {
 	clearInputError,
 	setContinueButtonEnabled,
 	clearInputStyling,
+	markWizardConnected,
 } from "controllers/mixins/wizard";
 
 /**
@@ -72,6 +73,7 @@ export default class extends Controller {
 		);
 		updateWizardUI(this);
 		this.updateContinueButton();
+		markWizardConnected(this);
 	}
 
 	// Step navigation

--- a/app/javascript/controllers/user_wizard_controller.js
+++ b/app/javascript/controllers/user_wizard_controller.js
@@ -11,6 +11,7 @@ import {
 	showInputSuccess,
 	clearInputStyling,
 	setContinueButtonEnabled,
+	markWizardConnected,
 } from "controllers/mixins/wizard";
 
 /**
@@ -39,6 +40,7 @@ export default class extends Controller {
 		this.checkEmailDebounced = debounce(this.performEmailCheck.bind(this), 400);
 		updateWizardUI(this);
 		this.updateContinueButton();
+		markWizardConnected(this);
 	}
 
 	// Step navigation

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -161,6 +161,10 @@ When("I go to the {string} step") do |step_name|
   tab_hash = tab_hashes[step_name.downcase]
   raise "Unknown step: #{step_name}" unless tab_hash
 
+  # Wait for the form-tabs controller to connect; a tab click before connect can
+  # be reverted on load, leaving the panel hidden.
+  wait_for_form_tabs
+
   # Find and click the tab by data-hash attribute (more reliable than emoji aria-labels)
   tab = page.find("input.tab[data-hash='#{tab_hash}']")
 
@@ -199,6 +203,9 @@ When("I click the {string} tab") do |tab_name|
     "Preview" => "preview"
   }
 
+  # Wait for the form-tabs controller to connect before clicking.
+  wait_for_form_tabs
+
   # Try data-hash first, fall back to aria-label match
   tab_hash = tab_hashes[tab_name]
   tab = if tab_hash
@@ -225,6 +232,9 @@ When("I go to form step {int}") do |step_number|
   tab_hashes = %w[basic location contact tags admins]
   tab_hash = tab_hashes[step_number - 1]
   raise "Invalid step number: #{step_number}" unless tab_hash
+
+  # Wait for the form-tabs controller to connect before clicking.
+  wait_for_form_tabs
 
   tab = page.find("input.tab[data-hash='#{tab_hash}']")
   # Handle unsaved changes confirmation if it appears

--- a/features/step_definitions/partner_steps.rb
+++ b/features/step_definitions/partner_steps.rb
@@ -31,7 +31,10 @@ When("I create a new partner with name {string}") do |name|
   await_datatables
   click_link "Add Partner"
 
-  # Step 1: Name - wizard form uses partner_wizard controller
+  # Step 1: Name - wizard form uses partner_wizard controller.
+  # Wait for the controller to connect: a Continue click before connect is
+  # dropped (no Stimulus action listener yet) and the step never advances.
+  wait_for_wizard
   fill_in "partner_name", with: name
 
   # Wait for name validation debounce to complete and enable Continue button

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -37,6 +37,25 @@ module CucumberHelpers
     JS
   end
 
+  # Wait for the wizard Stimulus controller (partner/calendar/user "new" forms)
+  # to connect. A "Continue"/step click before connect is silently dropped, so
+  # the step transition never happens. Mirrors TabHelpers#wait_for_form_tabs.
+  def wait_for_wizard
+    expect(page).to have_css("[data-wizard-connected]")
+  end
+
+  # Wait for the form-tabs Stimulus controller (multi-tab edit forms) to connect
+  # before clicking a tab; clicks before connect can be reverted on load.
+  def wait_for_form_tabs
+    expect(page).to have_css("[data-form-tabs-connected]")
+  end
+
+  # Wait for the save-bar Stimulus controller to connect before interacting with
+  # a tracked form, so its clean/dirty baseline is taken against the loaded form.
+  def wait_for_save_bar
+    expect(page).to have_css("[data-save-bar-connected]")
+  end
+
   # Wait for page to settle after JavaScript actions
   def wait_for_page_load
     Timeout.timeout(Capybara.default_max_wait_time) do

--- a/spec/system/admin/tags_spec.rb
+++ b/spec/system/admin/tags_spec.rb
@@ -41,9 +41,16 @@ RSpec.describe "Admin Tags", :slow, type: :system do
       # Wait for tabs, navigate to Basic Info tab (tab state may be stored from previous tests)
       expect(page).to have_css(".tabs.tabs-lift")
       click_tab("basic")
+      # Wait for the save-bar to connect so its clean/dirty baseline is taken
+      # against the loaded form before we edit it.
+      wait_for_save_bar
       expect(page).to have_field("Name")
 
       fill_in "Name", with: "A new tag name"
+      # Confirm the edit registered (and made the form dirty) before saving;
+      # a Save on a form the controller still reads as pristine submits the
+      # unchanged value.
+      expect(page).to have_field("Name", with: "A new tag name")
       click_button "Save"
 
       assert_has_flash(:success, "Tag was saved successfully")
@@ -106,9 +113,14 @@ RSpec.describe "Admin Tags", :slow, type: :system do
       # Name is on Basic Info tab (default)
       expect(page).to have_css('input[name="tag[name]"][value="AlphaFacility"]')
 
+      # Wait for the save-bar to connect before editing, so its dirty baseline
+      # is taken against the loaded form.
+      wait_for_save_bar
+
       # Change name and description on Basic Info tab
       fill_in "Name", with: "AlphaFacility 2"
       fill_in "Description", with: "The description has changed."
+      expect(page).to have_field("Name", with: "AlphaFacility 2")
       click_button "Save"
 
       assert_has_flash(:success, "Tag was saved successfully")


### PR DESCRIPTION
Fixes #3278, and the related `tags_spec` flake currently failing on `main`.

## Problem

Two JS-timing races in the admin multi-step forms caused intermittent CI failures. Both have the same shape: a Capybara interaction firing **before** the relevant Stimulus controller connected.

1. **`features/admin/partner_crud.feature:23`** — the "new partner" **wizard**. The "Continue" button is rendered enabled in the raw HTML, so the step asserted `disabled: false` and clicked it before `partner-wizard` connected. A click with no Stimulus action listener is silently dropped, so `[data-step='2']` never revealed. Unlike `form-tabs`/`save-bar`, the wizard controllers had **no connected marker** to wait on.

2. **`spec/system/admin/tags_spec.rb:37`** (the failure on `main`) — the tag **edit** tab-form. The CI failure screenshot showed the Name field still holding its original value with the Save button in its *clean* state: `fill_in` raced with `save-bar` setup, so the edit was lost / the form read pristine and Save submitted the unchanged value → no success flash.

## Fix

- **Wizard connected marker** — added `markWizardConnected()` to the wizard mixin, called in the `connect()` of the partner, calendar and user wizards. It sets `data-wizard-connected`, mirroring the existing `data-form-tabs-connected` / `data-save-bar-connected` pattern.
- **Cucumber wait helpers** — added `wait_for_wizard` / `wait_for_form_tabs` / `wait_for_save_bar`. Partner creation now waits for the wizard before filling, and the tab/step navigation steps wait for `form-tabs` before clicking.
- **`tags_spec`** — waits for `save-bar` to connect before editing (so its dirty baseline is taken against the loaded form) and confirms the typed value landed before saving.

## Verification (local)

- `spec/system/admin/tags_spec.rb` (7 examples): green across 6 consecutive runs.
- `features/admin/partner_crud.feature` (5 scenarios): green across 4 consecutive runs.
- Prettier and RuboCop clean.