### PR TITLE
SEO: canonicalise partner/event pages to directory apex + emit Place location schema

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -60,7 +60,10 @@ class SitemapsController < ApplicationController
   end
 
   def build_events
-    urls = Event.where(dtstart: 3.months.ago..)
+    # Only events that aren't over (dtend-aware, matching Event#past?) —
+    # past event pages are noindexed, and a sitemap listing noindexed URLs
+    # draws "submitted URL marked noindex" warnings in Search Console.
+    urls = Event.where('COALESCE(dtend, dtstart) >= ?', DateTime.current.beginning_of_day)
                 .order(dtstart: :desc)
                 .limit(MAX_URLS_PER_SITEMAP)
                 .pluck(:id, :updated_at)

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -140,6 +140,19 @@ class Address < ApplicationRecord
     all_address_lines.join(', ')
   end
 
+  # Schema.org PostalAddress node, shared by the partner and event JSON-LD
+  # builders (PartnerJsonLd, EventJsonLd).
+  # @return [Hash]
+  def to_json_ld
+    {
+      '@type' => 'PostalAddress',
+      'streetAddress' => full_street_address,
+      'addressLocality' => city,
+      'postalCode' => postcode,
+      'addressCountry' => country_code
+    }.compact
+  end
+
   private
 
   # ==== Private methods ====

--- a/app/models/concerns/event_json_ld.rb
+++ b/app/models/concerns/event_json_ld.rb
@@ -54,13 +54,7 @@ module EventJsonLd
       location = {
         '@type' => 'Place',
         'name' => partner_at_location&.name,
-        'address' => {
-          '@type' => 'PostalAddress',
-          'streetAddress' => location_address.full_street_address,
-          'addressLocality' => location_address.city,
-          'postalCode' => location_address.postcode,
-          'addressCountry' => location_address.country_code
-        }.compact
+        'address' => location_address.to_json_ld
       }.compact
 
       if location_address.latitude && location_address.longitude

--- a/app/models/concerns/partner_json_ld.rb
+++ b/app/models/concerns/partner_json_ld.rb
@@ -25,7 +25,7 @@ module PartnerJsonLd
     data['sameAs'] = same_as if same_as.any?
 
     if address
-      postal_address = postal_address_json_ld(address)
+      postal_address = address.to_json_ld
       data['address'] = postal_address
       build_json_ld_location(data, postal_address)
     end
@@ -79,10 +79,19 @@ module PartnerJsonLd
     parsed = JSON.parse(opening_times_data)
     return [] unless parsed.is_a?(Array)
 
+    # Defensive per-slot: the column's validation silently skips (rather than
+    # rejects) malformed slots, and legacy rows predate it entirely — one bad
+    # slot must drop out, not 500 the page or discard its siblings.
     parsed.filter_map do |slot|
-      day = slot['dayOfWeek']
-      opens = Time.zone.parse(slot['opens'].to_s)
-      closes = Time.zone.parse(slot['closes'].to_s)
+      next unless slot.is_a?(Hash)
+
+      day = slot['dayOfWeek'].to_s
+      begin
+        opens = Time.zone.parse(slot['opens'].to_s)
+        closes = Time.zone.parse(slot['closes'].to_s)
+      rescue ArgumentError
+        next
+      end
       next if day.blank? || opens.nil? || closes.nil?
 
       {
@@ -115,22 +124,10 @@ module PartnerJsonLd
         entry['location'] = {
           '@type' => 'Place',
           'name' => event.partner_at_location&.name,
-          'address' => postal_address_json_ld(event.address)
+          'address' => event.address.to_json_ld
         }
       end
       entry
     end
-  end
-
-  # Builds a schema.org PostalAddress node from an Address. Shared by the
-  # partner's own address and the addresses of its embedded events.
-  def postal_address_json_ld(addr)
-    {
-      '@type' => 'PostalAddress',
-      'streetAddress' => addr.full_street_address,
-      'addressLocality' => addr.city,
-      'postalCode' => addr.postcode,
-      'addressCountry' => addr.country_code
-    }.compact
   end
 end

--- a/app/models/concerns/partner_json_ld.rb
+++ b/app/models/concerns/partner_json_ld.rb
@@ -25,23 +25,30 @@ module PartnerJsonLd
     data['sameAs'] = same_as if same_as.any?
 
     if address
-      postal_address = {
-        '@type' => 'PostalAddress',
-        'streetAddress' => address.full_street_address,
-        'addressLocality' => address.city,
-        'postalCode' => address.postcode,
-        'addressCountry' => address.country_code
-      }.compact
+      postal_address = postal_address_json_ld(address)
       data['address'] = postal_address
       build_json_ld_location(data, postal_address)
     end
 
+    build_json_ld_area_served(data)
     build_json_ld_events(data, base_url) if base_url
 
     data
   end
 
   private
+
+  # Partners that operate across a region rather than at a fixed venue (no
+  # address, just service areas) get no `location`/`geo` — there's no honest
+  # point to emit. `areaServed` is the right signal for them: it names the
+  # regions served without implying a coordinate. Emitted for any partner with
+  # service areas, whether or not it also has a venue.
+  def build_json_ld_area_served(data)
+    areas = service_area_neighbourhoods.order(:name).map do |neighbourhood|
+      { '@type' => 'AdministrativeArea', 'name' => neighbourhood.name }
+    end
+    data['areaServed'] = areas if areas.any?
+  end
 
   # Partners are all kinds of thing (charities, groups, council services,
   # libraries), so the org itself stays a generic Organization. The physical
@@ -108,16 +115,22 @@ module PartnerJsonLd
         entry['location'] = {
           '@type' => 'Place',
           'name' => event.partner_at_location&.name,
-          'address' => {
-            '@type' => 'PostalAddress',
-            'streetAddress' => event.address.full_street_address,
-            'addressLocality' => event.address.city,
-            'postalCode' => event.address.postcode,
-            'addressCountry' => event.address.country_code
-          }.compact
+          'address' => postal_address_json_ld(event.address)
         }
       end
       entry
     end
+  end
+
+  # Builds a schema.org PostalAddress node from an Address. Shared by the
+  # partner's own address and the addresses of its embedded events.
+  def postal_address_json_ld(addr)
+    {
+      '@type' => 'PostalAddress',
+      'streetAddress' => addr.full_street_address,
+      'addressLocality' => addr.city,
+      'postalCode' => addr.postcode,
+      'addressCountry' => addr.country_code
+    }.compact
   end
 end

--- a/app/models/concerns/partner_json_ld.rb
+++ b/app/models/concerns/partner_json_ld.rb
@@ -25,13 +25,15 @@ module PartnerJsonLd
     data['sameAs'] = same_as if same_as.any?
 
     if address
-      data['address'] = {
+      postal_address = {
         '@type' => 'PostalAddress',
         'streetAddress' => address.full_street_address,
         'addressLocality' => address.city,
         'postalCode' => address.postcode,
         'addressCountry' => address.country_code
       }.compact
+      data['address'] = postal_address
+      build_json_ld_location(data, postal_address)
     end
 
     build_json_ld_events(data, base_url) if base_url
@@ -40,6 +42,52 @@ module PartnerJsonLd
   end
 
   private
+
+  # Partners are all kinds of thing (charities, groups, council services,
+  # libraries), so the org itself stays a generic Organization. The physical
+  # venue signals — geo + opening hours — hang off a `location` Place, which
+  # carries no "business" connotation and is what Google reads for local
+  # results. Only emitted when the partner has an address.
+  def build_json_ld_location(data, postal_address)
+    place = { '@type' => 'Place', 'address' => postal_address }
+
+    if address.latitude && address.longitude
+      place['geo'] = {
+        '@type' => 'GeoCoordinates',
+        'latitude' => address.latitude,
+        'longitude' => address.longitude
+      }
+    end
+
+    hours = json_ld_opening_hours
+    place['openingHoursSpecification'] = hours if hours.any?
+
+    data['location'] = place
+  end
+
+  # Maps the stored opening_times (already schema.org-shaped) into an
+  # OpeningHoursSpecification array, normalising the day to a plain name and
+  # times to HH:MM.
+  def json_ld_opening_hours
+    parsed = JSON.parse(opening_times_data)
+    return [] unless parsed.is_a?(Array)
+
+    parsed.filter_map do |slot|
+      day = slot['dayOfWeek']
+      opens = Time.zone.parse(slot['opens'].to_s)
+      closes = Time.zone.parse(slot['closes'].to_s)
+      next if day.blank? || opens.nil? || closes.nil?
+
+      {
+        '@type' => 'OpeningHoursSpecification',
+        'dayOfWeek' => day.split('/').last,
+        'opens' => opens.strftime('%H:%M'),
+        'closes' => closes.strftime('%H:%M')
+      }
+    end
+  rescue JSON::ParserError
+    []
+  end
 
   def build_json_ld_events(data, base_url)
     upcoming = events.upcoming.sort_by_time.limit(10)

--- a/app/models/concerns/permalinkable.rb
+++ b/app/models/concerns/permalinkable.rb
@@ -22,7 +22,7 @@ module Permalinkable
     def permalink_resource(resource_name)
       define_method(:permalink) do |base_url: nil|
         base_url ||= Site::DIRECTORY_URL
-        "#{base_url.chomp('/')}/#{resource_name}/#{id}"
+        "#{base_url.chomp('/')}/#{resource_name}/#{to_param}"
       end
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -265,6 +265,14 @@ class Event < ApplicationRecord
   def og_title
     str = "#{summary}, #{date}, #{time}"
     str += " @ #{organiser.name}" if organiser
+    str
+  end
+
+  # Whether the event is over (dtend-aware, so a multi-day event still
+  # running doesn't count). Used to noindex stale event pages.
+  # @return [Boolean]
+  def past?
+    (dtend || dtstart) < DateTime.current.beginning_of_day
   end
 
   private

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -16,7 +16,8 @@ class Views::Events::Show < Views::Base
     content_for(:image) { event_og_image_url(event) }
     content_for(:image_alt) { t('og_image.alt.event', name: event.summary) }
     content_for(:description) { html_to_plaintext(event.description_html) }
-    content_for(:json_ld) { safe(event.to_json_ld(base_url: request.base_url).to_json) }
+    # Directory apex, matching the canonical tag — see partners/show.rb.
+    content_for(:json_ld) { safe(event.to_json_ld(base_url: ::Site::DIRECTORY_URL).to_json) }
 
     if site.nil?
       render_directory_layout

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -13,6 +13,9 @@ class Views::Events::Show < Views::Base
   def view_template
     content_for(:title) { event.og_title }
     content_for(:canonical) { event.permalink }
+    # Past events have no search value and accumulate forever — noindex them
+    # so they stop eating crawl budget and diluting the indexed site.
+    content_for(:robots) { 'noindex, noarchive' } if event.past?
     content_for(:image) { event_og_image_url(event) }
     content_for(:image_alt) { t('og_image.alt.event', name: event.summary) }
     content_for(:description) { html_to_plaintext(event.description_html) }

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -12,6 +12,7 @@ class Views::Events::Show < Views::Base
 
   def view_template
     content_for(:title) { event.og_title }
+    content_for(:canonical) { event.permalink }
     content_for(:image) { event_og_image_url(event) }
     content_for(:image_alt) { t('og_image.alt.event', name: event.summary) }
     content_for(:description) { html_to_plaintext(event.description_html) }

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -117,7 +117,10 @@ class Views::Layouts::Application < Phlex::HTML
     canonical_href = content_for?(:canonical) ? content_for(:canonical) : request.original_url
     meta(property: 'og:url', content: canonical_href)
     link(rel: 'canonical', href: canonical_href)
-    meta(name: 'robots', content: 'noarchive')
+    # Views can tighten robots via content_for (e.g. past events set noindex
+    # so thousands of stale event pages don't dilute the site in the index).
+    robots_content = content_for?(:robots) ? content_for(:robots) : 'noarchive'
+    meta(name: 'robots', content: robots_content)
 
     json_ld = site ? site.to_json_ld(base_url: request.base_url) : Site.directory_json_ld(request.base_url)
     script(type: 'application/ld+json') { raw safe(json_ld.to_json) }

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -111,7 +111,11 @@ class Views::Layouts::Application < Phlex::HTML
     meta(name: 'twitter:site', content: '@PlaceCal')
     meta(name: 'twitter:creator', content: '@gfscstudio')
     meta(property: 'og:url', content: request.original_url)
-    link(rel: 'canonical', href: request.original_url)
+    # Pages served on multiple site subdomains (partners, events) set
+    # :canonical to their directory-apex permalink so Google consolidates the
+    # duplicates onto placecal.org instead of splitting authority per subdomain.
+    canonical_href = content_for?(:canonical) ? content_for(:canonical) : request.original_url
+    link(rel: 'canonical', href: canonical_href)
     meta(name: 'robots', content: 'noarchive')
 
     json_ld = site ? site.to_json_ld(base_url: request.base_url) : Site.directory_json_ld(request.base_url)

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -110,11 +110,12 @@ class Views::Layouts::Application < Phlex::HTML
     meta(name: 'twitter:card', content: 'summary_large_image')
     meta(name: 'twitter:site', content: '@PlaceCal')
     meta(name: 'twitter:creator', content: '@gfscstudio')
-    meta(property: 'og:url', content: request.original_url)
     # Pages served on multiple site subdomains (partners, events) set
     # :canonical to their directory-apex permalink so Google consolidates the
     # duplicates onto placecal.org instead of splitting authority per subdomain.
+    # og:url follows it — all URL-identity signals should name the same page.
     canonical_href = content_for?(:canonical) ? content_for(:canonical) : request.original_url
+    meta(property: 'og:url', content: canonical_href)
     link(rel: 'canonical', href: canonical_href)
     meta(name: 'robots', content: 'noarchive')
 

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -27,6 +27,7 @@ class Views::Partners::Show < Views::Base
 
   def set_content_for_tags
     content_for(:title) { partner.name }
+    content_for(:canonical) { partner.permalink }
     content_for(:image) { partner_og_image_url(partner) }
     content_for(:image_alt) { t('og_image.alt.partner', name: partner.name) }
     content_for(:description) { partner.summary } if partner.summary

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -26,7 +26,7 @@ class Views::Partners::Show < Views::Base
   private
 
   def set_content_for_tags
-    content_for(:title) { partner.name }
+    content_for(:title) { title_with_place }
     content_for(:canonical) { partner.permalink }
     content_for(:image) { partner_og_image_url(partner) }
     content_for(:image_alt) { t('og_image.alt.partner', name: partner.name) }
@@ -35,6 +35,14 @@ class Views::Partners::Show < Views::Base
     # names the same URL as the canonical tag above — the structured data must
     # reinforce the canonical entity, not contradict it per-subdomain.
     content_for(:json_ld) { safe(partner.to_json_ld(base_url: ::Site::DIRECTORY_URL).to_json) }
+  end
+
+  # "Partner Name, Place" — the locality makes the <title> match how people
+  # actually search ("X in Y"). Neighbourhood name first (most local), city
+  # as fallback; service-area-only partners just get their name.
+  def title_with_place
+    place = partner.address&.neighbourhood&.name.presence || partner.address&.city.presence
+    place ? "#{partner.name}, #{place}" : partner.name
   end
 
   def render_partner_description

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -31,7 +31,10 @@ class Views::Partners::Show < Views::Base
     content_for(:image) { partner_og_image_url(partner) }
     content_for(:image_alt) { t('og_image.alt.partner', name: partner.name) }
     content_for(:description) { partner.summary } if partner.summary
-    content_for(:json_ld) { safe(partner.to_json_ld(base_url: request.base_url).to_json) }
+    # Built from the directory apex, not request.base_url, so the JSON-LD @id
+    # names the same URL as the canonical tag above — the structured data must
+    # reinforce the canonical entity, not contradict it per-subdomain.
+    content_for(:json_ld) { safe(partner.to_json_ld(base_url: ::Site::DIRECTORY_URL).to_json) }
   end
 
   def render_partner_description

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -39,10 +39,14 @@ class Views::Partners::Show < Views::Base
 
   # "Partner Name, Place" — the locality makes the <title> match how people
   # actually search ("X in Y"). Neighbourhood name first (most local), city
-  # as fallback; service-area-only partners just get their name.
+  # as fallback; service-area-only partners just get their name. Skipped when
+  # the name already contains the place ("Moss Side Powerhouse Library, Moss
+  # Side" reads clunky in search results and adds nothing).
   def title_with_place
     place = partner.address&.neighbourhood&.name.presence || partner.address&.city.presence
-    place ? "#{partner.name}, #{place}" : partner.name
+    return partner.name if place.nil? || partner.name.downcase.include?(place.downcase)
+
+    "#{partner.name}, #{place}"
   end
 
   def render_partner_description

--- a/spec/models/concerns/partner_json_ld_spec.rb
+++ b/spec/models/concerns/partner_json_ld_spec.rb
@@ -90,6 +90,28 @@ RSpec.describe PartnerJsonLd do
       it "omits location key" do
         expect(data).not_to have_key("location")
       end
+
+      it "emits areaServed instead of a fabricated location" do
+        expect(data).to have_key("areaServed")
+        expect(data).not_to have_key("location")
+      end
+    end
+
+    context "with service areas" do
+      let(:ward) { create(:neighbourhood, name: "Moss Side") }
+      let(:partner) { create(:partner, address: nil, service_areas: [create(:service_area, neighbourhood: ward)]) }
+
+      it "names each served region as an AdministrativeArea" do
+        expect(data["areaServed"]).to eq([
+                                           { "@type" => "AdministrativeArea", "name" => "Moss Side" }
+                                         ])
+      end
+    end
+
+    context "without service areas" do
+      it "omits areaServed" do
+        expect(data).not_to have_key("areaServed")
+      end
     end
 
     context "with a physical location" do

--- a/spec/models/concerns/partner_json_ld_spec.rb
+++ b/spec/models/concerns/partner_json_ld_spec.rb
@@ -86,6 +86,51 @@ RSpec.describe PartnerJsonLd do
       it "omits address key" do
         expect(data).not_to have_key("address")
       end
+
+      it "omits location key" do
+        expect(data).not_to have_key("location")
+      end
+    end
+
+    context "with a physical location" do
+      it "emits a generic Place location (not LocalBusiness) with geo" do
+        location = data["location"]
+        expect(location["@type"]).to eq("Place")
+        expect(location["address"]["@type"]).to eq("PostalAddress")
+        expect(location["geo"]["@type"]).to eq("GeoCoordinates")
+        expect(location["geo"]["latitude"]).to eq(partner.address.latitude.to_f)
+        expect(location["geo"]["longitude"]).to eq(partner.address.longitude.to_f)
+      end
+
+      it "keeps the org itself typed as Organization" do
+        expect(data["@type"]).to eq("Organization")
+      end
+
+      it "omits geo when the address has no coordinates" do
+        partner.address.latitude = nil
+        partner.address.longitude = nil
+        expect(partner.to_json_ld["location"]).not_to have_key("geo")
+      end
+    end
+
+    context "with opening times" do
+      before do
+        partner.update!(opening_times: [
+          { "dayOfWeek" => "http://schema.org/Monday", "opens" => "09:00", "closes" => "17:00" }
+        ].to_json)
+      end
+
+      it "emits openingHoursSpecification on the location" do
+        spec = data["location"]["openingHoursSpecification"]
+        expect(spec).to eq([
+                             { "@type" => "OpeningHoursSpecification", "dayOfWeek" => "Monday", "opens" => "09:00", "closes" => "17:00" }
+                           ])
+      end
+
+      it "omits openingHoursSpecification when there are no opening times" do
+        partner.update!(opening_times: "[]")
+        expect(partner.to_json_ld["location"]).not_to have_key("openingHoursSpecification")
+      end
     end
 
     context "with embedded events" do

--- a/spec/models/concerns/partner_json_ld_spec.rb
+++ b/spec/models/concerns/partner_json_ld_spec.rb
@@ -153,6 +153,30 @@ RSpec.describe PartnerJsonLd do
         partner.update!(opening_times: "[]")
         expect(partner.to_json_ld["location"]).not_to have_key("openingHoursSpecification")
       end
+
+      # The opening_times validation silently skips malformed slots rather
+      # than rejecting them, and legacy rows predate it — so rendering must
+      # survive whatever is persisted, dropping only the bad slot.
+      it "drops slots with unparseable times instead of raising" do
+        partner.update!(opening_times: [
+          { "dayOfWeek" => "http://schema.org/Monday", "opens" => "25:99", "closes" => "17:00" },
+          { "dayOfWeek" => "http://schema.org/Tuesday", "opens" => "10:00", "closes" => "16:00" }
+        ].to_json)
+        spec = partner.to_json_ld["location"]["openingHoursSpecification"]
+        expect(spec).to eq([
+                             { "@type" => "OpeningHoursSpecification", "dayOfWeek" => "Tuesday", "opens" => "10:00", "closes" => "16:00" }
+                           ])
+      end
+
+      it "drops non-hash slots instead of raising" do
+        partner.update!(opening_times: [
+          "nonsense",
+          { "dayOfWeek" => "http://schema.org/Friday", "opens" => "09:00", "closes" => "12:00" }
+        ].to_json)
+        spec = partner.to_json_ld["location"]["openingHoursSpecification"]
+        expect(spec.length).to eq(1)
+        expect(spec.first["dayOfWeek"]).to eq("Friday")
+      end
     end
 
     context "with embedded events" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -99,6 +99,41 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#past?" do
+    it "is true once the event is over" do
+      event = build(:event, dtstart: 2.days.ago, dtend: 2.days.ago + 1.hour)
+      expect(event.past?).to be true
+    end
+
+    it "is false for upcoming events" do
+      event = build(:event, dtstart: 1.day.from_now, dtend: 1.day.from_now + 1.hour)
+      expect(event.past?).to be false
+    end
+
+    it "is false for a multi-day event still running" do
+      event = build(:event, dtstart: 1.day.ago, dtend: 1.day.from_now)
+      expect(event.past?).to be false
+    end
+
+    it "falls back to dtstart when dtend is missing" do
+      event = build(:event, dtstart: 2.days.ago, dtend: nil)
+      expect(event.past?).to be true
+    end
+  end
+
+  describe "#og_title" do
+    it "includes the organiser when present" do
+      event = build(:event, summary: "Tea Dance", organiser: build(:partner, name: "The Powerhouse"))
+      expect(event.og_title).to include("Tea Dance")
+      expect(event.og_title).to include("@ The Powerhouse")
+    end
+
+    it "still returns a title without an organiser" do
+      event = build(:event, summary: "Tea Dance", organiser: nil)
+      expect(event.og_title).to include("Tea Dance")
+    end
+  end
+
   describe "scopes" do
     let(:partner) { create(:partner) }
 

--- a/spec/requests/public/events_spec.rb
+++ b/spec/requests/public/events_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe "Public Events", type: :request do
       get event_url(event, host: "#{site.slug}.lvh.me")
       expect(response.body).to include(partner.name)
     end
+
+    it "does not noindex upcoming events" do
+      get event_url(event, host: "#{site.slug}.lvh.me")
+      expect(response.body).to include(%(<meta name="robots" content="noarchive">))
+      expect(response.body).not_to include("noindex")
+    end
+
+    it "noindexes past events" do
+      past_event = create(:event,
+                          organiser: partner,
+                          dtstart: 2.days.ago,
+                          dtend: 2.days.ago + 1.hour,
+                          address: address)
+      get event_url(past_event, host: "#{site.slug}.lvh.me")
+      expect(response).to be_successful
+      expect(response.body).to include(%(<meta name="robots" content="noindex, noarchive">))
+    end
   end
 
   describe "GET /events with date filter" do

--- a/spec/requests/public/partners_spec.rb
+++ b/spec/requests/public/partners_spec.rb
@@ -58,6 +58,13 @@ RSpec.describe "Public Partners", type: :request do
       )
     end
 
+    it "emits JSON-LD whose @id matches the canonical" do
+      get partner_url(partner, host: "#{site.slug}.lvh.me")
+      expect(response.body).to include(
+        %("@id":"https://placecal.org/partners/#{partner.slug}")
+      )
+    end
+
     it "shows partner summary" do
       get partner_url(partner, host: "#{site.slug}.lvh.me")
       expect(response.body).to include(partner.summary)

--- a/spec/requests/public/partners_spec.rb
+++ b/spec/requests/public/partners_spec.rb
@@ -75,9 +75,11 @@ RSpec.describe "Public Partners", type: :request do
       expect(response.body).to include(partner.address.postcode)
     end
 
-    it "shows correct page title" do
+    it "shows correct page title with locality" do
       get partner_url(partner, host: "#{site.slug}.lvh.me")
-      expect(response.body).to include("<title>#{partner.name} | #{site.name}</title>")
+      expect(response.body).to include(
+        "<title>#{partner.name}, #{partner.address.neighbourhood.name} | #{site.name}</title>"
+      )
     end
 
     it "includes Organization JSON-LD structured data" do

--- a/spec/requests/public/partners_spec.rb
+++ b/spec/requests/public/partners_spec.rb
@@ -75,11 +75,18 @@ RSpec.describe "Public Partners", type: :request do
       expect(response.body).to include(partner.address.postcode)
     end
 
-    it "shows correct page title with locality" do
-      get partner_url(partner, host: "#{site.slug}.lvh.me")
+    it "shows the page title with locality" do
+      named_partner = create(:partner, name: "Tea Dance Collective", address: create(:address, neighbourhood: ward))
+      get partner_url(named_partner, host: "#{site.slug}.lvh.me")
       expect(response.body).to include(
-        "<title>#{partner.name}, #{partner.address.neighbourhood.name} | #{site.name}</title>"
+        "<title>Tea Dance Collective, #{ward.name} | #{site.name}</title>"
       )
+    end
+
+    it "omits the locality when the partner name already contains it" do
+      # riverside_partner is "Riverside Community Hub" in the Riverside ward
+      get partner_url(partner, host: "#{site.slug}.lvh.me")
+      expect(response.body).to include("<title>#{partner.name} | #{site.name}</title>")
     end
 
     it "includes Organization JSON-LD structured data" do

--- a/spec/requests/public/partners_spec.rb
+++ b/spec/requests/public/partners_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe "Public Partners", type: :request do
       expect(response.body).to include(partner.name)
     end
 
+    it "canonicalises to the directory apex, not the site subdomain" do
+      get partner_url(partner, host: "#{site.slug}.lvh.me")
+      expect(response.body).to include(
+        %(<link rel="canonical" href="https://placecal.org/partners/#{partner.slug}">)
+      )
+    end
+
     it "shows partner summary" do
       get partner_url(partner, host: "#{site.slug}.lvh.me")
       expect(response.body).to include(partner.summary)

--- a/spec/requests/public/sitemaps_spec.rb
+++ b/spec/requests/public/sitemaps_spec.rb
@@ -38,18 +38,26 @@ RSpec.describe "Public Sitemaps", type: :request do
     end
 
     describe "GET /sitemap/events.xml" do
-      let!(:recent_event) { create(:event, dtstart: 1.week.from_now, dtend: 1.week.from_now + 1.hour) }
-      let!(:old_event) { create(:event, dtstart: 6.months.ago, dtend: 6.months.ago + 1.hour) }
+      let!(:upcoming_event) { create(:event, dtstart: 1.week.from_now, dtend: 1.week.from_now + 1.hour) }
+      let!(:past_event) { create(:event, dtstart: 1.week.ago, dtend: 1.week.ago + 1.hour) }
+      let!(:ongoing_event) { create(:event, dtstart: 1.day.ago, dtend: 1.day.from_now) }
 
-      it "includes recent events" do
+      it "includes upcoming events" do
         get "/sitemap/events.xml", headers: { "Host" => host }
         expect(response).to be_successful
-        expect(response.body).to include("https://placecal.org/events/#{recent_event.id}")
+        expect(response.body).to include("https://placecal.org/events/#{upcoming_event.id}")
       end
 
-      it "excludes events older than 3 months" do
+      # Past event pages are noindexed (see Views::Events::Show), so listing
+      # them would trigger "submitted URL marked noindex" warnings.
+      it "excludes past events" do
         get "/sitemap/events.xml", headers: { "Host" => host }
-        expect(response.body).not_to include("events/#{old_event.id}")
+        expect(response.body).not_to include("events/#{past_event.id}")
+      end
+
+      it "includes multi-day events still running" do
+        get "/sitemap/events.xml", headers: { "Host" => host }
+        expect(response.body).to include("events/#{ongoing_event.id}")
       end
     end
 

--- a/spec/support/schemas/schema_org_organization.json
+++ b/spec/support/schemas/schema_org_organization.json
@@ -29,6 +29,19 @@
 			},
 			"additionalProperties": false
 		},
+		"areaServed": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"required": ["@type", "name"],
+				"properties": {
+					"@type": { "type": "string", "enum": ["AdministrativeArea"] },
+					"name": { "type": "string", "minLength": 1 }
+				},
+				"additionalProperties": false
+			},
+			"minItems": 1
+		},
 		"location": {
 			"type": "object",
 			"required": ["@type"],

--- a/spec/support/schemas/schema_org_organization.json
+++ b/spec/support/schemas/schema_org_organization.json
@@ -29,6 +29,53 @@
 			},
 			"additionalProperties": false
 		},
+		"location": {
+			"type": "object",
+			"required": ["@type"],
+			"properties": {
+				"@type": { "type": "string", "enum": ["Place"] },
+				"address": {
+					"type": "object",
+					"required": ["@type"],
+					"properties": {
+						"@type": { "type": "string", "enum": ["PostalAddress"] },
+						"streetAddress": { "type": "string" },
+						"addressLocality": { "type": "string" },
+						"postalCode": { "type": "string" },
+						"addressCountry": { "type": "string" }
+					},
+					"additionalProperties": false
+				},
+				"geo": {
+					"type": "object",
+					"required": ["@type", "latitude", "longitude"],
+					"properties": {
+						"@type": { "type": "string", "enum": ["GeoCoordinates"] },
+						"latitude": { "type": "number" },
+						"longitude": { "type": "number" }
+					},
+					"additionalProperties": false
+				},
+				"openingHoursSpecification": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"required": ["@type", "dayOfWeek", "opens", "closes"],
+						"properties": {
+							"@type": {
+								"type": "string",
+								"enum": ["OpeningHoursSpecification"]
+							},
+							"dayOfWeek": { "type": "string", "minLength": 1 },
+							"opens": { "type": "string", "pattern": "^\\d{2}:\\d{2}$" },
+							"closes": { "type": "string", "pattern": "^\\d{2}:\\d{2}$" }
+						},
+						"additionalProperties": false
+					}
+				}
+			},
+			"additionalProperties": false
+		},
 		"event": {
 			"type": "array",
 			"items": {


### PR DESCRIPTION
## Why

We don't rank well for community-venue queries partly because **we compete against ourselves**. The same partner and event pages are served on every neighbourhood site subdomain (`manchesterlibraries.placecal.org`, `hulme.placecal.org`, …) *and* the nationwide directory. The layout emitted a **self-referential canonical** (`request.original_url`), so each subdomain copy canonicalised to itself. Google saw N near-duplicate copies of every partner/event across `*.placecal.org` and split ranking authority between them, often indexing a subdomain copy instead of the directory.

The `Permalinkable` concern was already written to build directory-apex permalinks — it was just never wired into the canonical tag, and it used the raw numeric `id` instead of the slug.

## What changed

**Canonical consolidation**
- `Permalinkable#permalink` now uses `to_param`, so partners canonicalise to their slug URL (`https://placecal.org/partners/moss-side-powerhouse-library`); events keep their id URL.
- The layout canonical is overridable via `content_for(:canonical)`, defaulting to `request.original_url`.
- Partner and event show views set the canonical to their directory-apex permalink, so all subdomain copies point at `placecal.org`.
- `og:url` and the JSON-LD `@id` follow the canonical — all URL-identity signals name the same page instead of contradicting each other per-subdomain.

**Richer partner structured data (local-search signals)**
- Partners stay typed `Organization` — they're charities, groups, council services, libraries, not all "businesses", so `LocalBusiness` would be semantically wrong and we have no category field to pick a subtype.
- Partners **with a venue** get a generic `location` **`Place`** carrying `geo` (`GeoCoordinates`) and `openingHoursSpecification` — mapped from the existing `opening_times` column, which was already stored in schema.org shape but never emitted.
- Partners **without a venue** (service-area-only) get **`areaServed`** (`AdministrativeArea` nodes from their service-area neighbourhoods) instead of a fabricated location.
- Opening-hours mapping is defensive per-slot: the column's validation silently skips malformed slots rather than rejecting them, and legacy rows predate it — one bad slot drops out instead of 500ing the page.

**Stale-event hygiene**
- New `Event#past?` (dtend-aware, so multi-day events still running don't count).
- Past event pages emit `noindex, noarchive` — thousands of stale, thin, near-duplicate pages stop eating crawl budget and diluting the indexed site.
- The events sitemap now lists only non-past events, so it never submits noindexed URLs (avoids "submitted URL marked noindex" Search Console warnings).

**Query-shaped titles**
- Partner pages: `Partner Name, Place | Site Name` (neighbourhood first, city fallback) — matches how people actually search ("X in Y"). Service-area-only partners keep just their name.
- Fixed a latent bug: `Event#og_title` returned `nil` for events without an organiser, leaving those pages with no title at all.

**Refactor**
- Schema.org `PostalAddress` was built identically in three places — now `Address#to_json_ld`, used by both partner and event JSON-LD builders.

## Reviewer notes
- Test JSON schema (`schema_org_organization.json`) extended for the new `location` and `areaServed` nodes (it uses `additionalProperties: false`).
- Verified end-to-end via request specs: subdomain partner pages emit apex canonical + matching JSON-LD `@id` + locality title; past events emit noindex; upcoming events don't.
- This is the code-side of the SEO story; the remaining wins are off-page (partner backlinks/embeds) and content (partner description completeness, neighbourhood landing pages). It won't beat a venue's own site for its brand name — the target is discovery queries ("what's on in moss side").