### PR TITLE
Add bin/ci local CI pipeline

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/boot'
+require 'active_support/continuous_integration'
+
+CI = ActiveSupport::ContinuousIntegration
+require_relative '../config/ci'

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Local CI — run the whole pipeline with `bin/ci` (Rails 8.1's
+# ActiveSupport::ContinuousIntegration). This mirrors the lint / security / test
+# jobs in .github/workflows/test-and-deploy.yml so the same checks run locally
+# and in the cloud.
+#
+# The test steps need a prepared test database, built assets, and Chrome (for
+# system/cucumber specs) — a normal dev machine has these. While iterating, run
+# the individual commands directly; reach for `bin/ci` as the full gate before
+# pushing.
+CI.run do
+  step 'Style: JS/CSS format', 'bin/yarn run format:check'
+  step 'Style: Ruby', 'bin/rubocop'
+
+  step 'Security: Brakeman', 'bundle exec brakeman --no-pager'
+  step 'Security: Importmap audit', 'bin/importmap audit'
+
+  step 'DB: prepare test database', 'env RAILS_ENV=test bin/rails db:test:prepare'
+  step 'Assets: JS build', 'bin/yarn run build:all'
+  step 'Assets: SCSS build', 'bin/rails dartsass:build'
+  step 'Assets: precompile', 'env RAILS_ENV=test bin/rails assets:precompile'
+
+  step 'Tests: RSpec (unit)', "bundle exec rspec --exclude-pattern 'spec/system/**/*'"
+  step 'Tests: RSpec (system)', 'env RUN_SLOW_TESTS=true bundle exec rspec spec/system'
+  step 'Tests: Cucumber (admin)', 'bundle exec cucumber --tags "not @wip" features/admin'
+  step 'Tests: Cucumber (public)',
+       'bundle exec cucumber --tags "not @wip" features/public features/authentication.feature'
+
+  step 'DB: consistency', 'env RAILS_ENV=test bundle exec database_consistency'
+end


### PR DESCRIPTION
## What

Adds `config/ci.rb` + `bin/ci` using Rails 8.1's `ActiveSupport::ContinuousIntegration`, so the whole pipeline runs locally with one command — mirroring the `lint` / `security` / `test` jobs in `.github/workflows/test-and-deploy.yml`:

- **Style** — `bin/yarn run format:check`, `bin/rubocop`
- **Security** — `bundle exec brakeman --no-pager`, `bin/importmap audit`
- **Tests** — RSpec unit (`--exclude-pattern spec/system`), RSpec system (`RUN_SLOW_TESTS=true … spec/system`), Cucumber admin + public (`--tags "not @wip"`)
- **DB** — `db:test:prepare`, `database_consistency`

## Context — no framework upgrade here

This started as "the Rails 8.1 upgrade," but PlaceCal is **already on Rails 8.1.3 with `config.load_defaults 8.1`** (since `3702e120 Upgrade Rails from 7.2.3 to 8.1.2`). So there's nothing to upgrade — this is purely the new local-CI feature that 8.1 makes available.

## Scope / notes

- **Independent of [#3288](https://github.com/geeksforsocialchange/PlaceCal/pull/3288)** — touches no shared files (no `Gemfile`/config overlap), so it's based on `main` and can merge in any order.
- The **cloud workflow is unchanged.** Pointing GitHub Actions at `bin/ci` (so local and CI share one definition) is a sensible follow-up but a riskier change, kept out of this PR.

## Verification

- `config/ci.rb` + `bin/ci` are syntax- and RuboCop-clean; `ActiveSupport::ContinuousIntegration.run` confirmed available in 8.1.3.
- Ran `bin/ci`: it prints the CI header, executes the first step, and halts fail-fast — wiring + step execution + fail-fast all work. (A full green run needs the usual test prerequisites: `yarn install`, a prepared test DB, and Chrome.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)