### PR TITLE
Verify DX tooling, fix bin/ci rubocop step, annotate schema

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -23,6 +23,11 @@ on:
 permissions:
   contents: read
 
+# These lint / security / test jobs mirror config/ci.rb, which devs can run
+# locally in one shot with `bin/ci` (Rails 8.1 ActiveSupport::ContinuousIntegration).
+# Keep the two in sync — a check added here should be added there, and vice
+# versa. CI keeps the jobs split and the test suite parallelised for speed;
+# bin/ci runs the same steps sequentially.
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -57,6 +62,9 @@ jobs:
 
       - name: Run Brakeman
         run: bundle exec brakeman --no-pager
+
+      - name: Audit JavaScript dependencies (importmap)
+        run: bin/importmap audit
 
   test:
     runs-on: ubuntu-latest

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  city             :string
+#  country_code     :string           default("UK"), not null
+#  latitude         :float
+#  longitude        :float
+#  postcode         :string           not null
+#  street_address   :string           not null
+#  street_address2  :string
+#  street_address3  :string
+#  neighbourhood_id :bigint
+#
+# Indexes
+#
+#  index_addresses_on_neighbourhood_id  (neighbourhood_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (neighbourhood_id => neighbourhoods.id)
+#
 class Address < ApplicationRecord
   # ==== Includes / Extends ====
   include NeighbourhoodCacheInvalidator

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: articles
+#
+#  id            :bigint           not null, primary key
+#  article_image :string
+#  body          :text             not null
+#  body_html     :string
+#  is_draft      :boolean          default(TRUE), not null
+#  published_at  :date
+#  slug          :string
+#  title         :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  author_id     :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_author_id  (author_id)
+#  index_articles_on_slug       (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#
 class Article < ApplicationRecord
   # ==== Includes / Extends ====
   extend FriendlyId

--- a/app/models/article_partner.rb
+++ b/app/models/article_partner.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: article_partners
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  partner_id :bigint           not null
+#
+# Indexes
+#
+#  index_article_partners_on_article_id_and_partner_id  (article_id,partner_id) UNIQUE
+#  index_article_partners_on_partner_id                 (partner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (partner_id => partners.id)
+#
 class ArticlePartner < ApplicationRecord
   # ==== Associations ====
   belongs_to :article

--- a/app/models/article_tag.rb
+++ b/app/models/article_tag.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: article_tags
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  tag_id     :bigint           not null
+#
+# Indexes
+#
+#  index_article_tags_article_id_tag_id  (article_id,tag_id) UNIQUE
+#  index_article_tags_on_tag_id          (tag_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (tag_id => tags.id)
+#
 class ArticleTag < ApplicationRecord
   # ==== Associations ====
   belongs_to :article

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -1,5 +1,45 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: calendars
+#
+#  id                   :bigint           not null, primary key
+#  api_token            :string
+#  calendar_state       :string           default("idle")
+#  checksum_updated_at  :datetime
+#  critical_error       :text
+#  import_started_at    :datetime
+#  importer_mode        :string           default("auto")
+#  importer_used        :string
+#  is_working           :boolean          default(TRUE), not null
+#  last_checksum        :string
+#  last_import_at       :datetime
+#  name                 :string           not null
+#  notice_count         :integer
+#  notices              :jsonb
+#  public_contact_email :string
+#  public_contact_name  :string
+#  public_contact_phone :string
+#  source               :string           not null
+#  strategy             :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  organiser_id         :bigint           not null
+#  place_id             :bigint
+#
+# Indexes
+#
+#  index_calendars_on_calendar_state  (calendar_state)
+#  index_calendars_on_organiser_id    (organiser_id)
+#  index_calendars_on_place_id        (place_id)
+#  index_calendars_source             (source) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organiser_id => partners.id)
+#  fk_rails_...  (place_id => partners.id)
+#
 class Calendar < ApplicationRecord
   # ==== Includes / Extends ====
   include ActionView::Helpers::DateHelper

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tags
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string           not null
+#  system_tag  :boolean          default(FALSE), not null
+#  type        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tags_name_type  (name,type) UNIQUE
+#  index_tags_slug_type  (slug,type) UNIQUE
+#
 class Category < Tag
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: collections
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  image       :string
+#  name        :string
+#  route       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class Collection < ApplicationRecord
   # ==== Includes / Extends ====
   include Permalinkable

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,51 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: events
+#
+#  id                       :bigint           not null, primary key
+#  are_spaces_available     :string
+#  description              :text
+#  description_html         :string
+#  dtend                    :datetime
+#  dtstart                  :datetime         not null
+#  footer                   :text
+#  is_active                :boolean          default(TRUE), not null
+#  notices                  :jsonb
+#  publisher_url            :string
+#  raw_location_from_source :text
+#  rrule                    :jsonb
+#  summary                  :text             not null
+#  summary_html             :string
+#  uid                      :string
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  address_id               :bigint
+#  calendar_id              :bigint
+#  online_address_id        :bigint
+#  organiser_id             :bigint           not null
+#  place_id                 :bigint
+#
+# Indexes
+#
+#  index_events_address_id                   (address_id)
+#  index_events_calendar_id_dtstart          (calendar_id,dtstart)
+#  index_events_dtstart                      (dtstart)
+#  index_events_on_online_address_id         (online_address_id)
+#  index_events_on_organiser_id_and_dtstart  (organiser_id,dtstart)
+#  index_events_on_place_id                  (place_id)
+#  index_events_uid                          (uid)
+#  index_events_unique_per_calendar          (calendar_id,uid,dtstart,dtend) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (address_id => addresses.id)
+#  fk_rails_...  (calendar_id => calendars.id)
+#  fk_rails_...  (online_address_id => online_addresses.id)
+#  fk_rails_...  (organiser_id => partners.id)
+#  fk_rails_...  (place_id => partners.id)
+#
 class Event < ApplicationRecord
   # ==== Includes / Extends ====
   has_paper_trail ignore: %i[rrule notices]

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -1,4 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tags
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string           not null
+#  system_tag  :boolean          default(FALSE), not null
+#  type        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tags_name_type  (name,type) UNIQUE
+#  index_tags_slug_type  (slug,type) UNIQUE
+#
 class Facility < Tag
 end

--- a/app/models/neighbourhood.rb
+++ b/app/models/neighbourhood.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: neighbourhoods
+#
+#  id              :bigint           not null, primary key
+#  ancestry        :string
+#  level           :integer
+#  name            :string
+#  name_abbr       :string
+#  parent_name     :string
+#  partners_count  :integer          default(0), not null
+#  release_date    :datetime
+#  unit            :string           default("ward")
+#  unit_code_key   :string           default("WD19CD")
+#  unit_code_value :string
+#  unit_name       :string
+#
+# Indexes
+#
+#  index_neighbourhoods_on_ancestry        (ancestry)
+#  index_neighbourhoods_on_level           (level)
+#  index_neighbourhoods_on_partners_count  (partners_count)
+#
 class Neighbourhood < ApplicationRecord
   # ==== Includes / Extends ====
   has_ancestry

--- a/app/models/neighbourhoods_user.rb
+++ b/app/models/neighbourhoods_user.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: neighbourhoods_users
+#
+#  id               :bigint           not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  neighbourhood_id :bigint           not null
+#  user_id          :bigint           not null
+#
+# Indexes
+#
+#  index_neighbourhoods_users_neighbourhood_id_user_id  (neighbourhood_id,user_id) UNIQUE
+#  index_neighbourhoods_users_on_user_id                (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (neighbourhood_id => neighbourhoods.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class NeighbourhoodsUser < ApplicationRecord
   # ==== Associations ====
   belongs_to :neighbourhood

--- a/app/models/online_address.rb
+++ b/app/models/online_address.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: online_addresses
+#
+#  id         :bigint           not null, primary key
+#  link_type  :string
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class OnlineAddress < ApplicationRecord
   # ==== Includes / Extends ====
   extend Enumerize

--- a/app/models/organisation_relationship.rb
+++ b/app/models/organisation_relationship.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organisation_relationships
+#
+#  id                 :bigint           not null, primary key
+#  verb               :string           not null
+#  partner_object_id  :bigint           not null
+#  partner_subject_id :bigint           not null
+#
+# Indexes
+#
+#  index_organisation_relationships_on_partner_object_id  (partner_object_id)
+#  unique_organisation_relationship_row                   (partner_subject_id,verb,partner_object_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (partner_object_id => partners.id)
+#  fk_rails_...  (partner_subject_id => partners.id)
+#
 class OrganisationRelationship < ApplicationRecord
   # NOTE: This model is (was) used to define a relationship between
   #   partners so one "big" partner can have lots of "small" partners "within"

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -1,5 +1,57 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: partners
+#
+#  id                      :bigint           not null, primary key
+#  accessibility_info      :text
+#  accessibility_info_html :string
+#  admin_email             :string
+#  admin_name              :string
+#  booking_info            :text
+#  calendar_email          :string
+#  calendar_name           :string
+#  calendar_phone          :string
+#  can_be_assigned_events  :boolean          default(FALSE), not null
+#  description             :text
+#  description_html        :string
+#  facebook_link           :string
+#  hidden                  :boolean          default(FALSE), not null
+#  hidden_reason           :text
+#  hidden_reason_html      :string
+#  image                   :string
+#  instagram_handle        :string
+#  is_a_place              :boolean          default(FALSE), not null
+#  name                    :string           not null
+#  opening_times           :jsonb
+#  partner_email           :string
+#  partner_name            :string
+#  partner_phone           :string
+#  public_email            :string
+#  public_name             :string
+#  public_phone            :string
+#  slug                    :string
+#  summary                 :string
+#  summary_html            :string
+#  twitter_handle          :string
+#  url                     :string
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  address_id              :bigint
+#  hidden_blame_id         :integer
+#
+# Indexes
+#
+#  index_partners_hidden         (hidden)
+#  index_partners_lower_name_    (lower((name)::text)) UNIQUE
+#  index_partners_on_address_id  (address_id)
+#  index_partners_on_slug        (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (address_id => addresses.id)
+#
 class Partner < ApplicationRecord
   # ==== Includes / Extends ====
   include Validation

--- a/app/models/partner_tag.rb
+++ b/app/models/partner_tag.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: partner_tags
+#
+#  id         :bigint           not null, primary key
+#  partner_id :bigint           not null
+#  tag_id     :bigint           not null
+#
+# Indexes
+#
+#  index_partner_tags_on_tag_id_and_partner_id  (tag_id,partner_id)
+#  index_partner_tags_partner_id_tag_id         (partner_id,tag_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (partner_id => partners.id)
+#  fk_rails_...  (tag_id => tags.id)
+#
 class PartnerTag < ApplicationRecord
   # ==== Associations ====
   belongs_to :partner

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -1,4 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tags
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string           not null
+#  system_tag  :boolean          default(FALSE), not null
+#  type        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tags_name_type  (name,type) UNIQUE
+#  index_tags_slug_type  (slug,type) UNIQUE
+#
 class Partnership < Tag
 end

--- a/app/models/service_area.rb
+++ b/app/models/service_area.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: service_areas
+#
+#  id               :bigint           not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  neighbourhood_id :bigint           not null
+#  partner_id       :bigint           not null
+#
+# Indexes
+#
+#  index_service_areas_on_neighbourhood_id_and_partner_id  (neighbourhood_id,partner_id) UNIQUE
+#  index_service_areas_on_partner_id                       (partner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (neighbourhood_id => neighbourhoods.id)
+#  fk_rails_...  (partner_id => partners.id)
+#
 class ServiceArea < ApplicationRecord
   # ==== Includes / Extends ====
   include NeighbourhoodCacheInvalidator

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,5 +1,44 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: sites
+#
+#  id                :bigint           not null, primary key
+#  badge_zoom_level  :string
+#  description       :text
+#  description_html  :string
+#  events_count      :integer          default(0), not null
+#  footer_logo       :string
+#  hero_alttext      :string
+#  hero_image        :string
+#  hero_image_credit :string
+#  hero_text         :string
+#  is_published      :boolean          default(FALSE), not null
+#  logo              :string
+#  name              :string           not null
+#  partners_count    :integer          default(0), not null
+#  place_name        :string
+#  slug              :string           not null
+#  tagline           :string
+#  theme             :string
+#  url               :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  site_admin_id     :bigint
+#
+# Indexes
+#
+#  index_sites_is_published       (is_published)
+#  index_sites_on_events_count    (events_count)
+#  index_sites_on_partners_count  (partners_count)
+#  index_sites_slug               (slug) UNIQUE
+#  index_sites_url                (url)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (site_admin_id => users.id)
+#
 class Site < ApplicationRecord
   # ==== Includes / Extends ====
   extend FriendlyId

--- a/app/models/sites_neighbourhood.rb
+++ b/app/models/sites_neighbourhood.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: sites_neighbourhoods
+#
+#  id               :bigint           not null, primary key
+#  relation_type    :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  neighbourhood_id :bigint           not null
+#  site_id          :bigint           not null
+#
+# Indexes
+#
+#  index_sites_neighbourhoods_neighbourhood_id_site_id  (neighbourhood_id,site_id) UNIQUE
+#  index_sites_neighbourhoods_site_id                   (site_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (neighbourhood_id => neighbourhoods.id)
+#  fk_rails_...  (site_id => sites.id)
+#
 class SitesNeighbourhood < ApplicationRecord
   # ==== Constants ====
 

--- a/app/models/sites_supporter.rb
+++ b/app/models/sites_supporter.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: sites_supporters
+#
+#  site_id      :bigint           not null
+#  supporter_id :bigint           not null
+#
+# Indexes
+#
+#  index_sites_supporters_on_supporter_id_and_site_id  (supporter_id,site_id)
+#  index_sites_supporters_site_id_supporter_id         (site_id,supporter_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (site_id => sites.id)
+#  fk_rails_...  (supporter_id => supporters.id)
+#
 class SitesSupporter < ApplicationRecord
   # ==== Associations ====
   belongs_to :supporter

--- a/app/models/sites_tag.rb
+++ b/app/models/sites_tag.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: sites_tags
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  site_id    :bigint           not null
+#  tag_id     :bigint           not null
+#
+# Indexes
+#
+#  index_sites_tags_on_site_id_and_tag_id  (site_id,tag_id) UNIQUE
+#  index_sites_tags_on_tag_id              (tag_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (site_id => sites.id)
+#  fk_rails_...  (tag_id => tags.id)
+#
 class SitesTag < ApplicationRecord
   # ==== Associations ====
   belongs_to :tag

--- a/app/models/supporter.rb
+++ b/app/models/supporter.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: supporters
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  is_global   :boolean          default(FALSE), not null
+#  logo        :string
+#  name        :string           not null
+#  url         :string
+#  weight      :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class Supporter < ApplicationRecord
   # ==== Attributes ====
   attribute :description, :string

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tags
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string           not null
+#  system_tag  :boolean          default(FALSE), not null
+#  type        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tags_name_type  (name,type) UNIQUE
+#  index_tags_slug_type  (slug,type) UNIQUE
+#
 class Tag < ApplicationRecord
   # ==== Includes / Extends ====
   extend FriendlyId

--- a/app/models/tags_user.rb
+++ b/app/models/tags_user.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tags_users
+#
+#  id      :bigint           not null, primary key
+#  tag_id  :bigint           not null
+#  user_id :bigint           not null
+#
+# Indexes
+#
+#  index_tags_users_on_user_id_and_tag_id  (user_id,tag_id)
+#  index_tags_users_tag_id_user_id         (tag_id,user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (tag_id => tags.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class TagsUser < ApplicationRecord
   # ==== Constants ====
   self.table_name = 'tags_users'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,43 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                      :bigint           not null, primary key
+#  access_token            :string
+#  access_token_expires_at :string
+#  avatar                  :string
+#  current_sign_in_at      :datetime
+#  current_sign_in_ip      :inet
+#  email                   :string           default(""), not null
+#  encrypted_password      :string           default("")
+#  first_name              :string
+#  invitation_accepted_at  :datetime
+#  invitation_created_at   :datetime
+#  invitation_limit        :integer
+#  invitation_sent_at      :datetime
+#  invitation_token        :string
+#  invited_by_type         :string
+#  last_name               :string
+#  last_sign_in_at         :datetime
+#  last_sign_in_ip         :inet
+#  phone                   :string
+#  remember_created_at     :datetime
+#  reset_password_sent_at  :datetime
+#  reset_password_token    :string
+#  role                    :string           not null
+#  sign_in_count           :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  invited_by_id           :integer
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_invitation_token      (invitation_token) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 class User < ApplicationRecord
   # ==== Includes / Extends ====
   include Validation

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -11,7 +11,10 @@
 # pushing.
 CI.run do
   step 'Style: JS/CSS format', 'bin/yarn run format:check'
-  step 'Style: Ruby', 'bin/rubocop'
+  # Use `bundle exec rubocop` (not bin/rubocop): the bin/rubocop binstub forces
+  # --config .rubocop.yml, which breaks inherit_from of .rubocop_todo.yml and
+  # surfaces thousands of grandfathered offenses. This matches CI.
+  step 'Style: Ruby', 'bundle exec rubocop'
 
   step 'Security: Brakeman', 'bundle exec brakeman --no-pager'
   step 'Security: Importmap audit', 'bin/importmap audit'

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: articles
+#
+#  id            :bigint           not null, primary key
+#  article_image :string
+#  body          :text             not null
+#  body_html     :string
+#  is_draft      :boolean          default(TRUE), not null
+#  published_at  :date
+#  slug          :string
+#  title         :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  author_id     :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_author_id  (author_id)
+#  index_articles_on_slug       (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#
 FactoryBot.define do
   factory :article do
     sequence(:title) { |n| "Article #{n}" }

--- a/spec/factories/calendars.rb
+++ b/spec/factories/calendars.rb
@@ -1,5 +1,45 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: calendars
+#
+#  id                   :bigint           not null, primary key
+#  api_token            :string
+#  calendar_state       :string           default("idle")
+#  checksum_updated_at  :datetime
+#  critical_error       :text
+#  import_started_at    :datetime
+#  importer_mode        :string           default("auto")
+#  importer_used        :string
+#  is_working           :boolean          default(TRUE), not null
+#  last_checksum        :string
+#  last_import_at       :datetime
+#  name                 :string           not null
+#  notice_count         :integer
+#  notices              :jsonb
+#  public_contact_email :string
+#  public_contact_name  :string
+#  public_contact_phone :string
+#  source               :string           not null
+#  strategy             :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  organiser_id         :bigint           not null
+#  place_id             :bigint
+#
+# Indexes
+#
+#  index_calendars_on_calendar_state  (calendar_state)
+#  index_calendars_on_organiser_id    (organiser_id)
+#  index_calendars_on_place_id        (place_id)
+#  index_calendars_source             (source) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organiser_id => partners.id)
+#  fk_rails_...  (place_id => partners.id)
+#
 FactoryBot.define do
   factory :calendar do
     sequence(:name) { |n| "Calendar #{n}" }

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: collections
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  image       :string
+#  name        :string
+#  route       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
   factory :collection do
     sequence(:name) { |n| "Collection #{n}" }

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,5 +1,51 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: events
+#
+#  id                       :bigint           not null, primary key
+#  are_spaces_available     :string
+#  description              :text
+#  description_html         :string
+#  dtend                    :datetime
+#  dtstart                  :datetime         not null
+#  footer                   :text
+#  is_active                :boolean          default(TRUE), not null
+#  notices                  :jsonb
+#  publisher_url            :string
+#  raw_location_from_source :text
+#  rrule                    :jsonb
+#  summary                  :text             not null
+#  summary_html             :string
+#  uid                      :string
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  address_id               :bigint
+#  calendar_id              :bigint
+#  online_address_id        :bigint
+#  organiser_id             :bigint           not null
+#  place_id                 :bigint
+#
+# Indexes
+#
+#  index_events_address_id                   (address_id)
+#  index_events_calendar_id_dtstart          (calendar_id,dtstart)
+#  index_events_dtstart                      (dtstart)
+#  index_events_on_online_address_id         (online_address_id)
+#  index_events_on_organiser_id_and_dtstart  (organiser_id,dtstart)
+#  index_events_on_place_id                  (place_id)
+#  index_events_uid                          (uid)
+#  index_events_unique_per_calendar          (calendar_id,uid,dtstart,dtend) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (address_id => addresses.id)
+#  fk_rails_...  (calendar_id => calendars.id)
+#  fk_rails_...  (online_address_id => online_addresses.id)
+#  fk_rails_...  (organiser_id => partners.id)
+#  fk_rails_...  (place_id => partners.id)
+#
 FactoryBot.define do
   factory :event do
     sequence(:summary) { |n| "Event #{n}" }

--- a/spec/factories/online_addresses.rb
+++ b/spec/factories/online_addresses.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: online_addresses
+#
+#  id         :bigint           not null, primary key
+#  link_type  :string
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :online_address do
     url { Faker::Internet.url }

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -1,5 +1,57 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: partners
+#
+#  id                      :bigint           not null, primary key
+#  accessibility_info      :text
+#  accessibility_info_html :string
+#  admin_email             :string
+#  admin_name              :string
+#  booking_info            :text
+#  calendar_email          :string
+#  calendar_name           :string
+#  calendar_phone          :string
+#  can_be_assigned_events  :boolean          default(FALSE), not null
+#  description             :text
+#  description_html        :string
+#  facebook_link           :string
+#  hidden                  :boolean          default(FALSE), not null
+#  hidden_reason           :text
+#  hidden_reason_html      :string
+#  image                   :string
+#  instagram_handle        :string
+#  is_a_place              :boolean          default(FALSE), not null
+#  name                    :string           not null
+#  opening_times           :jsonb
+#  partner_email           :string
+#  partner_name            :string
+#  partner_phone           :string
+#  public_email            :string
+#  public_name             :string
+#  public_phone            :string
+#  slug                    :string
+#  summary                 :string
+#  summary_html            :string
+#  twitter_handle          :string
+#  url                     :string
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  address_id              :bigint
+#  hidden_blame_id         :integer
+#
+# Indexes
+#
+#  index_partners_hidden         (hidden)
+#  index_partners_lower_name_    (lower((name)::text)) UNIQUE
+#  index_partners_on_address_id  (address_id)
+#  index_partners_on_slug        (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (address_id => addresses.id)
+#
 require_relative "../../lib/normal_island"
 
 FactoryBot.define do

--- a/spec/factories/service_areas.rb
+++ b/spec/factories/service_areas.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: service_areas
+#
+#  id               :bigint           not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  neighbourhood_id :bigint           not null
+#  partner_id       :bigint           not null
+#
+# Indexes
+#
+#  index_service_areas_on_neighbourhood_id_and_partner_id  (neighbourhood_id,partner_id) UNIQUE
+#  index_service_areas_on_partner_id                       (partner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (neighbourhood_id => neighbourhoods.id)
+#  fk_rails_...  (partner_id => partners.id)
+#
 FactoryBot.define do
   factory :service_area do
     association :partner

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -1,5 +1,44 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: sites
+#
+#  id                :bigint           not null, primary key
+#  badge_zoom_level  :string
+#  description       :text
+#  description_html  :string
+#  events_count      :integer          default(0), not null
+#  footer_logo       :string
+#  hero_alttext      :string
+#  hero_image        :string
+#  hero_image_credit :string
+#  hero_text         :string
+#  is_published      :boolean          default(FALSE), not null
+#  logo              :string
+#  name              :string           not null
+#  partners_count    :integer          default(0), not null
+#  place_name        :string
+#  slug              :string           not null
+#  tagline           :string
+#  theme             :string
+#  url               :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  site_admin_id     :bigint
+#
+# Indexes
+#
+#  index_sites_is_published       (is_published)
+#  index_sites_on_events_count    (events_count)
+#  index_sites_on_partners_count  (partners_count)
+#  index_sites_slug               (slug) UNIQUE
+#  index_sites_url                (url)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (site_admin_id => users.id)
+#
 require_relative "../../lib/normal_island"
 
 FactoryBot.define do

--- a/spec/factories/supporters.rb
+++ b/spec/factories/supporters.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: supporters
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  is_global   :boolean          default(FALSE), not null
+#  logo        :string
+#  name        :string           not null
+#  url         :string
+#  weight      :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
   factory :supporter do
     sequence(:name) { |n| "Supporter #{n}" }

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tags
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string           not null
+#  system_tag  :boolean          default(FALSE), not null
+#  type        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tags_name_type  (name,type) UNIQUE
+#  index_tags_slug_type  (slug,type) UNIQUE
+#
 FactoryBot.define do
   factory :tag do
     sequence(:name) { |n| "Tag #{n}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,43 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                      :bigint           not null, primary key
+#  access_token            :string
+#  access_token_expires_at :string
+#  avatar                  :string
+#  current_sign_in_at      :datetime
+#  current_sign_in_ip      :inet
+#  email                   :string           default(""), not null
+#  encrypted_password      :string           default("")
+#  first_name              :string
+#  invitation_accepted_at  :datetime
+#  invitation_created_at   :datetime
+#  invitation_limit        :integer
+#  invitation_sent_at      :datetime
+#  invitation_token        :string
+#  invited_by_type         :string
+#  last_name               :string
+#  last_sign_in_at         :datetime
+#  last_sign_in_ip         :inet
+#  phone                   :string
+#  remember_created_at     :datetime
+#  reset_password_sent_at  :datetime
+#  reset_password_token    :string
+#  role                    :string           not null
+#  sign_in_count           :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  invited_by_id           :integer
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_invitation_token      (invitation_token) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@placecal.org" }

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  city             :string
+#  country_code     :string           default("UK"), not null
+#  latitude         :float
+#  longitude        :float
+#  postcode         :string           not null
+#  street_address   :string           not null
+#  street_address2  :string
+#  street_address3  :string
+#  neighbourhood_id :bigint
+#
+# Indexes
+#
+#  index_addresses_on_neighbourhood_id  (neighbourhood_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (neighbourhood_id => neighbourhoods.id)
+#
 require "rails_helper"
 
 RSpec.describe Address, type: :model do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: articles
+#
+#  id            :bigint           not null, primary key
+#  article_image :string
+#  body          :text             not null
+#  body_html     :string
+#  is_draft      :boolean          default(TRUE), not null
+#  published_at  :date
+#  slug          :string
+#  title         :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  author_id     :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_author_id  (author_id)
+#  index_articles_on_slug       (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#
 require "rails_helper"
 
 RSpec.describe Article do

--- a/spec/models/calendar_spec.rb
+++ b/spec/models/calendar_spec.rb
@@ -1,5 +1,45 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: calendars
+#
+#  id                   :bigint           not null, primary key
+#  api_token            :string
+#  calendar_state       :string           default("idle")
+#  checksum_updated_at  :datetime
+#  critical_error       :text
+#  import_started_at    :datetime
+#  importer_mode        :string           default("auto")
+#  importer_used        :string
+#  is_working           :boolean          default(TRUE), not null
+#  last_checksum        :string
+#  last_import_at       :datetime
+#  name                 :string           not null
+#  notice_count         :integer
+#  notices              :jsonb
+#  public_contact_email :string
+#  public_contact_name  :string
+#  public_contact_phone :string
+#  source               :string           not null
+#  strategy             :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  organiser_id         :bigint           not null
+#  place_id             :bigint
+#
+# Indexes
+#
+#  index_calendars_on_calendar_state  (calendar_state)
+#  index_calendars_on_organiser_id    (organiser_id)
+#  index_calendars_on_place_id        (place_id)
+#  index_calendars_source             (source) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organiser_id => partners.id)
+#  fk_rails_...  (place_id => partners.id)
+#
 require "rails_helper"
 
 RSpec.describe Calendar, type: :model do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: collections
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  image       :string
+#  name        :string
+#  route       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require "rails_helper"
 
 RSpec.describe Collection do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,5 +1,51 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: events
+#
+#  id                       :bigint           not null, primary key
+#  are_spaces_available     :string
+#  description              :text
+#  description_html         :string
+#  dtend                    :datetime
+#  dtstart                  :datetime         not null
+#  footer                   :text
+#  is_active                :boolean          default(TRUE), not null
+#  notices                  :jsonb
+#  publisher_url            :string
+#  raw_location_from_source :text
+#  rrule                    :jsonb
+#  summary                  :text             not null
+#  summary_html             :string
+#  uid                      :string
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  address_id               :bigint
+#  calendar_id              :bigint
+#  online_address_id        :bigint
+#  organiser_id             :bigint           not null
+#  place_id                 :bigint
+#
+# Indexes
+#
+#  index_events_address_id                   (address_id)
+#  index_events_calendar_id_dtstart          (calendar_id,dtstart)
+#  index_events_dtstart                      (dtstart)
+#  index_events_on_online_address_id         (online_address_id)
+#  index_events_on_organiser_id_and_dtstart  (organiser_id,dtstart)
+#  index_events_on_place_id                  (place_id)
+#  index_events_uid                          (uid)
+#  index_events_unique_per_calendar          (calendar_id,uid,dtstart,dtend) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (address_id => addresses.id)
+#  fk_rails_...  (calendar_id => calendars.id)
+#  fk_rails_...  (online_address_id => online_addresses.id)
+#  fk_rails_...  (organiser_id => partners.id)
+#  fk_rails_...  (place_id => partners.id)
+#
 require "rails_helper"
 
 RSpec.describe Event, type: :model do

--- a/spec/models/neighbourhood_spec.rb
+++ b/spec/models/neighbourhood_spec.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: neighbourhoods
+#
+#  id              :bigint           not null, primary key
+#  ancestry        :string
+#  level           :integer
+#  name            :string
+#  name_abbr       :string
+#  parent_name     :string
+#  partners_count  :integer          default(0), not null
+#  release_date    :datetime
+#  unit            :string           default("ward")
+#  unit_code_key   :string           default("WD19CD")
+#  unit_code_value :string
+#  unit_name       :string
+#
+# Indexes
+#
+#  index_neighbourhoods_on_ancestry        (ancestry)
+#  index_neighbourhoods_on_level           (level)
+#  index_neighbourhoods_on_partners_count  (partners_count)
+#
 require "rails_helper"
 
 RSpec.describe Neighbourhood, type: :model do

--- a/spec/models/online_address_spec.rb
+++ b/spec/models/online_address_spec.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: online_addresses
+#
+#  id         :bigint           not null, primary key
+#  link_type  :string
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require "rails_helper"
 
 RSpec.describe OnlineAddress do

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -1,5 +1,57 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: partners
+#
+#  id                      :bigint           not null, primary key
+#  accessibility_info      :text
+#  accessibility_info_html :string
+#  admin_email             :string
+#  admin_name              :string
+#  booking_info            :text
+#  calendar_email          :string
+#  calendar_name           :string
+#  calendar_phone          :string
+#  can_be_assigned_events  :boolean          default(FALSE), not null
+#  description             :text
+#  description_html        :string
+#  facebook_link           :string
+#  hidden                  :boolean          default(FALSE), not null
+#  hidden_reason           :text
+#  hidden_reason_html      :string
+#  image                   :string
+#  instagram_handle        :string
+#  is_a_place              :boolean          default(FALSE), not null
+#  name                    :string           not null
+#  opening_times           :jsonb
+#  partner_email           :string
+#  partner_name            :string
+#  partner_phone           :string
+#  public_email            :string
+#  public_name             :string
+#  public_phone            :string
+#  slug                    :string
+#  summary                 :string
+#  summary_html            :string
+#  twitter_handle          :string
+#  url                     :string
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  address_id              :bigint
+#  hidden_blame_id         :integer
+#
+# Indexes
+#
+#  index_partners_hidden         (hidden)
+#  index_partners_lower_name_    (lower((name)::text)) UNIQUE
+#  index_partners_on_address_id  (address_id)
+#  index_partners_on_slug        (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (address_id => addresses.id)
+#
 require "rails_helper"
 
 RSpec.describe Partner, type: :model do

--- a/spec/models/service_area_spec.rb
+++ b/spec/models/service_area_spec.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: service_areas
+#
+#  id               :bigint           not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  neighbourhood_id :bigint           not null
+#  partner_id       :bigint           not null
+#
+# Indexes
+#
+#  index_service_areas_on_neighbourhood_id_and_partner_id  (neighbourhood_id,partner_id) UNIQUE
+#  index_service_areas_on_partner_id                       (partner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (neighbourhood_id => neighbourhoods.id)
+#  fk_rails_...  (partner_id => partners.id)
+#
 require "rails_helper"
 
 RSpec.describe ServiceArea do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,5 +1,44 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: sites
+#
+#  id                :bigint           not null, primary key
+#  badge_zoom_level  :string
+#  description       :text
+#  description_html  :string
+#  events_count      :integer          default(0), not null
+#  footer_logo       :string
+#  hero_alttext      :string
+#  hero_image        :string
+#  hero_image_credit :string
+#  hero_text         :string
+#  is_published      :boolean          default(FALSE), not null
+#  logo              :string
+#  name              :string           not null
+#  partners_count    :integer          default(0), not null
+#  place_name        :string
+#  slug              :string           not null
+#  tagline           :string
+#  theme             :string
+#  url               :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  site_admin_id     :bigint
+#
+# Indexes
+#
+#  index_sites_is_published       (is_published)
+#  index_sites_on_events_count    (events_count)
+#  index_sites_on_partners_count  (partners_count)
+#  index_sites_slug               (slug) UNIQUE
+#  index_sites_url                (url)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (site_admin_id => users.id)
+#
 require "rails_helper"
 
 RSpec.describe Site, type: :model do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tags
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string           not null
+#  system_tag  :boolean          default(FALSE), not null
+#  type        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tags_name_type  (name,type) UNIQUE
+#  index_tags_slug_type  (slug,type) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe Tag, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,43 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                      :bigint           not null, primary key
+#  access_token            :string
+#  access_token_expires_at :string
+#  avatar                  :string
+#  current_sign_in_at      :datetime
+#  current_sign_in_ip      :inet
+#  email                   :string           default(""), not null
+#  encrypted_password      :string           default("")
+#  first_name              :string
+#  invitation_accepted_at  :datetime
+#  invitation_created_at   :datetime
+#  invitation_limit        :integer
+#  invitation_sent_at      :datetime
+#  invitation_token        :string
+#  invited_by_type         :string
+#  last_name               :string
+#  last_sign_in_at         :datetime
+#  last_sign_in_ip         :inet
+#  phone                   :string
+#  remember_created_at     :datetime
+#  reset_password_sent_at  :datetime
+#  reset_password_token    :string
+#  role                    :string           not null
+#  sign_in_count           :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  invited_by_id           :integer
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_invitation_token      (invitation_token) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe User, type: :model do


### PR DESCRIPTION
Ran all the newly-merged DX tooling (#3288, #3289) against a real DB on `main`, fixed a bug it surfaced, ran the deferred annotation pass, and tightened CI.

## Checker results (all run for real)

| Checker | Result |
|---|---|
| `bundle exec rubocop` | ✅ 993 files, 0 offenses |
| prettier `format:check` | ✅ clean |
| Brakeman | ✅ 0 warnings |
| `bin/importmap audit` | ✅ no vulnerable packages |
| `database_consistency` (test) | ✅ ran |
| RSpec (models) | ✅ 402 examples, 0 failures |
| strong_migrations / bullet / test-prof | ✅ all load |
| annotaterb | ✅ annotated 48 files, rubocop-clean |
| `bin/ci` | ✅ runs the pipeline (verified through the lint/security steps) |

## What's in this PR

1. **Annotate models, specs & factories** — ran the deferred `annotaterb models` pass (48 files, schema-comment additions only, no behaviour change).
2. **Fix `config/ci.rb`** — its RuboCop step used `bin/rubocop`, whose binstub force-adds `--config .rubocop.yml`, which breaks `inherit_from` of `.rubocop_todo.yml` and reports **~9,000 grandfathered offenses**. CI uses `bundle exec rubocop` (clean), so `bin/ci` failed where CI passes. Switched to `bundle exec rubocop`; verified `bin/ci` now passes `Style: Ruby` (993 files, 0 offenses).
3. **CI** — kept the fast 4-way parallel matrix (routing cloud CI through `bin/ci` would serialise it, ~2-3× slower). Added the one check `config/ci.rb` had that CI lacked — `bin/importmap audit` in the security job — and a comment that the jobs mirror `config/ci.rb`.

## Known, out of scope

`bin/rubocop` itself is a broken binstub (same `--config` issue → ~9,000 phantom offenses). Nothing uses it (CI + pre-commit use `bundle exec rubocop`), so it's left alone here and flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)