### PR TITLE
Modernise Release Drafter: auto-versioning, auto-tagging, PR autolabelling

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,35 +1,70 @@
-template: |
-  ## What’s Changed
+# Release Drafter config. Maintains a DRAFT GitHub release, continuously updated
+# as PRs merge to main, with categorised notes + an auto-resolved semver bump.
+# Publishing that draft is what deploys production (see test-and-deploy.yml).
+#
+# Categorisation + version bump are driven by PR labels — but the `autolabeler`
+# below applies those labels automatically from PR titles/branches, so no manual
+# labelling is required. Renovate applies `dependencies` itself. To force a
+# specific bump, label the PR `major`/`minor`/`patch` by hand.
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 
-  $CHANGES
 categories:
   - title: "🚀 Features"
-    labels:
-      - "enhancement"
-  - title: "🐛 Bug Fixes"
-    labels:
-      - "bug"
-  - title: "🧰 Maintenance"
-    labels:
-      - "chore"
-      - "code-smell"
-      - "dependencies"
-  - title: "🌍 Translations"
-    labels:
-      - "translation"
-  - title: "📚 Documentation"
-    labels:
-      - "docs"
+    labels: [enhancement]
+  - title: "🐛 Fixes"
+    labels: [fix, bug]
+  - title: "🔒 Security"
+    labels: [security]
+  - title: "🧹 Maintenance"
+    labels: [maintenance, dependencies]
+  - title: "📚 Docs"
+    labels: [docs]
+
+# Anything not matched by the categories above still shows under this heading.
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'
+exclude-labels: [duplicate, "won't fix"]
+
 version-resolver:
   major:
-    labels:
-      - "major"
+    labels: [breaking, major]
   minor:
-    labels:
-      - "minor"
+    labels: [enhancement, minor]
   patch:
-    labels:
-      - "patch"
+    labels: [fix, bug, security, maintenance, docs, dependencies, patch]
   default: patch
-# name-template: '$RESOLVED_VERSION 🌈'
-# tag-template: '$RESOLVED_VERSION'
+
+autolabeler:
+  - label: enhancement
+    title: ["/^feat/i", "/^feature/i", "/^add/i"]
+    branch: ["/^feat/i", "/^feature/i", "/^add/i"]
+  - label: fix
+    title: ["/^fix/i", "/^bugfix/i", "/^hotfix/i"]
+    branch: ["/^fix/i", "/^hotfix/i"]
+  - label: docs
+    title: ["/^docs/i"]
+    branch: ["/^docs/i"]
+    files: ["doc/**", "**/*.md"]
+  - label: maintenance
+    title:
+      [
+        "/^chore/i",
+        "/^refactor/i",
+        "/^ci/i",
+        "/^test/i",
+        "/^perf/i",
+        "/^build/i",
+        "/^upgrade/i",
+        "/^bump/i",
+      ]
+    branch: ["/^chore/i", "/^refactor/i"]
+  - label: breaking
+    title: ["/!:/", "/^break/i"]
+
+template: |
+  ## What's changed
+
+  $CHANGES
+
+  **Full changelog**: https://github.com/geeksforsocialchange/PlaceCal/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,15 +1,22 @@
 name: Release Drafter
 
 on:
+  # Update the draft release as PRs merge to main.
   push:
     branches:
       - main
+  # Autolabel PRs from their title/branch (see .github/release-drafter.yml).
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: write # create/update the draft release
+      pull-requests: write # apply autolabels
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1


### PR DESCRIPTION
## Description

Ports the Release Drafter setup from [Improve-Your-Accent/iya](https://github.com/Improve-Your-Accent/iya) to bring PlaceCal up to the same spec: auto-resolved version numbers, proper auto-tagging, and autolabelled PRs.

What changes:

- **Auto version + tag**: `name-template`/`tag-template` now use `v$RESOLVED_VERSION`, so the draft release arrives pre-named and pre-tagged with the next semver instead of needing a hand-typed version at publish time.
- **Autolabeler**: PRs are labelled automatically from their titles/branches (`Fix:` → `fix`, `Add:` → `enhancement`, `chore/`/`refactor` → `maintenance`, `docs` → `docs`, `!:`/`break` → `breaking`). Renovate already applies `dependencies` itself. No manual labelling needed for release notes to categorise correctly.
- **Version resolver**: labels drive the bump (`breaking` → major, `enhancement` → minor, everything else → patch), with manual `major`/`minor`/`patch` labels kept as an override.
- **Full changelog link** appended to the release body.
- **Workflow**: now also runs on `pull_request` events (needed for autolabelling), with least-privilege permissions moved to the job level (`contents: write`, `pull-requests: write`).

### Motivation and Context

The existing config referenced labels that don't exist on this repo (`chore`, `code-smell`, `translation`) and required hand-labelling PRs `major`/`minor`/`patch` for the version resolver to do anything — in practice categorisation and versioning were mostly manual. The iya setup automates both.

Categories now use labels that actually exist. I created the missing ones the autolabeler needs: `enhancement`, `fix`, `maintenance`, `breaking`, plus `major`/`minor` to match the existing `patch` override label.

### Type of change

- [x] This change requires a change to the deployment process (only in the sense that publishing the draft release no longer requires typing a version/tag — the release-published → production deploy flow in `test-and-deploy.yml` is unchanged)

### How Has This Been Tested?

Config-only change; behaviour is exercised by GitHub Actions. This PR itself is the first test of the autolabeler (`chore/` branch → `maintenance` label). The draft release update runs on the next merge to main.

### How Will This Be Deployed?

Merges take effect immediately — no infra or env changes. The six labels mentioned above have already been created on the repo.
