### PR TITLE
Fix partner-sidebar partnership links pointing at production in dev

### DIFF
--- a/app/components/directory/partner_sidebar.rb
+++ b/app/components/directory/partner_sidebar.rb
@@ -41,7 +41,9 @@ class Components::Directory::PartnerSidebar < Components::Directory::Base
           plain t('directory.sidebar.partnerships_description', name: @partner.name)
         end
         Array(@containing_sites).each do |site_record|
-          a(href: "https://#{site_record.slug}.placecal.org",
+          # Relative to the current host so the links work in development
+          # (slug.lvh.me) as well as production (slug.placecal.org)
+          a(href: root_url(subdomain: site_record.slug),
             class: 'flex items-center justify-between py-2 no-underline text-foreground hover:bg-background/50 transition-colors rounded px-1') do
             div do
               div(class: 'font-extra-bold text-sm') { site_record.name }

--- a/spec/requests/public/directory_partners_spec.rb
+++ b/spec/requests/public/directory_partners_spec.rb
@@ -139,6 +139,16 @@ RSpec.describe "Directory Partners", type: :request do
       expect(response).to be_successful
     end
 
+    it "links partnerships in the sidebar relative to the current host" do
+      site = create(:site, is_published: true)
+      site.neighbourhoods << partner.address.neighbourhood
+
+      get partner_url(partner, host: "lvh.me")
+
+      expect(response.body).to include("http://#{site.slug}.lvh.me")
+      expect(response.body).not_to include("#{site.slug}.placecal.org")
+    end
+
     it "displays partner name in hero" do
       get partner_url(partner, host: "lvh.me")
       expect(response.body).to include(partner.name)


### PR DESCRIPTION
## Description

The directory partner page's "Part of these partnerships" sidebar hardcoded `https://slug.placecal.org` for each site a partner appears on, so in development the links pointed at production instead of `slug.lvh.me:3000`.

Now uses `root_url(subdomain: site.slug)`, following the request host in every environment — the same idiom the neighbourhood home card already uses. (Sites resolve by slug on any domain via `Site.find_by_request`, so the links work in production too.)

### Motivation and Context

Spotted while reviewing http://lvh.me:3000/partners/riverside-advice-centre locally — none of the partnership links worked.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

New request spec asserts the sidebar links carry the request's host (`slug.lvh.me`) and never the hardcoded production domain. Full `directory_partners_spec.rb` green (29 examples).

### How Will This Be Deployed?

No infra or config changes.
