### PR TITLE
Install Node from official dist in Docker (fix deploy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,25 @@ RUN apt-get update -qq && \
       imagemagick libmagickwand-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Install Node.js
+# Install Node.js from the official dist (arch-aware, checksum-verified).
 # renovate: datasource=node-version depName=node
 ARG NODE_VERSION=24.17.0
 ENV PATH=/usr/local/node/bin:$PATH
-RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
-    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
-    rm -rf /tmp/node-build-master
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) node_arch="x64" ;; \
+      arm64) node_arch="arm64" ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    tarball="node-v${NODE_VERSION}-linux-${node_arch}.tar.gz"; \
+    curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/${tarball}"; \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" \
+      | grep " ${tarball}\$" | sha256sum -c -; \
+    mkdir -p /usr/local/node; \
+    tar -xzf "${tarball}" -C /usr/local/node --strip-components=1 --no-same-owner; \
+    rm "${tarball}"; \
+    node --version; npm --version
 
 # Install yarn
 RUN npm install -g yarn


### PR DESCRIPTION
## Problem

`main`'s **deploy** job is failing — the Kamal image build dies with:

```
node-build: definition not found: 24.17.0
```

The lint/security/test jobs all pass; only the Docker build fails. Cause: the Dockerfile compiled Node via **nodenv/node-build**, whose definitions lag official releases (its latest 24.x is **24.16.0** — no `24.17.0`). CI's `setup-node` pulls from the **official dist** (which has 24.17.0), so a Renovate bump to 24.17.0 (`8f9e15e3`) broke the image build while CI stayed green.

## Fix

Install Node from the **official distribution** in the Dockerfile instead of compiling via node-build — the same source CI uses. This removes node-build's release lag as an entire class of deploy failure (future Renovate bumps to real releases just work).

- Arch-aware (amd64 / arm64)
- Checksum-verified against `SHASUMS256.txt`
- Extracts to `/usr/local/node` (unchanged `PATH`)
- Node stays **24.17.0** (no version change — `.node-version`, `.nvmrc`, `package.json` already agree)

## Verification

Ran the exact install logic in `debian:trixie-slim` (the image's `deb13`/trixie base):

```
node-v24.17.0-linux-arm64.tar.gz: OK      # checksum verified
node: v24.17.0  npm: 11.13.0              # installs + runs from /usr/local/node/bin
```

Both `x64` and `arm64` tarballs + checksums exist on nodejs.org, so the deploy arch (amd64) builds the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)