### PR TITLE
News v2: visibility follows the partner, news everywhere, RSS, publishing UX (#3308)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,9 @@ notes.md
 # Coverage
 coverage
 
-# ERD pdf as it's messing up diffs
+# ERD output as it's messing up diffs
 erd.pdf
+erd.mmd
 
 # Ignore the dump directory
 dump/

--- a/app/components/admin/save_bar.rb
+++ b/app/components/admin/save_bar.rb
@@ -23,8 +23,9 @@ class Components::Admin::SaveBar < Components::Admin::Base
   end
 
   def view_template(&block)
-    # In simple mode, the content block from ERB is treated as button content
-    @button_blocks << block if block && !@wizard && !@multi_step
+    # In simple and multi-step modes, the content block is treated as extra
+    # button content (rendered before the built-in buttons)
+    @button_blocks << block if block && !@wizard
 
     div(
       class: 'sticky bottom-0 z-40 bg-base-200 border-t border-base-300 py-4 px-4 sm:px-6 -mx-4 sm:-mx-6 mt-6 shadow-[0_-4px_20px_-4px_rgba(0,0,0,0.15)]',
@@ -120,6 +121,10 @@ class Components::Admin::SaveBar < Components::Admin::Base
           data_save_bar_target: 'saveButton',
           data_action: 'click->save-bar#saveOnly'
         ) { t('admin.actions.save') }
+
+        # Extra buttons render after Save so pressing Enter in a field
+        # (implicit submission uses the first submit button) stays a plain save
+        @button_blocks.each(&:call)
 
         button(
           type: 'submit',

--- a/app/components/admin/tab_form.rb
+++ b/app/components/admin/tab_form.rb
@@ -9,7 +9,9 @@ class Components::Admin::TabForm < Components::Admin::Base
   prop :settings_hash, _Nilable(String), default: nil
   prop :preview_hash, _Nilable(String), default: nil
 
-  def view_template
+  # An optional block renders as extra buttons in the save bar, next to Save
+  # (e.g. the article form's Publish/Unpublish action)
+  def view_template(&)
     div(class: 'tabs tabs-lift') do
       visible_tabs.each_with_index do |tab, index|
         div(class: 'tab flex-1 cursor-default') if tab[:spacer_before]
@@ -35,7 +37,8 @@ class Components::Admin::TabForm < Components::Admin::Base
       tab_name: @tab_name,
       settings_hash: @settings_hash,
       preview_hash: @preview_hash,
-      storage_key: @storage_key
+      storage_key: @storage_key,
+      &
     )
   end
 

--- a/app/components/directory/news_row.rb
+++ b/app/components/directory/news_row.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# A news article as a single row for directory-styled lists: date badge,
+# linked title and, optionally, a summary line and partner/area attribution.
+# Named News* (not Article*) so the component namespace stays clear of the
+# Article model.
+class Components::Directory::NewsRow < Components::Directory::Base
+  prop :article, ::Article
+  # The partner page the row is shown on, so we don't repeat its name
+  prop :context_partner, _Nilable(::Partner), default: nil
+  # Area breadcrumb for the article's first partner (PartnersQuery.area_labels)
+  prop :area, _Nilable(String), default: nil
+  prop :summary, _Boolean, default: false
+
+  def view_template
+    div(class: 'grid grid-cols-[64px_1fr] gap-4 items-start py-3 border-b border-rules') do
+      render_date_badge
+      render_body
+    end
+  end
+
+  private
+
+  def render_date_badge
+    date = @article.published_at
+    div(class: 'font-serif text-center bg-home-background-3 rounded-lg py-1 px-2') do
+      div(class: 'text-[1.7rem] leading-none font-regular tracking-tight') { date.day.to_s }
+      div(class: 'font-sans text-2xs uppercase tracking-widest text-tertiary font-extra-bold mt-1') do
+        plain date.strftime('%b %Y').upcase
+      end
+    end
+  end
+
+  def render_body
+    div do
+      div(class: 'font-bold text-lg leading-tight mb-1') do
+        link_to(@article.title, news_path(@article),
+                class: 'no-underline text-foreground hover:border-b-2 hover:border-primary',
+                data: { turbo_frame: '_top' })
+      end
+
+      div(class: 'text-foreground leading-snug mt-1 line-clamp-2') { summary_text } if @summary && summary_text.present?
+
+      div(class: 'flex flex-wrap gap-x-3 gap-y-0.5 text-sm text-tertiary mt-1') do
+        render_meta_partners if attributed_partners.any?
+        render_meta_area if @area.present?
+      end
+    end
+  end
+
+  def render_meta_partners
+    span(class: 'inline-flex items-center gap-1') do
+      render_icon(:partner)
+      attributed_partners.each_with_index do |partner, index|
+        plain ', ' if index.positive?
+        link_to(partner.name.truncate(30), partner_path(partner),
+                class: 'text-foreground underline decoration-primary decoration-2 underline-offset-2 hover:text-foreground/80',
+                data: { turbo_frame: '_top' })
+      end
+    end
+  end
+
+  def render_meta_area
+    span(class: 'inline-flex items-center gap-1') do
+      render_icon(:event_place)
+      plain @area
+    end
+  end
+
+  def render_icon(name)
+    raw(view_context.icon(name, size: nil, css_class: 'w-3.5 h-3.5 text-tertiary opacity-55 shrink-0'))
+  end
+
+  def attributed_partners
+    @attributed_partners ||= @article.partners.reject { |partner| partner == @context_partner }
+  end
+
+  def summary_text
+    @summary_text ||= view_context.article_summary_text(@article)
+  end
+end

--- a/app/components/directory/partner_sidebar.rb
+++ b/app/components/directory/partner_sidebar.rb
@@ -41,7 +41,9 @@ class Components::Directory::PartnerSidebar < Components::Directory::Base
           plain t('directory.sidebar.partnerships_description', name: @partner.name)
         end
         Array(@containing_sites).each do |site_record|
-          a(href: "https://#{site_record.slug}.placecal.org",
+          # Relative to the current host so the links work in development
+          # (slug.lvh.me) as well as production (slug.placecal.org)
+          a(href: root_url(subdomain: site_record.slug),
             class: 'flex items-center justify-between py-2 no-underline text-foreground hover:bg-background/50 transition-colors rounded px-1') do
             div do
               div(class: 'font-extra-bold text-sm') { site_record.name }

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -37,11 +37,12 @@ module Admin
     end
 
     def create
-      @article = Article.new(permitted_attributes(Article))
+      attrs = permitted_attributes(Article)
+      @article = Article.new(attrs)
 
       authorize @article
 
-      if @article.save
+      if save_with_required_partner(attrs)
         flash[:success] = 'Article has been created'
         redirect_to admin_articles_path
       else
@@ -53,7 +54,7 @@ module Admin
     def update
       authorize @article
 
-      if @article.update(permitted_attributes(@article))
+      if save_with_required_partner(permitted_attributes(@article))
         flash[:success] = 'Article was saved successfully'
         redirect_to edit_admin_article_path(@article)
       else
@@ -73,6 +74,27 @@ module Admin
 
     def set_article
       @article = Article.friendly.find(params[:id])
+    end
+
+    # Visibility follows the partner (issue #3308): an article with no partners
+    # is invisible on every site, so non-staff authors must link at least one.
+    # Root and editor may publish partner-less platform posts (consumed via the
+    # tag-based API). Checked against the submitted params, before assignment,
+    # because assigning partner_ids to a persisted article writes immediately.
+    def save_with_required_partner(attrs)
+      if missing_required_partner?(attrs)
+        @article.errors.add(:base, t('admin.articles.errors.partner_required'))
+        false
+      else
+        @article.update(attrs)
+      end
+    end
+
+    def missing_required_partner?(attrs)
+      return false if current_user.root? || current_user.editor?
+      return false unless @article.new_record? || attrs.key?(:partner_ids)
+
+      Array(attrs[:partner_ids]).compact_blank.empty?
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -258,18 +258,24 @@ class ApplicationController < ActionController::Base
 
   def directory_navigation
     [
-      ['Home', root_path],
-      ['Partners', partners_path],
-      ['Partnerships', partnerships_path],
-      ['Events', events_path]
+      [t('navigation.home'), root_path],
+      [t('navigation.partners'), partners_path],
+      [t('navigation.partnerships'), partnerships_path],
+      [t('navigation.events'), events_path],
+      [t('navigation.news'), news_index_path]
     ]
   end
 
   def sub_site_navigation
-    [
-      ['Home', root_path],
-      ['Events', events_path],
-      ['Partners', partners_path]
+    nav = [
+      [t('navigation.home'), root_path],
+      [t('navigation.events'), events_path],
+      [t('navigation.partners'), partners_path]
     ]
+    # No sad empty News tab: only sites whose partners have published news get
+    # one. current_site is nil on the admin subdomain, which also builds this
+    # nav (and never renders it).
+    nav << [t('navigation.news'), news_index_path] if current_site&.news_article_count&.positive?
+    nav
   end
 end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -14,12 +14,10 @@ class NewsController < ApplicationController
 
     @article_count = Article
                      .for_site(@site)
-                     .published
                      .count
 
     @articles = Article
                 .for_site(@site)
-                .published
                 .by_publish_date
                 .offset(@offset)
                 .limit(ARTICLES_PER_PAGE)

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -10,10 +10,15 @@ class NewsController < ApplicationController
   before_action :set_partner_filter, only: %i[index]
 
   def index
-    if directory_request?
-      render_directory_index
-    else
-      render_site_index
+    respond_to do |format|
+      format.html do
+        if directory_request?
+          render_directory_index
+        else
+          render_site_index
+        end
+      end
+      format.rss { render_feed }
     end
   end
 
@@ -55,6 +60,25 @@ class NewsController < ApplicationController
     render Views::News::Index.new(
       articles: @articles, site: @site, partner: @partner, next_offset: @next_offset
     )
+  end
+
+  # RSS 2.0 (issue #3308 Phase 3): same scoping as the HTML index — per site,
+  # per partner via ?partner=, or platform-wide on the directory
+  def render_feed
+    @articles = base_articles.includes(:partners).limit(ARTICLES_PER_PAGE)
+    @feed_title = feed_title
+    @feed_description = @site&.tagline.presence || t('news.feed.description')
+
+    render :index, layout: false
+  end
+
+  def feed_title
+    name = @site&.name || 'PlaceCal'
+    if @partner
+      t('news.feed.title_for_partner', name: name, partner: @partner.name)
+    else
+      t('news.feed.title', name: name)
+    end
   end
 
   def render_directory_index

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,38 +1,69 @@
 # frozen_string_literal: true
 
 class NewsController < ApplicationController
+  include Pagy::Offset::Method
+
   ARTICLES_PER_PAGE = 20
 
   before_action :set_article, only: %i[show]
   before_action :set_site
-  before_action :redirect_from_directory
+  before_action :set_partner_filter, only: %i[index]
 
   def index
-    @offset = params[:offset].to_i
-    @offset = 0 if @offset.negative?
-    @next_offset = @offset + ARTICLES_PER_PAGE
-
-    @article_count = Article
-                     .for_site(@site)
-                     .count
-
-    @articles = Article
-                .for_site(@site)
-                .by_publish_date
-                .offset(@offset)
-                .limit(ARTICLES_PER_PAGE)
-
-    render Views::News::Index.new(articles: @articles, site: @site, next_offset: @next_offset)
+    if directory_request?
+      render_directory_index
+    else
+      render_site_index
+    end
   end
 
   def show
-    render Views::News::Show.new(article: @article, site: @site)
+    if directory_request?
+      render Views::Directory::News::Show.new(article: @article)
+    else
+      render Views::News::Show.new(article: @article, site: @site)
+    end
   end
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
   def set_article
     @article = Article.published.friendly.find(params[:id])
+  end
+
+  def set_partner_filter
+    @partner = Partner.friendly.find(params[:partner]) if params[:partner].present?
+  end
+
+  # Published articles for this host (site-scoped or platform-wide on the
+  # directory), optionally narrowed to one partner, newest first
+  def base_articles
+    articles = directory_request? ? Article.published : Article.for_site(@site)
+    articles = articles.for_partner(@partner) if @partner
+    articles.by_publish_date
+  end
+
+  def render_site_index
+    @offset = params[:offset].to_i
+    @offset = 0 if @offset.negative?
+    @next_offset = @offset + ARTICLES_PER_PAGE
+
+    articles = base_articles
+    @article_count = articles.count
+    @articles = articles.offset(@offset).limit(ARTICLES_PER_PAGE)
+
+    render Views::News::Index.new(
+      articles: @articles, site: @site, partner: @partner, next_offset: @next_offset
+    )
+  end
+
+  def render_directory_index
+    articles = base_articles.includes(partners: [{ address: :neighbourhood }, { service_areas: :neighbourhood }])
+    @pagy, @articles = pagy(articles, limit: ARTICLES_PER_PAGE)
+    @area_labels = PartnersQuery.area_labels(@articles.flat_map(&:partners).uniq)
+
+    render Views::Directory::News::Index.new(
+      articles: @articles, pagy: @pagy, partner: @partner, area_labels: @area_labels
+    )
   end
 end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -61,6 +61,12 @@ class PartnersController < ApplicationController
 
     @containing_sites = Site.sites_that_contain_partner(@partner) if directory_request?
 
+    # Latest news (issue #3308 Phase 2): up to 3 recent posts, with a count so
+    # the view knows whether to offer "more news from X"
+    news_scope = Article.published.for_partner(@partner).by_publish_date
+    @news_total = news_scope.count
+    @news_articles = news_scope.limit(3)
+
     respond_to do |format|
       format.html do
         view_class = directory_request? ? Views::Directory::Partners::Show : Views::Partners::Show
@@ -70,7 +76,8 @@ class PartnersController < ApplicationController
           period: @period, date_period: @date_period, sort: @sort,
           repeating: @repeating, no_event_message: @no_event_message,
           paginator: @paginator, show_monthly: @show_monthly || false,
-          containing_sites: @containing_sites
+          containing_sites: @containing_sites,
+          news_articles: @news_articles, news_total: @news_total
         )
       end
       format.ics do

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -6,6 +6,14 @@ module ArticlesHelper
     policy_scope(Partner).all.order(:name).pluck(:name, :id)
   end
 
+  # Partners the current user may attach an article to. Root and editor manage
+  # all articles (issue #2045), so they can attach any partner; everyone else
+  # is limited to the partners they administer.
+  def options_for_article_partners
+    scope = current_user.root? || current_user.editor? ? Partner.all : policy_scope(Partner)
+    scope.order(:name).pluck(:name, :id)
+  end
+
   def article_partner_links(article)
     article.partners.map do |partner|
       link_to(partner.name, partner_path(partner))

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -128,7 +128,9 @@ class Article < ApplicationRecord
   private
 
   # ==== Private methods ====
+  # Publishing stamps the current time unless a publication date was set
+  # explicitly (backdating, seeds); unpublishing clears it
   def update_published_at
-    self.published_at = is_draft ? nil : Time.current
+    self.published_at = is_draft ? nil : (published_at || Time.current)
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -74,63 +74,19 @@ class Article < ApplicationRecord
     joins(:article_tags).where(article_tags: { tag: tag_ids })
   }
 
+  # Published articles visible on a site: an article is visible iff at least
+  # one of its partners is on the site (per PartnersQuery — address OR service
+  # area in the site's neighbourhoods, strict partnership-tag filter on tagged
+  # sites, hidden partners excluded). News follows the partner, exactly like
+  # events. Article tags play no part in site visibility — they remain a
+  # curation tool for the tag-based GraphQL queries.
   scope :for_site, lambda { |site|
-    # this is a bit complicated but necessary
-    # the main problem to overcome is that we want articles by tag OR location
-    # (emphasis on OR).
-    #
-    # in simple AR land we would just chain scope methods like
-    #   `Article.by_tag(tags).by_location(neighbourhoods)` and be done with it
-    # each scope would set up its `joins` to pull in tables and its `wheres`
-    # to filter based on those joins. simple!
-    # but unfortunately these scopes get combined with 'AND' clauses in
-    # the `where` part.
-    #
-    # so what this does is build up the query for tags and locations like
-    # we were chaining scope methods without the conditions. we store
-    # the conditions as (clause, params) in an array as we go. when we reach
-    # the end we then extend the scope with a `where` clause that combines
-    # everything with `OR' as is needed and then return that to the
-    # calling code as a regular scope for further chaining.
-    #
-    # this also also allows us to skip an entire chunk of query if the
-    # site has no tags or locations.
+    site_partners = PartnersQuery.new(site: site).call.reorder(nil)
 
-    site_neighbourhood_ids = site.owned_neighbourhoods.pluck(:id)
-    site_tag_ids = site.tags.pluck(:id)
-
-    # if site has no tags or neighbourhoods then just return nothing to caller
-    return none if site_neighbourhood_ids.empty? && site_tag_ids.empty?
-
-    scope = all
-
-    where_fragments = []
-    where_params = []
-
-    # articles by neighbourhood
-    if site_neighbourhood_ids.any?
-      # TODO: service areas?
-      scope = scope
-              .joins('LEFT OUTER JOIN article_partners ON articles.id=article_partners.article_id')
-              .joins('LEFT OUTER JOIN partners ON article_partners.partner_id = partners.id')
-              .joins('LEFT OUTER JOIN addresses ON partners.address_id = addresses.id')
-      where_fragments << 'addresses.neighbourhood_id IN (?)'
-      where_params << site_neighbourhood_ids
-    end
-
-    # articles by tag
-    if site_tag_ids.any?
-      scope = scope
-              .joins(' LEFT OUTER JOIN article_tags ON articles.id=article_tags.article_id')
-      where_fragments << 'article_tags.tag_id IN (?)'
-      where_params << site_tag_ids
-    end
-
-    # combine conditions with params to extend the scope
-    scope = scope
-            .where("(#{where_fragments.join(' OR ')})", *where_params)
-
-    scope.distinct('articles.id')
+    published
+      .joins(:partners)
+      .where(partners: { id: site_partners.select(:id) })
+      .distinct
   }
 
   # ==== Callbacks ====

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -63,6 +63,10 @@ class Article < ApplicationRecord
   scope :published, -> { where is_draft: false }
   scope :by_publish_date, -> { order(published_at: :desc) }
 
+  scope :for_partner, lambda { |partner|
+    joins(:article_partners).where(article_partners: { partner_id: partner.id })
+  }
+
   scope :global_newsfeed, -> { published.order(published_at: :desc) }
 
   scope :with_partner_tag, lambda { |tag_id|
@@ -103,6 +107,17 @@ class Article < ApplicationRecord
   # @return [String, nil] high-resolution header image URL
   def highres_image
     article_image&.highres&.url
+  end
+
+  # Image for social-share cards: the article's own image, falling back to the
+  # first partner's. Callers fall through to the site/directory default when nil.
+  #
+  # @return [String, nil] image path
+  def og_image_path
+    return highres_image if article_image.present?
+
+    partner_with_image = partners.detect(&:image?)
+    partner_with_image&.image&.url(:standard)
   end
 
   # @return [Array] FriendlyId slug candidates

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -9,7 +9,7 @@
 #  body          :text             not null
 #  body_html     :string
 #  is_draft      :boolean          default(TRUE), not null
-#  published_at  :date
+#  published_at  :datetime
 #  slug          :string
 #  title         :text             not null
 #  created_at    :datetime         not null
@@ -18,8 +18,9 @@
 #
 # Indexes
 #
-#  index_articles_on_author_id  (author_id)
-#  index_articles_on_slug       (slug) UNIQUE
+#  index_articles_on_author_id     (author_id)
+#  index_articles_on_published_at  (published_at)
+#  index_articles_on_slug          (slug) UNIQUE
 #
 # Foreign Keys
 #
@@ -35,7 +36,7 @@ class Article < ApplicationRecord
   attribute :body,         :text
   attribute :body_html,    :string # populated by HtmlRenderCache
   attribute :is_draft,     :boolean, default: true
-  attribute :published_at, :date
+  attribute :published_at, :datetime
   attribute :slug,         :string
   attribute :title,        :text
 
@@ -113,6 +114,6 @@ class Article < ApplicationRecord
 
   # ==== Private methods ====
   def update_published_at
-    self.published_at = is_draft ? nil : DateTime.now
+    self.published_at = is_draft ? nil : Time.current
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -170,10 +170,7 @@ class Site < ApplicationRecord
 
   # @return [Integer] published articles count for this site
   def news_article_count
-    Article
-      .for_site(self)
-      .published
-      .count
+    Article.for_site(self).count
   end
 
   # @return [Boolean] whether neighbourhood badges should be shown

--- a/app/views/admin/articles/form.rb
+++ b/app/views/admin/articles/form.rb
@@ -27,8 +27,8 @@ class Views::Admin::Articles::Form < Views::Admin::Base
     div(class: 'card bg-base-100 border border-base-300 shadow-sm') do
       div(class: 'card-body p-6') do
         SectionHeader(
-          title: 'Image',
-          description: 'Image will be cropped to 16:9 ratio.',
+          title: t('admin.articles.image.title'),
+          description: t('admin.articles.image.description'),
           margin: 4
         )
         render Views::Admin::Articles::FormTabImage.new(form: form)
@@ -38,16 +38,26 @@ class Views::Admin::Articles::Form < Views::Admin::Base
     div(class: 'card bg-base-100 border border-base-300 shadow-sm') do
       div(class: 'card-body p-6') do
         SectionHeader(
-          title: 'References',
-          description: 'Link this article to partners and partnerships.',
+          title: t('admin.articles.references.title'),
+          description: t('admin.articles.references.description'),
           margin: 4
         )
         render Views::Admin::Articles::FormTabReferences.new(form: form)
       end
     end
 
+    # Clear "save draft" vs "publish" actions instead of a checkbox buried in
+    # a settings tab (issue #3308 Phase 4). The buttons submit is_draft; save
+    # draft comes first so implicit (Enter-key) submission never publishes.
     SaveBar() do
-      raw form.submit(t('admin.actions.save'), class: 'btn bg-placecal-orange hover:bg-orange-600 text-white border-placecal-orange')
+      button(type: 'submit', name: 'article[is_draft]', value: 'true',
+             class: 'btn bg-base-300 hover:bg-base-content/20 text-base-content border-base-300') do
+        plain t('admin.articles.actions.save_draft')
+      end
+      button(type: 'submit', name: 'article[is_draft]', value: 'false',
+             class: 'btn bg-placecal-orange hover:bg-orange-600 text-white border-placecal-orange') do
+        plain t('admin.articles.actions.publish')
+      end
     end
   end
 
@@ -64,6 +74,26 @@ class Views::Admin::Articles::Form < Views::Admin::Base
       settings_hash: 'settings',
       form: form,
       record: article
-    )
+    ) do
+      render_publish_toggle
+    end
+  end
+
+  # Publish/unpublish lives in the always-visible save bar rather than a
+  # checkbox in the settings tab (issue #3308 Phase 4)
+  def render_publish_toggle
+    if article.is_draft
+      button(type: 'submit', name: 'article[is_draft]', value: 'false',
+             class: 'btn bg-placecal-orange hover:bg-orange-600 text-white border-placecal-orange',
+             data: { action: 'click->save-bar#saveOnly' }) do
+        plain t('admin.articles.actions.publish')
+      end
+    else
+      button(type: 'submit', name: 'article[is_draft]', value: 'true',
+             class: 'btn btn-ghost border border-base-300 text-base-content',
+             data: { action: 'click->save-bar#saveOnly' }) do
+        plain t('admin.articles.actions.unpublish')
+      end
+    end
   end
 end

--- a/app/views/admin/articles/form_tab_references.rb
+++ b/app/views/admin/articles/form_tab_references.rb
@@ -30,7 +30,7 @@ class Views::Admin::Articles::FormTabReferences < Views::Admin::Base
       StackedListSelector(
         field_name: 'article[partner_ids][]',
         items: article.partners,
-        options: disabled_fields.include?(:partner_ids) ? [] : options_for_partners,
+        options: disabled_fields.include?(:partner_ids) ? [] : options_for_article_partners,
         icon_name: :partner,
         icon_color: 'bg-emerald-100 text-emerald-600',
         empty_text: t('admin.empty.none_assigned', items: Partner.model_name.human(count: 2).downcase),

--- a/app/views/admin/articles/form_tab_references.rb
+++ b/app/views/admin/articles/form_tab_references.rb
@@ -9,7 +9,9 @@ class Views::Admin::Articles::FormTabReferences < Views::Admin::Base
 
     div(class: 'grid grid-cols-1 lg:grid-cols-2 gap-8') do
       render_partners_section(article, disabled_fields)
-      render_partnerships_section(article, disabled_fields)
+      # Partnership tags are a root/editor curation tool (they feed the
+      # tag-based API, not site visibility) — hidden from partner admins
+      render_partnerships_section(article, disabled_fields) if current_user.root? || current_user.editor?
     end
   end
 
@@ -23,7 +25,7 @@ class Views::Admin::Articles::FormTabReferences < Views::Admin::Base
         end
         div do
           h2(class: 'text-lg font-semibold') { Partner.model_name.human(count: 2) }
-          p(class: 'text-sm text-gray-600 mt-0.5') { 'Link this article to one or more partners.' }
+          p(class: 'text-sm text-gray-600 mt-0.5') { t('admin.articles.references.partners_hint') }
         end
       end
 
@@ -49,7 +51,7 @@ class Views::Admin::Articles::FormTabReferences < Views::Admin::Base
         end
         div do
           h2(class: 'text-lg font-semibold') { Partnership.model_name.human(count: 2) }
-          p(class: 'text-sm text-gray-600 mt-0.5') { 'Link this article to partnerships for filtering and organization.' }
+          p(class: 'text-sm text-gray-600 mt-0.5') { t('admin.articles.references.partnerships_hint') }
         end
       end
 

--- a/app/views/admin/articles/form_tab_settings.rb
+++ b/app/views/admin/articles/form_tab_settings.rb
@@ -20,24 +20,44 @@ class Views::Admin::Articles::FormTabSettings < Views::Admin::Base
       FormCard(
         icon: :newspaper,
         title: t('admin.sections.publishing'),
-        description: 'Control when and if this article is visible on PlaceCal.'
+        description: status_hint(article)
       ) do
-        fieldset(class: 'fieldset') do
-          raw form.input(:is_draft, wrapper: :tw_boolean,
-                                    as: :boolean,
-                                    checked_value: false,
-                                    unchecked_value: true,
-                                    label: 'Publish this article')
-        end
+        render_status_line(article)
 
         if !article.new_record? && disabled_fields.exclude?(:published_at)
           fieldset(class: 'fieldset mt-4') do
-            legend(class: 'fieldset-legend') { 'Publication Date' }
+            legend(class: 'fieldset-legend') { t('admin.articles.fields.published') }
             raw form.date_field(:published_at, class: 'input input-bordered w-full max-w-xs')
           end
         end
       end
     end
+  end
+
+  def status_hint(article)
+    article.is_draft ? t('admin.articles.status.draft_hint') : t('admin.articles.status.published_hint')
+  end
+
+  def render_status_line(article)
+    div(class: 'flex items-center gap-3') do
+      if article.is_draft
+        span(class: 'badge badge-ghost') { t('admin.articles.status.draft') }
+      else
+        span(class: 'badge badge-success') { t('admin.articles.status.published') }
+        span(class: 'text-sm text-gray-600') { article.published_at.strftime('%-d %b %Y') } if article.published_at.present?
+        a(href: live_article_path, target: '_blank', rel: 'noopener',
+          class: 'link text-placecal-teal-dark text-sm') do
+          plain t('admin.articles.actions.view_live')
+        end
+      end
+    end
+  end
+
+  # The article on the nationwide directory, which shows every published
+  # article — a link that works no matter which sites the partner is on
+  def live_article_path
+    article = form.object
+    news_url(article, subdomain: false)
   end
 
   def render_danger_zone(article)

--- a/app/views/admin/articles/form_tab_text.rb
+++ b/app/views/admin/articles/form_tab_text.rb
@@ -83,6 +83,13 @@ class Views::Admin::Articles::FormTabText < Views::Admin::Base
         else
           span(class: 'text-gray-600 italic') { t('admin.articles.fields.not_published') }
         end
+
+        unless article.is_draft
+          a(href: news_url(article, subdomain: false), target: '_blank', rel: 'noopener',
+            class: 'link text-placecal-teal-dark text-sm ml-2') do
+            plain t('admin.articles.actions.view_live')
+          end
+        end
       end
     end
   end
@@ -94,12 +101,14 @@ class Views::Admin::Articles::FormTabText < Views::Admin::Base
       }
 
       p(class: 'text-sm text-gray-600 mb-3') do
-        plain 'This field accepts '
+        plain t('admin.articles.markdown.hint')
+        plain ' '
         a(
           href: 'https://www.markdownguide.org/basic-syntax/',
           class: 'link underline text-placecal-teal-dark hover:no-underline',
-          target: '_blank'
-        ) { 'Markdown syntax' }
+          target: '_blank',
+          rel: 'noopener'
+        ) { t('admin.articles.markdown.hint_link') }
         plain '.'
       end
 

--- a/app/views/admin/base.rb
+++ b/app/views/admin/base.rb
@@ -15,6 +15,7 @@ class Views::Admin::Base < Views::Base
   register_value_helper :options_for_organiser
   register_value_helper :options_for_location
   register_value_helper :options_for_partners
+  register_value_helper :options_for_article_partners
   register_value_helper :options_for_users
   register_value_helper :options_for_user_partnerships
   register_value_helper :permitted_options_for_partners

--- a/app/views/directory/news/index.rb
+++ b/app/views/directory/news/index.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class Views::Directory::News::Index < Views::Base
+  prop :articles, _Interface(:each)
+  prop :pagy, Pagy::Offset
+  prop :partner, _Nilable(::Partner), default: nil
+  # Area breadcrumbs keyed by partner id (PartnersQuery.area_labels)
+  prop :area_labels, Hash, default: -> { {} }
+
+  def view_template
+    content_for(:title) { hero_title }
+    content_for(:description) { t('directory.news.index.description') }
+
+    Directory::PageHero(
+      title: hero_title,
+      kicker: kicker,
+      subtitle: t('directory.news.index.hero_subtitle'),
+      breadcrumb_label: t('navigation.news')
+    )
+
+    div(class: 'container-public py-6') do
+      article_list.each do |article|
+        Directory::NewsRow(
+          article: article,
+          summary: true,
+          area: area_label_for(article)
+        )
+      end
+
+      render_empty_state if article_list.empty?
+
+      Directory::Paginator(pagy: @pagy)
+    end
+  end
+
+  private
+
+  def article_list
+    @article_list ||= @articles.to_a
+  end
+
+  def hero_title
+    if @partner
+      t('news.index.title_for_partner', partner: @partner.name)
+    else
+      t('directory.news.index.hero_title')
+    end
+  end
+
+  def kicker
+    kicker = t('directory.news.index.results.total', count: @pagy.count)
+    kicker += t('directory.news.index.results.page', page: @pagy.page, pages: @pagy.pages) if @pagy.pages > 1
+    kicker
+  end
+
+  def area_label_for(article)
+    partner = article.partners.first
+    partner && @area_labels[partner.id]
+  end
+
+  def render_empty_state
+    Directory::EmptyState(
+      message: t('directory.news.index.empty'),
+      link_text: (t('directory.filters.clear') if @partner),
+      link_href: (news_index_path if @partner)
+    )
+  end
+end

--- a/app/views/directory/news/index.rb
+++ b/app/views/directory/news/index.rb
@@ -10,6 +10,7 @@ class Views::Directory::News::Index < Views::Base
   def view_template
     content_for(:title) { hero_title }
     content_for(:description) { t('directory.news.index.description') }
+    content_for(:rss_feed) { rss_feed_path }
 
     Directory::PageHero(
       title: hero_title,
@@ -30,6 +31,11 @@ class Views::Directory::News::Index < Views::Base
       render_empty_state if article_list.empty?
 
       Directory::Paginator(pagy: @pagy)
+
+      p(class: 'mt-6 text-sm') do
+        link_to t('directory.news.index.rss'), rss_feed_path,
+                class: 'with-no-sass text-tertiary underline decoration-primary decoration-2 underline-offset-2 hover:text-foreground'
+      end
     end
   end
 
@@ -56,6 +62,10 @@ class Views::Directory::News::Index < Views::Base
   def area_label_for(article)
     partner = article.partners.first
     partner && @area_labels[partner.id]
+  end
+
+  def rss_feed_path
+    news_index_path(**{ format: :rss, partner: @partner&.slug }.compact)
   end
 
   def render_empty_state

--- a/app/views/directory/news/show.rb
+++ b/app/views/directory/news/show.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class Views::Directory::News::Show < Views::Base
+  register_output_helper :article_partner_links
+  register_value_helper :article_summary_text
+
+  prop :article, Article, reader: :private
+
+  def view_template
+    set_content_for_tags
+
+    div(vocab: 'http://schema.org/', typeof: 'Article') do
+      Directory::PageHero(
+        title: article.title,
+        kicker: kicker,
+        breadcrumb_label: t('navigation.news'),
+        breadcrumb_path: news_index_path
+      )
+
+      div(class: 'container-public py-8') do
+        div(class: 'max-w-(--width-prose-lg)') do
+          render_byline
+
+          img(src: article.article_image.url, alt: '', class: 'rounded-lg mb-6 max-w-full') if article.article_image.present?
+
+          div(class: 'markdown-content text-base leading-relaxed', property: 'articleBody') do
+            raw safe(article.body_html.to_s)
+          end
+
+          div(class: 'mt-8') do
+            link_to t('directory.news.show.back'), news_index_path,
+                    class: 'with-no-sass text-foreground underline decoration-primary decoration-2 underline-offset-2 hover:text-foreground/80'
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def set_content_for_tags
+    content_for(:title) { article.title }
+    content_for(:description) { article_summary_text(article) }
+
+    og_image = article.og_image_path
+    return if og_image.blank?
+
+    content_for(:image) { og_image }
+    content_for(:image_alt) { article.title }
+  end
+
+  def kicker
+    date = article.published_at.strftime('%-d %B %Y')
+    author = article.author_name
+    author.present? ? "#{date} · #{t('directory.news.show.by')} #{author}" : date
+  end
+
+  def render_byline
+    return if article.partners.blank?
+
+    p(class: 'text-sm text-tertiary mb-6', property: 'publisher') do
+      article_partner_links(article)
+      plain '.'
+    end
+  end
+end

--- a/app/views/directory/partners/show.rb
+++ b/app/views/directory/partners/show.rb
@@ -16,6 +16,7 @@ class Views::Directory::Partners::Show < Views::Partners::Show
         div do
           render_directory_about
           render_directory_events
+          render_directory_news
           render_directory_location
           render_directory_accessibility
         end
@@ -41,6 +42,25 @@ class Views::Directory::Partners::Show < Views::Partners::Show
       end
       Directory::OverflowToggle(items: flat.drop(10), label_key: 'directory.partners.show.show_more_events') do |event|
         Directory::EventRow(event: event, context_partner: partner)
+      end
+    end
+  end
+
+  def render_directory_news
+    return if news_articles.blank?
+
+    div(class: 'py-4') do
+      h2(class: 'udl udl--fw allcaps text-xl') { t('directory.partners.show.latest_news') }
+      news_articles.each do |article|
+        Directory::NewsRow(article: article, context_partner: partner)
+      end
+
+      if news_total > news_articles.size
+        p(class: 'mt-3') do
+          link_to t('directory.partners.show.more_news', name: partner.name),
+                  news_index_path(partner: partner.slug),
+                  class: 'with-no-sass text-foreground underline decoration-primary decoration-2 underline-offset-2 hover:text-foreground/80'
+        end
       end
     end
   end

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -114,6 +114,8 @@ class Views::Layouts::Application < Phlex::HTML
     link(rel: 'canonical', href: request.original_url)
     meta(name: 'robots', content: 'noarchive')
 
+    link(rel: 'alternate', type: 'application/rss+xml', title: compute_title, href: content_for(:rss_feed)) if content_for?(:rss_feed)
+
     json_ld = site ? site.to_json_ld(base_url: request.base_url) : Site.directory_json_ld(request.base_url)
     script(type: 'application/ld+json') { raw safe(json_ld.to_json) }
     return unless content_for?(:json_ld)

--- a/app/views/news/index.rb
+++ b/app/views/news/index.rb
@@ -11,6 +11,7 @@ class Views::News::Index < Views::Base
 
   def view_template
     content_for(:title) { page_title }
+    content_for(:rss_feed) { rss_feed_path }
 
     Hero(page_title, site.tagline)
 
@@ -22,6 +23,10 @@ class Views::News::Index < Views::Base
 
     p(class: 'articles__pagination') do
       link_to t('news.index.older'), news_index_path(**pagination_params) if articles.count == NewsController::ARTICLES_PER_PAGE
+    end
+
+    p(class: 'articles__rss') do
+      link_to t('news.index.rss'), rss_feed_path
     end
   end
 
@@ -37,6 +42,10 @@ class Views::News::Index < Views::Base
 
   def pagination_params
     { offset: next_offset, partner: partner&.slug }.compact
+  end
+
+  def rss_feed_path
+    news_index_path(**{ format: :rss, partner: partner&.slug }.compact)
   end
 
   def render_article_card(article)

--- a/app/views/news/index.rb
+++ b/app/views/news/index.rb
@@ -6,12 +6,13 @@ class Views::News::Index < Views::Base
 
   prop :articles, ActiveRecord::Relation, reader: :private
   prop :site, Site, reader: :private
+  prop :partner, _Nilable(Partner), reader: :private, default: nil
   prop :next_offset, _Nilable(Integer), reader: :private
 
   def view_template
-    content_for(:title) { 'News from your area' }
+    content_for(:title) { page_title }
 
-    Hero('News from your area', site.tagline)
+    Hero(page_title, site.tagline)
 
     div(class: 'articles') do
       articles.each do |article|
@@ -20,11 +21,23 @@ class Views::News::Index < Views::Base
     end
 
     p(class: 'articles__pagination') do
-      link_to 'Older news items', "?offset=#{next_offset}" if articles.count == NewsController::ARTICLES_PER_PAGE
+      link_to t('news.index.older'), news_index_path(**pagination_params) if articles.count == NewsController::ARTICLES_PER_PAGE
     end
   end
 
   private
+
+  def page_title
+    if partner
+      t('news.index.title_for_partner', partner: partner.name)
+    else
+      t('news.index.title')
+    end
+  end
+
+  def pagination_params
+    { offset: next_offset, partner: partner&.slug }.compact
+  end
 
   def render_article_card(article)
     div(class: 'articles__article-card g') do
@@ -56,7 +69,7 @@ class Views::News::Index < Views::Base
           end
         end
 
-        p { link_to 'Find out more', news_path(article), class: 'btn btn--alt btn--mt' }
+        p { link_to t('news.index.read_more'), news_path(article), class: 'btn btn--alt btn--mt' }
       end
     end
   end

--- a/app/views/news/index.rss.builder
+++ b/app/views/news/index.rss.builder
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss(version: '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom') do
+  xml.channel do
+    xml.title @feed_title
+    xml.description @feed_description
+    xml.link news_index_url
+    xml.tag!('atom:link', href: request.original_url, rel: 'self', type: 'application/rss+xml')
+    xml.language I18n.locale.to_s
+
+    @articles.each do |article|
+      xml.item do
+        xml.title article.title
+        xml.link news_url(article)
+        xml.guid news_url(article)
+        xml.pubDate article.published_at.rfc822
+        xml.description { xml.cdata!(article.body_html.to_s) }
+        article.partners.each { |partner| xml.category partner.name }
+
+        if article.article_image.present? && (image_size = article.article_image.file&.size).to_i.positive?
+          xml.enclosure(
+            url: "#{request.base_url}#{article.article_image.url}",
+            length: image_size,
+            type: article.article_image.content_type.presence || 'image/jpeg'
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/views/news/show.rb
+++ b/app/views/news/show.rb
@@ -2,18 +2,19 @@
 
 class Views::News::Show < Views::Base
   register_output_helper :article_partner_links
+  register_value_helper :article_summary_text
 
   prop :article, Article, reader: :private
   prop :site, Site, reader: :private
 
   def view_template
-    content_for(:title) { article.title }
+    set_content_for_tags
 
     div(vocab: 'http://schema.org/', typeof: 'Article') do
       Hero(article.title, site.tagline, 'name')
       div(class: 'container-public mb-32') do
         Breadcrumb(
-          trail: [['News', news_index_path], [article.title, news_path(article)]],
+          trail: [[t('navigation.news'), news_index_path], [article.title, news_path(article)]],
           site_name: site.name
         )
         hr
@@ -23,6 +24,17 @@ class Views::News::Show < Views::Base
   end
 
   private
+
+  def set_content_for_tags
+    content_for(:title) { article.title }
+    content_for(:description) { article_summary_text(article) }
+
+    og_image = article.og_image_path
+    return if og_image.blank?
+
+    content_for(:image) { og_image }
+    content_for(:image_alt) { article.title }
+  end
 
   def render_article_body
     div(class: 'g article') do
@@ -35,7 +47,8 @@ class Views::News::Show < Views::Base
       div(class: 'gi gi__4-5 article__main') do
         if article.author&.full_name.present?
           h3(class: 'article__author') do
-            plain 'By '
+            plain t('news.show.by')
+            plain ' '
             em { article.author.full_name }
           end
         end
@@ -50,7 +63,6 @@ class Views::News::Show < Views::Base
         if article.article_image.present?
           div(class: 'article__image') do
             image_tag article.article_image.url, class: 'border'
-            p(class: 'article__image-attribute') { 'Image credit and/or title' }
           end
         end
 
@@ -59,7 +71,7 @@ class Views::News::Show < Views::Base
         end
 
         div(class: 'article__back') do
-          link_to 'Back to news', news_path
+          link_to t('news.show.back'), news_index_path
         end
       end
     end

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -16,6 +16,8 @@ class Views::Partners::Show < Views::Base
   prop :date_period, _Nilable(String), reader: :private, default: nil
   prop :show_monthly, _Boolean, reader: :private, default: true
   prop :containing_sites, _Nilable(_Interface(:each)), reader: :private, default: nil
+  prop :news_articles, _Interface(:each), reader: :private, default: -> { [] }
+  prop :news_total, Integer, reader: :private, default: 0
 
   def view_template
     set_content_for_tags
@@ -70,6 +72,7 @@ class Views::Partners::Show < Views::Base
         render_partner_details
         render_managees
         render_events_section
+        render_news_section
       end
     end
   end
@@ -179,6 +182,30 @@ class Views::Partners::Show < Views::Base
       else
         p { em { no_event_message || empty_period_message } }
       end
+    end
+  end
+
+  def render_news_section
+    return if news_articles.blank?
+
+    hr
+    h2(class: 'udl udl--fw allcaps h4') { t('news.partner_section.title') }
+    ul(class: 'reset') do
+      news_articles.each do |article|
+        li(class: 'mb-2') do
+          link_to article.title, news_path(article)
+          plain ' — '
+          span(title: article.published_at.to_s) { article.published_at.strftime('%B %Y') }
+        end
+      end
+    end
+
+    return unless news_total > news_articles.size
+
+    p do
+      link_to t('news.partner_section.more', partner: partner.name),
+              news_index_path(partner: partner.slug),
+              class: 'btn btn--alt btn--mt'
     end
   end
 

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -262,6 +262,21 @@ en:
     # Articles
     # -------------------------------------------------------------------------
     articles:
+      actions:
+        save_draft: "Save draft"
+        publish: "Publish"
+        unpublish: "Unpublish to draft"
+        view_live: "View live"
+      status:
+        published: "Published"
+        draft: "Draft"
+        draft_hint: "Only admins can see this article. Publish it with the button in the save bar."
+        published_hint: "This article is live on PlaceCal. You can unpublish it from the save bar."
+      references:
+        title: "References"
+        description: "Link this article to partners and partnerships."
+        partners_hint: "Link this article to one or more partners — it appears on their pages and on every site they're part of."
+        partnerships_hint: "Link this article to partnerships for filtering and organization."
       errors:
         partner_required: "Link this article to at least one partner — articles with no partner don't appear on any site"
       sections:
@@ -271,6 +286,8 @@ en:
         published: "Published"
         not_published: "Not published"
       markdown:
+        hint: "Just write — plain text works fine, and the toolbar adds bold text, lists and links. Want more formatting? See the"
+        hint_link: "Markdown guide"
         write: "Write"
         preview: "Preview"
         preview_placeholder: "Start typing to see preview..."

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -262,6 +262,8 @@ en:
     # Articles
     # -------------------------------------------------------------------------
     articles:
+      errors:
+        partner_required: "Link this article to at least one partner — articles with no partner don't appear on any site"
       sections:
         details: "Article Details"
       fields:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,35 @@ en:
       open: "Open to read more"
       close: "Close"
 
+  navigation:
+    home: "Home"
+    events: "Events"
+    partners: "Partners"
+    partnerships: "Partnerships"
+    news: "News"
+
+  # ===========================================================================
+  # NEWS (site subdomains; directory news lives under directory.news)
+  # ===========================================================================
+
+  news:
+    index:
+      title: "News from your area"
+      title_for_partner: "News from %{partner}"
+      older: "Older news items"
+      read_more: "Find out more"
+      rss: "Subscribe to these news posts (RSS)"
+    show:
+      by: "By"
+      back: "Back to news"
+    partner_section:
+      title: "Latest news"
+      more: "More news from %{partner}"
+    feed:
+      title: "%{name}: news"
+      title_for_partner: "%{name}: news from %{partner}"
+      description: "Community news from PlaceCal partners"
+
   # ===========================================================================
   # DIRECTORY (public placecal.org)
   # ===========================================================================
@@ -203,12 +232,30 @@ en:
         clear: "Clear filters"
       show:
         upcoming_events: "Upcoming events"
+        latest_news: "Latest news"
+        more_news: "More news from %{name}"
         location: "Location"
         accessibility_info: "Accessibility info"
         show_more_events:
           one: "Show 1 more event"
           other: "Show %{count} more events"
         serves: "Serves %{area}."
+    news:
+      index:
+        hero_title: "News from PlaceCal partners"
+        hero_subtitle: "Community news straight from the groups organising things near you, newest first."
+        description: "Read the latest community news from partners across PlaceCal."
+        results:
+          total:
+            one: "1 news post"
+            other: "%{count} news posts"
+          page: " — page %{page} of %{pages}"
+        empty: "No news posts yet."
+        rss: "Subscribe to these news posts (RSS)"
+      show:
+        kicker: "News"
+        back: "All news"
+        by: "By"
     partnerships:
       index:
         hero_title: "Partnerships on PlaceCal"

--- a/db/migrate/20260703154503_change_articles_published_at_to_datetime.rb
+++ b/db/migrate/20260703154503_change_articles_published_at_to_datetime.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# News v2 (issue #3308): published_at needs time-of-day precision so same-day
+# posts have a defined order in feeds and "latest news" listings. Existing date
+# values become midnight UTC. Indexed because every public listing orders by it.
+class ChangeArticlesPublishedAtToDatetime < ActiveRecord::Migration[8.1]
+  def up
+    # safety_assured: articles is a small table (tens of rows in production),
+    # so the type-change rewrite locks it only momentarily.
+    safety_assured { change_column :articles, :published_at, :datetime }
+  end
+
+  def down
+    safety_assured { change_column :articles, :published_at, :date }
+  end
+end

--- a/db/migrate/20260703154504_add_index_to_articles_published_at.rb
+++ b/db/migrate/20260703154504_add_index_to_articles_published_at.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Every public news listing and feed orders by published_at (issue #3308).
+class AddIndexToArticlesPublishedAt < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :articles, :published_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_154504) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -52,11 +52,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_090000) do
     t.string "body_html"
     t.datetime "created_at", null: false
     t.boolean "is_draft", default: true, null: false
-    t.date "published_at"
+    t.datetime "published_at"
     t.string "slug"
     t.text "title", null: false
     t.datetime "updated_at", null: false
     t.index ["author_id"], name: "index_articles_on_author_id"
+    t.index ["published_at"], name: "index_articles_on_published_at"
     t.index ["slug"], name: "index_articles_on_slug", unique: true
   end
 

--- a/db/seeds/007_articles.rb
+++ b/db/seeds/007_articles.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+# News articles for a sample of partners (issue #3308). Millbrook and Ashdale
+# partners get news so their sites show the News tab, partner-page sections,
+# and populated feeds; Seaview/Coastshire is deliberately left without any so
+# the no-news state (no nav tab) stays demonstrable.
+module SeedArticles # rubocop:disable Metrics/ModuleLength
+  # One template per partner-type suffix, matched against the procedurally
+  # generated partner names from 005_partners.rb
+  TEMPLATES = {
+    'Food Bank' => {
+      title: 'Winter opening hours and how you can help',
+      body: <<~MARKDOWN
+        We're extending our opening hours over the winter months so nobody has to
+        choose between warmth and food.
+
+        ## New opening times
+
+        - **Monday to Friday**: 9am – 5pm
+        - **Saturday**: 10am – 2pm
+
+        We always need tinned goods, UHT milk and toiletries. Drop donations in
+        during opening hours — and thank you, as ever, for your support.
+      MARKDOWN
+    },
+    'Community Garden' => {
+      title: 'Spring planting day — everyone welcome',
+      body: <<~MARKDOWN
+        Our annual **spring planting day** is coming up and we'd love to see you
+        there. No experience needed — tools, gloves and tea provided.
+
+        ## What we're planting
+
+        - Raised beds of salad and herbs
+        - A new wildflower border for the pollinators
+        - Fruit trees along the back fence
+
+        Bring sturdy shoes and a friend. Kids very welcome.
+      MARKDOWN
+    },
+    'Repair Cafe' => {
+      title: 'A record month of repairs',
+      body: <<~MARKDOWN
+        Last month our volunteers fixed **47 items** that would otherwise have
+        gone to landfill — toasters, trousers, laptops and one much-loved teddy
+        bear.
+
+        If you have something broken, bring it along to our next session. If you
+        can solder, sew or just make good tea, we'd love your help too.
+      MARKDOWN
+    },
+    'Music School' => {
+      title: 'Free taster lessons this term',
+      body: <<~MARKDOWN
+        We have a handful of **free taster lessons** available this term for
+        anyone who's always fancied picking up an instrument.
+
+        Guitar, keyboard, voice and drums — all ages, all levels, no sheet music
+        required. Get in touch to book a slot.
+      MARKDOWN
+    },
+    'Yoga Studio' => {
+      title: 'New beginners class on Saturday mornings',
+      body: <<~MARKDOWN
+        By popular demand we're adding a **beginners class** on Saturday
+        mornings. Slow-paced, friendly, and no bendiness required.
+
+        Mats provided. Wear something comfortable and arrive ten minutes early
+        for your first session.
+      MARKDOWN
+    },
+    'Cycling Club' => {
+      title: 'Group rides restart next week',
+      body: <<~MARKDOWN
+        The evenings are getting lighter, which means our **group rides** are
+        back on. All abilities welcome — nobody gets dropped.
+
+        ## The plan
+
+        - Tuesdays: gentle social ride, about an hour
+        - Sundays: longer route with a cafe stop
+
+        Free bike checks before every ride from our maintenance volunteers.
+      MARKDOWN
+    }
+  }.freeze
+
+  DISTRICTS_WITH_NEWS = %w[Millbrook Ashdale].freeze
+
+  def self.run
+    $stdout.puts 'Articles'
+
+    author = User.find_by(email: 'editor@placecal.org') || User.find_by(role: 'root')
+    unless author
+      $stdout.puts '  Skipping: no editor or root user to author articles'
+      return
+    end
+
+    create_partner_articles(author)
+    create_joint_article(author)
+    create_draft_article(author)
+
+    $stdout.puts "  Total articles: #{Article.count}"
+  end
+
+  # Spread publication dates over recent weeks, so every list and feed has a
+  # meaningful order
+  def self.create_partner_articles(author)
+    newsworthy_partners.each_with_index do |(partner, template), index|
+      title = "#{template[:title]} — #{partner.name}"
+      next if Article.exists?(title: title)
+
+      article = Article.create!(
+        title: title,
+        body: template[:body],
+        author: author,
+        is_draft: false,
+        published_at: (index + 1).weeks.ago.change(hour: 9 + (index % 8)),
+        partners: [partner]
+      )
+      attach_image(article, partner)
+      $stdout.puts "  Created article: #{article.title}"
+    end
+  end
+
+  # A joint post between two partners, to exercise multi-partner display and
+  # the distinct handling in Article.for_site
+  def self.create_joint_article(author)
+    partners = Partner.where("name LIKE 'Riverside %'").order(:name).limit(2).to_a
+    return if partners.size < 2
+
+    title = 'Riverside Summer Fair — a joint announcement'
+    return if Article.exists?(title: title)
+
+    Article.create!(
+      title: title,
+      body: <<~MARKDOWN,
+        Two of Riverside's community organisations are teaming up for a
+        **summer fair** on the green — stalls, food, music and activities for
+        all ages.
+
+        Want a stall? Get in touch with either of us. All proceeds go back into
+        running free sessions through the year.
+      MARKDOWN
+      author: author,
+      is_draft: false,
+      published_at: 2.days.ago.change(hour: 14),
+      partners: partners
+    )
+    $stdout.puts "  Created article: #{title}"
+  end
+
+  def self.create_draft_article(author)
+    partner, = newsworthy_partners.first
+    return unless partner
+
+    title = 'Draft: our plans for next year'
+    return if Article.exists?(title: title)
+
+    Article.create!(
+      title: title,
+      body: "Still being written — this draft is only visible in the admin.\n",
+      author: author,
+      is_draft: true,
+      partners: [partner]
+    )
+    $stdout.puts "  Created draft: #{title}"
+  end
+
+  # Two [partner, template] pairs per ward in the districts that get news,
+  # rotating through the templates so wards don't all publish the same thing
+  def self.newsworthy_partners
+    @newsworthy_partners ||= newsworthy_wards.each_with_index.flat_map do |ward, index|
+      TEMPLATES.keys.rotate(index).take(2).filter_map do |suffix|
+        partner = Partner.find_by(name: "#{ward[:name]} #{suffix}")
+        [partner, TEMPLATES[suffix]] if partner
+      end
+    end
+  end
+
+  def self.newsworthy_wards
+    NormalIsland::WARDS.filter_map do |_key, ward|
+      ward if DISTRICTS_WITH_NEWS.include?(NormalIsland::DISTRICTS[ward[:parent_district]][:name])
+    end
+  end
+
+  def self.attach_image(article, partner)
+    return unless partner.image.present? && partner.image.file&.exists?
+
+    article.article_image = File.open(partner.image.file.path)
+    article.save!
+  rescue StandardError => e
+    $stdout.puts "  (no image for #{article.title}: #{e.message})"
+  end
+end
+
+SeedArticles.run

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -9,7 +9,7 @@
 #  body          :text             not null
 #  body_html     :string
 #  is_draft      :boolean          default(TRUE), not null
-#  published_at  :date
+#  published_at  :datetime
 #  slug          :string
 #  title         :text             not null
 #  created_at    :datetime         not null
@@ -18,8 +18,9 @@
 #
 # Indexes
 #
-#  index_articles_on_author_id  (author_id)
-#  index_articles_on_slug       (slug) UNIQUE
+#  index_articles_on_author_id     (author_id)
+#  index_articles_on_published_at  (published_at)
+#  index_articles_on_slug          (slug) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe Article do
 
       expect(article_draft.published_at).to be_present
     end
+
+    it "keeps an explicitly set publication date when publishing" do
+      backdated = 3.weeks.ago.change(usec: 0)
+      article = create(:article, is_draft: false, published_at: backdated)
+
+      expect(article.published_at).to eq(backdated)
+    end
+
+    it "clears the date on unpublish and restamps on republish" do
+      article.update!(is_draft: true)
+      expect(article.reload.published_at).to be_nil
+
+      article.update!(is_draft: false)
+      expect(article.published_at).to be_present
+    end
   end
 
   describe ".with_tags" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -119,95 +119,99 @@ RSpec.describe Article do
   end
 
   describe ".for_site" do
-    let(:neighbourhood_1) { create(:riverside_ward) }
-    let(:neighbourhood_2) { create(:oldtown_ward) }
-    let(:author) { create(:root) }
+    # Visibility follows the partner (issue #3308 §4): an article is visible on
+    # a site iff at least one of its partners is on that site per PartnersQuery.
+    let(:site_ward) { create(:riverside_ward) }
+    let(:other_ward) { create(:oldtown_ward) }
+    let(:site) do
+      create(:site).tap { |s| create(:sites_neighbourhood, site: s, neighbourhood: site_ward) }
+    end
+    let(:site_partner) { create(:partner, address: create(:address, neighbourhood: site_ward)) }
 
-    it "returns articles for site (via neighbourhood)" do
-      site = create(:site)
-      site.neighbourhoods << neighbourhood_1
-      site.neighbourhoods << neighbourhood_2
-
-      partner_1 = create(:partner, address: create(:address, neighbourhood: neighbourhood_1))
-      partner_2 = create(:partner, address: create(:address, neighbourhood: neighbourhood_2))
-
-      # from first partner
-      2.times do |n|
-        partner_1.articles.create!(
-          title: "#{n} Article from Partner 1",
-          is_draft: false,
-          body: "lorem ipsum dorem ditsum",
-          author: author
-        )
-      end
-
-      # from second partner
-      3.times do |n|
-        partner_2.articles.create!(
-          title: "#{n} Article from Partner 2",
-          is_draft: false,
-          body: "lorem ipsum dorem ditsum",
-          author: author
-        )
-      end
-
-      found = described_class.for_site(site).select(:id)
-      expect(found.count).to eq(5)
+    def create_article(partners:, is_draft: false)
+      create(:article, partners: partners, is_draft: is_draft)
     end
 
-    it "returns articles with site tags applied" do
-      tag = create(:tag)
+    it "returns articles from partners whose address is in a site neighbourhood" do
+      article = create_article(partners: [site_partner])
 
-      site = create(:site)
-      site.tags << tag
-      site.validate!
-
-      3.times do |n|
-        article = described_class.create!(
-          title: "#{n} Article with tag",
-          is_draft: false,
-          body: "lorem ipsum dorem ditsum",
-          author: author
-        )
-        article.tags << tag
-        article.validate!
-      end
-
-      found = described_class.for_site(site)
-      expect(found.count).to eq(3)
+      expect(described_class.for_site(site)).to contain_exactly(article)
     end
 
-    it "finds articles by both neighbourhood and tag" do
-      site = create(:site)
+    it "returns articles from partners with only a service area in a site neighbourhood" do
+      # Address is deliberately outside the site; only the service area matches
+      partner = create(:mobile_partner,
+                       address: create(:address, neighbourhood: other_ward),
+                       service_area_wards: [site_ward])
+      article = create_article(partners: [partner])
 
-      site.neighbourhoods << neighbourhood_1
+      expect(described_class.for_site(site)).to contain_exactly(article)
+    end
 
-      partner = create(:partner, address: create(:address, neighbourhood: neighbourhood_1))
+    it "excludes articles from partners outside the site's neighbourhoods" do
+      partner = create(:partner, address: create(:address, neighbourhood: other_ward))
+      create_article(partners: [partner])
 
-      3.times do |n|
-        partner.articles.create!(
-          title: "#{n} Article from Partner by neighbourhood",
-          is_draft: false,
-          body: "lorem ipsum dorem ditsum",
-          author: author
-        )
+      expect(described_class.for_site(site)).to be_empty
+    end
+
+    it "excludes draft articles" do
+      create_article(partners: [site_partner], is_draft: true)
+
+      expect(described_class.for_site(site)).to be_empty
+    end
+
+    it "excludes articles from hidden partners" do
+      site_partner.update!(hidden: true, hidden_reason: "spam", hidden_blame_id: create(:root_user).id)
+      create_article(partners: [site_partner])
+
+      expect(described_class.for_site(site)).to be_empty
+    end
+
+    it "excludes articles with no partners" do
+      create(:article)
+
+      expect(described_class.for_site(site)).to be_empty
+    end
+
+    it "returns a multi-partner article once" do
+      second_partner = create(:partner, address: create(:address, neighbourhood: site_ward))
+      article = create_article(partners: [site_partner, second_partner])
+
+      expect(described_class.for_site(site).to_a).to contain_exactly(article)
+    end
+
+    it "returns nothing for a site with no neighbourhoods" do
+      empty_site = create(:site)
+      create_article(partners: [site_partner])
+
+      expect(described_class.for_site(empty_site)).to be_empty
+    end
+
+    context "when the site has partnership tags" do
+      let(:partnership) { create(:partnership_tag) }
+
+      before { site.tags << partnership }
+
+      it "returns articles from tagged partners in the site's neighbourhoods" do
+        site_partner.tags << partnership
+        article = create_article(partners: [site_partner])
+
+        expect(described_class.for_site(site)).to contain_exactly(article)
       end
 
-      tag = create(:tag)
-      site.tags << tag
+      it "excludes articles from untagged partners even in the site's neighbourhoods" do
+        create_article(partners: [site_partner])
 
-      5.times do |n|
-        article = described_class.create!(
-          title: "#{n} Article with tag",
-          is_draft: false,
-          body: "lorem ipsum dorem ditsum",
-          author: author
-        )
-        article.tags << tag
+        expect(described_class.for_site(site)).to be_empty
       end
 
-      found = described_class.for_site(site).select(:id)
-      expect(found.count).to eq(8)
+      it "ignores article tags for visibility (they are an API curation tool)" do
+        article = create(:article)
+        article.tags << partnership
+
+        expect(described_class.for_site(site)).to be_empty
+      end
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -9,7 +9,7 @@
 #  body          :text             not null
 #  body_html     :string
 #  is_draft      :boolean          default(TRUE), not null
-#  published_at  :date
+#  published_at  :datetime
 #  slug          :string
 #  title         :text             not null
 #  created_at    :datetime         not null
@@ -18,8 +18,9 @@
 #
 # Indexes
 #
-#  index_articles_on_author_id  (author_id)
-#  index_articles_on_slug       (slug) UNIQUE
+#  index_articles_on_author_id     (author_id)
+#  index_articles_on_published_at  (published_at)
+#  index_articles_on_slug          (slug) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -216,6 +216,28 @@ RSpec.describe Article do
     end
   end
 
+  describe "#og_image_path" do
+    it "is nil with no article image and no partner image" do
+      article = create(:article, partners: [create(:partner)])
+
+      expect(article.og_image_path).to be_nil
+    end
+
+    it "falls back to a partner's image" do
+      partner = create(:partner, image: Rack::Test::UploadedFile.new("spec/fixtures/files/good-cat-picture.jpg", "image/jpeg"))
+      article = create(:article, partners: [partner])
+
+      expect(article.og_image_path).to be_present
+    end
+
+    it "prefers the article's own image" do
+      article = create(:article,
+                       article_image: Rack::Test::UploadedFile.new("spec/fixtures/files/good-cat-picture.jpg", "image/jpeg"))
+
+      expect(article.og_image_path).to eq(article.highres_image)
+    end
+  end
+
   describe "body_html" do
     it "is rendered from body" do
       art = create(:article)

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -241,6 +241,27 @@ RSpec.describe Site, type: :model do
     end
   end
 
+  describe "#news_article_count" do
+    let(:ward) { create(:riverside_ward) }
+    let(:site) do
+      create(:site).tap { |s| create(:sites_neighbourhood, site: s, neighbourhood: ward) }
+    end
+
+    it "counts published articles from the site's partners, including service-area ones" do
+      address_partner = create(:partner, address: create(:address, neighbourhood: ward))
+      service_area_partner = create(:mobile_partner,
+                                    address: create(:address, neighbourhood: create(:oldtown_ward)),
+                                    service_area_wards: [ward])
+
+      create(:article, partners: [address_partner])
+      create(:article, partners: [service_area_partner])
+      create(:article, partners: [address_partner], is_draft: true)
+      create(:article) # no partner — visible nowhere
+
+      expect(site.news_article_count).to eq(2)
+    end
+  end
+
   describe "scopes" do
     describe "default ordering" do
       let!(:site_a) { create(:site, name: "Alpha Site") }

--- a/spec/policies/article_policy_spec.rb
+++ b/spec/policies/article_policy_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ArticlePolicy, type: :policy do
-  subject { described_class.new(user, article) }
+  subject(:policy) { described_class.new(user, article) }
 
   let(:partner) { create(:partner) }
   let(:article) { create(:article, partners: [partner]) }
@@ -26,6 +26,31 @@ RSpec.describe ArticlePolicy, type: :policy do
     it { is_expected.to permit_action(:create) }
     it { is_expected.to permit_action(:update) }
     it { is_expected.to permit_action(:destroy) }
+  end
+
+  describe "for an editor" do
+    # Regression coverage for issue #2045 — editors manage all news articles
+    let(:user) { create(:editor_user) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:destroy) }
+
+    it "has no disabled fields" do
+      expect(policy.disabled_fields).to be_empty
+    end
+
+    describe "scope" do
+      it "resolves every article, including other partners' ones" do
+        with_partner = article
+        without_partner = create(:article)
+
+        resolved = described_class::Scope.new(user, Article).resolve
+        expect(resolved).to contain_exactly(with_partner, without_partner)
+      end
+    end
   end
 
   describe "for a partner admin" do

--- a/spec/requests/admin/articles_spec.rb
+++ b/spec/requests/admin/articles_spec.rb
@@ -172,6 +172,82 @@ RSpec.describe "Admin::Articles", type: :request do
     end
   end
 
+  describe "publishing UX (issue #3308 Phase 4)" do
+    context "on the new-article form as a partner admin" do
+      before { sign_in partner_admin }
+
+      it "offers Save draft and Publish actions" do
+        get new_admin_article_url(host: admin_host)
+
+        expect(response.body).to include(I18n.t("admin.articles.actions.save_draft"))
+        expect(response.body).to include(I18n.t("admin.articles.actions.publish"))
+      end
+
+      it "hides the partnerships selector" do
+        get new_admin_article_url(host: admin_host)
+
+        expect(response.body).not_to include(I18n.t("admin.articles.references.partnerships_hint"))
+      end
+
+      it "shows plain-language markdown microcopy" do
+        get new_admin_article_url(host: admin_host)
+
+        expect(response.body).to include(I18n.t("admin.articles.markdown.hint_link"))
+      end
+
+      it "publishes immediately when created via Publish" do
+        post admin_articles_url(host: admin_host), params: {
+          article: { title: "Published straight away", body: "Some words", author_id: partner_admin.id,
+                     partner_ids: [partner.id], is_draft: "false" }
+        }
+
+        article = Article.find_by(title: "Published straight away")
+        expect(article.is_draft).to be false
+        expect(article.published_at).to be_present
+      end
+
+      it "stays a draft when created via Save draft" do
+        post admin_articles_url(host: admin_host), params: {
+          article: { title: "Still cooking", body: "Some words", author_id: partner_admin.id,
+                     partner_ids: [partner.id], is_draft: "true" }
+        }
+
+        expect(Article.find_by(title: "Still cooking").is_draft).to be true
+      end
+    end
+
+    it "shows the partnerships selector to editors" do
+      sign_in editor_user
+
+      get new_admin_article_url(host: admin_host)
+
+      expect(response.body).to include(I18n.t("admin.articles.references.partnerships_hint"))
+    end
+
+    context "on the edit form" do
+      before { sign_in partner_admin }
+
+      it "offers Publish on a draft" do
+        draft = create(:article, partners: [partner], is_draft: true)
+
+        get edit_admin_article_url(draft, host: admin_host)
+
+        expect(response.body).to include(I18n.t("admin.articles.actions.publish"))
+        expect(response.body).not_to include(I18n.t("admin.articles.actions.unpublish"))
+      end
+
+      it "offers Unpublish and a view-live link on a published article" do
+        article = create(:article, partners: [partner])
+
+        get edit_admin_article_url(article, host: admin_host)
+
+        expect(response.body).to include(I18n.t("admin.articles.actions.unpublish"))
+        expect(response.body).to include(I18n.t("admin.articles.actions.view_live"))
+        expect(response.body).to include("/news/#{article.slug}")
+      end
+    end
+  end
+
   describe "POST /admin/articles" do
     context "with bad image upload" do
       before { sign_in root_user }

--- a/spec/requests/admin/articles_spec.rb
+++ b/spec/requests/admin/articles_spec.rb
@@ -65,6 +65,113 @@ RSpec.describe "Admin::Articles", type: :request do
     end
   end
 
+  describe "editor role end-to-end (issue #2045 regression)" do
+    before { sign_in editor_user }
+
+    let(:other_partner_article) { create(:article, partners: [create(:partner)]) }
+
+    it "shows the Articles link in the admin nav" do
+      get "http://#{admin_host}"
+      expect(response).to be_successful
+      expect(response.body).to include(admin_articles_path)
+    end
+
+    it "can view the articles index" do
+      get admin_articles_url(host: admin_host)
+      expect(response).to be_successful
+    end
+
+    it "offers every partner in the new-article form" do
+      partner
+      get new_admin_article_url(host: admin_host)
+      expect(response).to be_successful
+      expect(response.body).to include(partner.name)
+    end
+
+    it "can edit another partner's article and still see all partner options" do
+      get edit_admin_article_url(other_partner_article, host: admin_host)
+      expect(response).to be_successful
+      expect(response.body).to include(partner.name)
+    end
+
+    it "can create an article attached to any partner" do
+      post admin_articles_url(host: admin_host), params: {
+        article: {
+          title: "Editor-created article",
+          body: "Words about a community group",
+          author_id: editor_user.id,
+          partner_ids: [partner.id]
+        }
+      }
+
+      expect(response).to redirect_to(admin_articles_path)
+      expect(Article.find_by(title: "Editor-created article").partners).to contain_exactly(partner)
+    end
+
+    it "can update another partner's article" do
+      put admin_article_url(other_partner_article, host: admin_host), params: {
+        article: { title: "Updated by editor" }
+      }
+
+      expect(response).to be_redirect
+      expect(other_partner_article.reload.title).to eq("Updated by editor")
+    end
+
+    it "can delete another partner's article" do
+      delete admin_article_url(other_partner_article, host: admin_host)
+
+      expect(response).to be_redirect
+      expect(Article.exists?(other_partner_article.id)).to be false
+    end
+  end
+
+  describe "partner requirement for non-staff authors" do
+    context "as a partner admin" do
+      before { sign_in partner_admin }
+
+      it "rejects creating an article with no partners" do
+        post admin_articles_url(host: admin_host), params: {
+          article: { title: "Orphan article", body: "Some words", author_id: partner_admin.id, partner_ids: [""] }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("at least one partner")
+        expect(Article.find_by(title: "Orphan article")).to be_nil
+      end
+
+      it "creates an article linked to their partner" do
+        post admin_articles_url(host: admin_host), params: {
+          article: { title: "Partner news", body: "Some words", author_id: partner_admin.id, partner_ids: [partner.id] }
+        }
+
+        expect(response).to redirect_to(admin_articles_path)
+        expect(Article.find_by(title: "Partner news").partners).to contain_exactly(partner)
+      end
+
+      it "rejects removing every partner on update" do
+        article = create(:article, partners: [partner])
+
+        put admin_article_url(article, host: admin_host), params: {
+          article: { title: article.title, partner_ids: [""] }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(article.reload.partners).to contain_exactly(partner)
+      end
+    end
+
+    it "allows editors to create partner-less platform posts" do
+      sign_in editor_user
+
+      post admin_articles_url(host: admin_host), params: {
+        article: { title: "Platform announcement", body: "Some words", author_id: editor_user.id, partner_ids: [""] }
+      }
+
+      expect(response).to redirect_to(admin_articles_path)
+      expect(Article.find_by(title: "Platform announcement")).to be_present
+    end
+  end
+
   describe "POST /admin/articles" do
     context "with bad image upload" do
       before { sign_in root_user }

--- a/spec/requests/graphql/articles_spec.rb
+++ b/spec/requests/graphql/articles_spec.rb
@@ -129,12 +129,16 @@ RSpec.describe "GraphQL Articles", type: :request do
       expect(articles.length).to eq(3)
     end
 
-    it "sorts articles by title" do
+    # ORDER BY published_at DESC first, title as tiebreak — what production has
+    # always returned (explicit publication dates used to be silently clobbered
+    # to identical values at creation, which made this look title-sorted under
+    # the suite's frozen clock)
+    it "sorts articles newest first" do
       result = execute_query(query, variables: { tagId: tag.id })
 
       articles = result["data"]["articlesByTag"]
-      expect(articles.first["name"]).to eq("Tagged published article 0")
-      expect(articles.last["name"]).to eq("Tagged published article 2")
+      expect(articles.first["name"]).to eq("Tagged published article 2")
+      expect(articles.last["name"]).to eq("Tagged published article 0")
     end
   end
 
@@ -194,12 +198,12 @@ RSpec.describe "GraphQL Articles", type: :request do
       expect(articles.length).to eq(5)
     end
 
-    it "sorts articles by title" do
+    it "sorts articles newest first" do
       result = execute_query(query, variables: { tagId: tag.id })
 
       articles = result["data"]["articlesByPartnerTag"]
-      expect(articles.first["name"]).to eq("Partner article 0")
-      expect(articles.last["name"]).to eq("Partner article 4")
+      expect(articles.first["name"]).to eq("Partner article 4")
+      expect(articles.last["name"]).to eq("Partner article 0")
     end
   end
 

--- a/spec/requests/public/articles_spec.rb
+++ b/spec/requests/public/articles_spec.rb
@@ -42,6 +42,143 @@ RSpec.describe "Public Articles (News)", type: :request do
     end
   end
 
+  describe "GET /news?partner=slug (partner filter)" do
+    let!(:partner1) { create(:partner, address: address) }
+    let!(:partner2) { create(:partner, address: address) }
+    let!(:article1) { create(:article, partners: [partner1], title: "Post from partner one") }
+    let!(:article2) { create(:article, partners: [partner2], title: "Post from partner two") }
+
+    it "shows only the filtered partner's articles" do
+      get news_index_url(host: "#{site.slug}.lvh.me", params: { partner: partner1.slug })
+
+      expect(response).to be_successful
+      expect(response.body).to include("Post from partner one")
+      expect(response.body).not_to include("Post from partner two")
+    end
+
+    it "titles the page for the partner" do
+      get news_index_url(host: "#{site.slug}.lvh.me", params: { partner: partner1.slug })
+
+      expect(response.body).to include(
+        CGI.escapeHTML(I18n.t("news.index.title_for_partner", partner: partner1.name))
+      )
+    end
+  end
+
+  describe "site navigation News link" do
+    let!(:partner) { create(:partner, address: address) }
+
+    it "appears when the site's partners have published news" do
+      create(:article, partners: [partner])
+
+      get partners_url(host: "#{site.slug}.lvh.me")
+
+      expect(response.body).to include('href="/news"')
+    end
+
+    it "does not appear when the site has no news" do
+      get partners_url(host: "#{site.slug}.lvh.me")
+
+      expect(response.body).not_to include('href="/news"')
+    end
+  end
+
+  describe "partner page latest news section" do
+    let!(:partner) { create(:partner, address: address) }
+
+    it "shows up to 3 recent posts with a more link when there are more" do
+      4.times { |n| create(:article, partners: [partner], title: "Partner post #{n}", published_at: n.days.ago) }
+
+      get partner_url(partner, host: "#{site.slug}.lvh.me")
+
+      expect(response).to be_successful
+      expect(response.body).to include(I18n.t("news.partner_section.title"))
+      expect(response.body).to include("Partner post 0")
+      expect(response.body).to include("Partner post 2")
+      expect(response.body).not_to include("Partner post 3")
+      expect(response.body).to include(
+        CGI.escapeHTML(I18n.t("news.partner_section.more", partner: partner.name))
+      )
+    end
+
+    it "renders no news section when the partner has no posts" do
+      get partner_url(partner, host: "#{site.slug}.lvh.me")
+
+      expect(response.body).not_to include(I18n.t("news.partner_section.title"))
+    end
+
+    it "shows the section on the directory partner page" do
+      create(:article, partners: [partner], title: "Directory partner post")
+
+      get partner_url(partner, host: "lvh.me")
+
+      expect(response).to be_successful
+      expect(response.body).to include(I18n.t("directory.partners.show.latest_news"))
+      expect(response.body).to include("Directory partner post")
+    end
+  end
+
+  describe "GET /news on the directory (placecal.org)" do
+    let!(:partner) { create(:partner, address: address) }
+    let!(:article) { create(:article, partners: [partner], title: "Platform-wide post") }
+    let!(:draft) { create(:article, partners: [partner], title: "Unpublished post", is_draft: true) }
+
+    it "renders the platform-wide news index" do
+      get news_index_url(host: "lvh.me")
+
+      expect(response).to be_successful
+      expect(response.body).to include(I18n.t("directory.news.index.hero_title"))
+      expect(response.body).to include("Platform-wide post")
+      expect(response.body).not_to include("Unpublished post")
+    end
+
+    it "shows the partner name on the card" do
+      get news_index_url(host: "lvh.me")
+
+      expect(response.body).to include(partner.name)
+    end
+
+    it "filters by partner" do
+      other = create(:partner, address: address)
+      create(:article, partners: [other], title: "Someone else entirely")
+
+      get news_index_url(host: "lvh.me", params: { partner: partner.slug })
+
+      expect(response.body).to include("Platform-wide post")
+      expect(response.body).not_to include("Someone else entirely")
+    end
+
+    it "renders the article show page" do
+      get news_url(article, host: "lvh.me")
+
+      expect(response).to be_successful
+      expect(response.body).to include("Platform-wide post")
+      expect(response.body).to include(I18n.t("directory.news.show.back"))
+    end
+
+    it "shows the empty state with no articles" do
+      Article.destroy_all
+
+      get news_index_url(host: "lvh.me")
+
+      expect(response).to be_successful
+      expect(response.body).to include(I18n.t("directory.news.index.empty"))
+    end
+  end
+
+  describe "article show meta tags" do
+    let!(:partner) { create(:partner, address: address) }
+    let!(:article) do
+      create(:article, partners: [partner], title: "Meta post", body: "A body worth describing in meta tags")
+    end
+
+    it "sets a meta description from the article body" do
+      get news_url(article, host: "#{site.slug}.lvh.me")
+
+      expect(response.body).to include('property="og:description" content="A body worth describing in meta tags"')
+    end
+  end
+
   describe "GET /news/:id (show)" do
     context "with articles linked to partners" do
       let!(:article) { create(:article, is_draft: false) }

--- a/spec/requests/public/directory_partners_spec.rb
+++ b/spec/requests/public/directory_partners_spec.rb
@@ -139,6 +139,16 @@ RSpec.describe "Directory Partners", type: :request do
       expect(response).to be_successful
     end
 
+    it "links partnerships in the sidebar relative to the current host" do
+      site = create(:site, is_published: true)
+      site.neighbourhoods << partner.address.neighbourhood
+
+      get partner_url(partner, host: "lvh.me")
+
+      expect(response.body).to include("http://#{site.slug}.lvh.me")
+      expect(response.body).not_to include("#{site.slug}.placecal.org")
+    end
+
     it "displays partner name in hero" do
       get partner_url(partner, host: "lvh.me")
       expect(response.body).to include(partner.name)

--- a/spec/requests/public/news_feed_spec.rb
+++ b/spec/requests/public/news_feed_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "News RSS feeds", type: :request do
+  let(:site) { create(:site, slug: "feed-site") }
+  let(:ward) { create(:riverside_ward) }
+  let(:other_ward) { create(:oldtown_ward) }
+
+  # An address partner and a service-area-only partner, both on the site
+  let!(:address_partner) { create(:partner, address: create(:address, neighbourhood: ward)) }
+  let!(:service_area_partner) do
+    create(:mobile_partner,
+           address: create(:address, neighbourhood: other_ward),
+           service_area_wards: [ward])
+  end
+  # A partner nowhere near the site
+  let!(:outside_partner) { create(:partner, address: create(:address, neighbourhood: other_ward)) }
+
+  let!(:address_article) { create(:article, partners: [address_partner], title: "Address partner post") }
+  let!(:service_area_article) { create(:article, partners: [service_area_partner], title: "Service area post") }
+  let!(:outside_article) { create(:article, partners: [outside_partner], title: "Outside post") }
+  let!(:draft_article) { create(:article, partners: [address_partner], title: "Draft post", is_draft: true) }
+
+  before { site.neighbourhoods << ward }
+
+  def feed_for(response)
+    Nokogiri::XML(response.body).tap do |doc|
+      expect(doc.errors).to be_empty
+    end
+  end
+
+  def item_titles(doc)
+    doc.xpath("//item/title").map(&:text)
+  end
+
+  describe "GET /news.rss on a site" do
+    it "returns valid RSS scoped to the site, including service-area partners" do
+      get news_index_url(host: "#{site.slug}.lvh.me", format: :rss)
+
+      expect(response).to be_successful
+      expect(response.media_type).to eq("application/rss+xml")
+
+      doc = feed_for(response)
+      expect(doc.at_xpath("//channel/title").text).to eq(I18n.t("news.feed.title", name: site.name))
+      expect(item_titles(doc)).to contain_exactly("Address partner post", "Service area post")
+    end
+
+    it "includes item metadata" do
+      get news_index_url(host: "#{site.slug}.lvh.me", format: :rss)
+
+      doc = feed_for(response)
+      item = doc.xpath("//item").find { |i| i.at_xpath("title").text == "Address partner post" }
+
+      expect(item.at_xpath("link").text).to include("/news/#{address_article.slug}")
+      expect(item.at_xpath("pubDate").text).to eq(address_article.published_at.rfc822)
+      expect(item.at_xpath("category").text).to eq(address_partner.name)
+      expect(item.at_xpath("description").text).to be_present
+    end
+  end
+
+  describe "GET /news.rss?partner=slug" do
+    it "scopes the feed to one partner and titles it accordingly" do
+      get news_index_url(host: "#{site.slug}.lvh.me", format: :rss, params: { partner: address_partner.slug })
+
+      doc = feed_for(response)
+      expect(doc.at_xpath("//channel/title").text)
+        .to eq(I18n.t("news.feed.title_for_partner", name: site.name, partner: address_partner.name))
+      expect(item_titles(doc)).to contain_exactly("Address partner post")
+    end
+  end
+
+  describe "GET /news.rss on the directory" do
+    it "includes every published article platform-wide and no drafts" do
+      get news_index_url(host: "lvh.me", format: :rss)
+
+      doc = feed_for(response)
+      expect(doc.at_xpath("//channel/title").text).to eq(I18n.t("news.feed.title", name: "PlaceCal"))
+      expect(item_titles(doc)).to contain_exactly("Address partner post", "Service area post", "Outside post")
+    end
+  end
+
+  describe "feed discovery on HTML index pages" do
+    it "adds a rel=alternate link and a visible RSS link on the site index" do
+      get news_index_url(host: "#{site.slug}.lvh.me")
+
+      expect(response.body).to include('rel="alternate" type="application/rss+xml"')
+      expect(response.body).to include("/news.rss")
+      expect(response.body).to include(I18n.t("news.index.rss"))
+    end
+
+    it "adds both on the directory index" do
+      get news_index_url(host: "lvh.me")
+
+      expect(response.body).to include('rel="alternate" type="application/rss+xml"')
+      expect(response.body).to include(I18n.t("directory.news.index.rss"))
+    end
+  end
+end


### PR DESCRIPTION
Resolves #3308
Resolves #2045

## Description

Implements all four phases of the News v2 PRD (#3308) plus seed data, in seven commits that read phase by phase.

**Phase 1 — correct plumbing**
- `Article.for_site` now delegates to `PartnersQuery`: an article is visible on a site iff at least one of its partners is on that site — the same edges as events and partner listings. This fixes the two long-standing gaps: partners with only a service area (no address in the site's patch) could never surface news anywhere, and article tags leaked into site visibility with different semantics than events. Article tags remain as the curation tool behind the tag-based GraphQL queries (The Trans Dimension contract untouched — its specs stay green).
- `published_at` migrated from `date` to `datetime` (+ index), so same-day posts have a defined order in feeds. The publish callback now honours an explicitly set date instead of always stamping `Time.current` (backdating was impossible; the suite's frozen clock had been hiding this).
- #2045 root-caused and fixed: the policy and nav were already editor-friendly, but the form's partner selector used `policy_scope(Partner)`, which is empty for editors — so editors could never attach a partner. Regression-tested end-to-end (tests verified to fail without the fix).
- Non-staff articles must have at least one partner (checked against submitted params in the controller — a partner-less article is invisible everywhere). Root/editor can still post partner-less platform announcements.

**Phase 2 — news visible everywhere**
- Site nav gains a News link only when `site.news_article_count > 0` (no empty tab); nav labels moved to i18n.
- Partner pages (site + directory variants) get a "Latest news" section (3 most recent) with a "More news from X" link driving the new `/news?partner=slug` filter.
- The directory stops redirecting `/news` to `/find-placecal` and gets a platform-wide news index (newest first, partner + area per card, Pagy pagination) and article pages in the firehose design. New `Directory::NewsRow` component — News-flavoured naming, no `Components::Article` namespace.
- Article pages emit OG description + share image (article image → partner image → site/directory default). Two drive-by fixes: "Back to news" self-linked, and a literal "Image credit and/or title" placeholder rendered under every article image.

**Phase 3 — outbound RSS**
- RSS 2.0 via a builder template (no new gems) at three levels, all sharing the HTML index's scoping: `<site>/news.rss`, `/news.rss?partner=slug`, and platform-wide `placecal.org/news.rss`. Items: canonical link/guid, sanitised `body_html`, RFC-822 pubDate, partner categories, image enclosure. Index pages advertise the feed via `rel=alternate` (new `content_for(:rss_feed)` layout hook) plus a visible subscribe link.

**Phase 4 — publishing UX for groups**
- "Save draft" / "Publish" buttons in the save bar replace the is_draft checkbox buried in the Settings tab — new articles previously *couldn't* be published without reopening them. On the edit form the publish/unpublish action sits in the sticky save bar on every tab, after the Save button so Enter-key implicit submission never publishes.
- Settings tab shows a status badge plus a "View live" link to the article on the nationwide directory (also next to the publication date on the Text tab).
- Partnership tags hidden from partner admins (root/editor curation tool); markdown microcopy switched to plain language; remaining hardcoded form strings moved to locale keys.

**Seeds** — new `db/seeds/007_articles.rb`: 12 templated posts across Millbrook/Ashdale partners with staggered dates and images, a joint two-partner announcement, and one draft. Seaview/Coastshire deliberately gets no news so the hidden-nav-tab state stays demonstrable. Idempotent.

### Motivation and Context

News is the weakest limb of the one-stop-shop story: articles existed but nothing linked to them, the visibility rules didn't match events, and community groups couldn't realistically publish. Full brief in #3308.

Decisions on the PRD's open questions (all "simplest v1"): no directory news filters beyond `?partner=` (Q1); no cross-host `rel=canonical` yet — view-live links treat the directory as de-facto canonical (Q2); `/news` stays the path on both host types (Q3); article tags stay staff-only (Q4); no site-level opt-out (Q5).

Reviewer notes:
- The nav check adds one indexed COUNT query per site page render. Fine for now; easy to cache on the site row if it ever shows in AppSignal.
- Two small follow-up branches stack on this one: `fix/article-policy-record-scoping` (per-record ArticlePolicy checks) and `chore/consolidate-partner-options-helpers`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- Full RSpec suite green locally: **1943 examples, 0 failures** (after `bin/rails dartsass:build`; the suite needs `home.css` built).
- New coverage: model specs for the visibility scope (address / service-area / tagged / untagged / hidden / multi-partner / draft cases) and the publish callback; policy specs for the editor role; request specs for editor CRUD, the partner requirement, partner filtering, directory news pages, OG tags, feed XML validity and scoping (Nokogiri-parsed), and the Phase 4 form behaviours.
- Cucumber `features/public/news.feature` and `features/admin/articles.feature` pass (run individually; running the two `@javascript` files in one batch hits a pre-existing DB-truncation deadlock unrelated to this change).
- Seeds run twice against a dev database: 14 articles first run, 0 the second.

### How Will This Be Deployed?

- Two migrations: `published_at` date→datetime (small table, momentary lock, `safety_assured`) and a concurrent index on `published_at`. No env vars, no infra changes.
- GraphQL shapes unchanged; The Trans Dimension keeps working.
- placecal.org `/news` changes behaviour: it stops redirecting to `/find-placecal` and serves the platform-wide news index.
