### PR TITLE
Per-partner events CSV export for Canva Bulk Create posters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :development do
   gem 'rack-mini-profiler'        # In-page performance profiler (?pp=help in dev)
   gem 'rails-erd'                 # Entity-relationship diagrams
   gem 'rdoc'                      # Documentation generator
-  gem 'rubocop', '1.88.0', require: false
+  gem 'rubocop', '1.88.1', require: false
   gem 'rubocop-graphql', '1.6.0', require: false
   gem 'rubocop-performance', '1.26.1', require: false
   gem 'rubocop-rails', '2.35.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -598,7 +598,7 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
-    rubocop (1.88.0)
+    rubocop (1.88.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -816,7 +816,7 @@ DEPENDENCIES
   rails-erd
   rdoc
   rspec-rails (~> 8.0)
-  rubocop (= 1.88.0)
+  rubocop (= 1.88.1)
   rubocop-graphql (= 1.6.0)
   rubocop-performance (= 1.26.1)
   rubocop-rails (= 2.35.5)

--- a/app/components/directory/partner_sidebar.rb
+++ b/app/components/directory/partner_sidebar.rb
@@ -121,7 +121,7 @@ class Components::Directory::PartnerSidebar < Components::Directory::Base
           plain t('directory.sidebar.subscribe_ical')
         end
       end
-      div(class: 'mt-3') do
+      div(class: 'mt-1.5') do
         a(href: partner_url(@partner, format: :csv),
           class: 'inline-flex items-center gap-1.5 text-sm font-bold text-foreground no-underline hover:underline hover:decoration-primary') do
           raw(view_context.icon(:arrow_down, size: '3.5'))

--- a/app/components/directory/partner_sidebar.rb
+++ b/app/components/directory/partner_sidebar.rb
@@ -121,6 +121,13 @@ class Components::Directory::PartnerSidebar < Components::Directory::Base
           plain t('directory.sidebar.subscribe_ical')
         end
       end
+      div(class: 'mt-3') do
+        a(href: partner_url(@partner, format: :csv),
+          class: 'inline-flex items-center gap-1.5 text-sm font-bold text-foreground no-underline hover:underline hover:decoration-primary') do
+          raw(view_context.icon(:arrow_down, size: '3.5'))
+          plain t('directory.sidebar.download_csv')
+        end
+      end
     end
   end
 end

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -10,12 +10,12 @@ class Components::Navigation < Components::Base
     header(class: [
              'header grid grid-cols-[1fr_auto] items-center',
              *(
-              if @site.nil?
-                ['header__default container-public py-6 bg-background border-b border-rules']
-              else
-                ['header__partner mx-4 pt-4', 'lg:py-4 lg:mx-12 lg:py-6']
-              end
-            )
+               if @site.nil?
+                 ['header__default container-public py-6 bg-background border-b border-rules']
+               else
+                 ['header__partner mx-4 pt-4', 'lg:py-4 lg:mx-12 lg:py-6']
+               end
+             )
            ], data: { controller: 'mobile-menu' }) do
       render_branding
       render_toggle

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -170,7 +170,16 @@ class ApplicationController < ActionController::Base
   # Sets a distinct AppSignal action name and sends a server-side pageview
   # to Plausible (iCal clients don't execute JavaScript).
   def track_ical_download
-    Appsignal::Transaction.current.set_action("#{self.class.name}#ical_feed")
+    track_file_download('ical_feed')
+  end
+
+  # Track CSV event exports (see EventsCsv) the same way.
+  def track_csv_download
+    track_file_download('csv_export')
+  end
+
+  def track_file_download(action)
+    Appsignal::Transaction.current.set_action("#{self.class.name}##{action}")
 
     return unless Rails.env.production?
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -25,7 +25,7 @@ class PartnersController < ApplicationController
   # GET /partners/1
   # GET /partners/1.json
   def show
-    redirect_to root_path if @partner.hidden
+    return redirect_to root_path if @partner.hidden
 
     upcoming_count = Event.by_organiser_or_place(@partner).upcoming.count
     if upcoming_count.zero?
@@ -78,6 +78,13 @@ class PartnersController < ApplicationController
         cal = create_calendar(Event.by_organiser_or_place(@partner).ical_feed, "#{@partner} - Powered by PlaceCal")
         cal.publish
         render plain: cal.to_ical
+      end
+      format.csv do
+        track_csv_download
+        events = Event.by_organiser_or_place(@partner).upcoming.sort_by_time
+        site_url = current_site&.url || 'https://placecal.org'
+        send_data EventsCsv.new(events, site_url: site_url).call,
+                  filename: "#{@partner.slug}-events.csv", type: :csv
       end
     end
   end

--- a/app/services/events_csv.rb
+++ b/app/services/events_csv.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+# Builds a CSV of events for download, one row per event.
+#
+# The column set is designed to feed Canva's Bulk Create feature
+# (https://www.canva.com/help/bulk-create/), which generates one design per
+# row from a poster template. Bulk Create treats URLs in cells as plain
+# text, so every column is text — image URLs would not flow into image
+# frames. See doc/canva-posters.md.
+class EventsCsv
+  HEADERS = %i[title date time location organiser url description].freeze
+
+  # @param events [Enumerable<Event>]
+  # @param site_url [String] base URL used to build each event's page link
+  def initialize(events, site_url:)
+    @events = events
+    @site_url = site_url
+  end
+
+  # @return [String] UTF-8 CSV with a header row
+  def call
+    CSV.generate do |csv|
+      csv << HEADERS.map { |header| I18n.t("events.csv_export.headers.#{header}") }
+      @events.each { |event| csv << row(event) }
+    end
+  end
+
+  private
+
+  def row(event)
+    [
+      event.summary,
+      event.date_year.strip,
+      event.time,
+      event.location,
+      event.organiser&.name,
+      "#{@site_url}/events/#{event.id}",
+      plain_description(event)
+    ]
+  end
+
+  # Descriptions imported from iCal sources keep RFC 5545 escape sequences
+  # (same set handled by ApplicationController#unescape_ical_text); a poster
+  # blurb wants none of them, nor any line breaks.
+  def plain_description(event)
+    event.description.to_s
+         .gsub('\\n', ' ')
+         .gsub('\\,', ',')
+         .gsub('\\;', ';')
+         .gsub("\\'", "'")
+         .gsub('\\"', '"')
+         .gsub('\\\\', '\\')
+         .squish
+  end
+end

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -240,6 +240,10 @@ class Views::Partners::Show < Views::Base
     Meta("/partners/#{partner.id}") do |component|
       component.with_link do
         link_to "Subscribe to #{partner}'s events with iCal", partner_url(partner, protocol: :webcal, format: :ics)
+        if events.any?
+          whitespace
+          link_to t('events.csv_export.link'), partner_url(partner, format: :csv)
+        end
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,6 +247,7 @@ en:
       categories: "Categories"
       share_subscribe: "Share & subscribe"
       subscribe_ical: "Subscribe via iCal"
+      download_csv: "Download events (CSV)"
     contact:
       get_in_touch: "Get in touch"
       no_contact: "No contact information — let us know!"
@@ -292,6 +293,26 @@ en:
       build: "Build:"
       placecal_logo_alt: "PlaceCal logo"
       gfsc_logo_alt: "Geeks for Social Change"
+
+  # ===========================================================================
+  # EVENT EXPORTS (shared by local sites and the directory)
+  # ===========================================================================
+
+  events:
+    csv_export:
+      link: "Download events as CSV"
+      # Column headers for the events CSV (app/services/events_csv.rb).
+      # These double as Canva Bulk Create field names — the shared poster
+      # template's fields are connected to them by name, so renaming a
+      # header means updating the template too (see doc/canva-posters.md).
+      headers:
+        title: "Title"
+        date: "Date"
+        time: "Time"
+        location: "Location"
+        organiser: "Organiser"
+        url: "More info"
+        description: "Description"
 
   # ===========================================================================
   # DATE & TIME FORMATS

--- a/doc/canva-posters.md
+++ b/doc/canva-posters.md
@@ -1,0 +1,57 @@
+# Making event posters with Canva Bulk Create
+
+PlaceCal can export any partner's upcoming events as a CSV file. Paired with
+Canva's [Bulk Create](https://www.canva.com/help/bulk-create/) feature, this
+lets a partner generate a poster (or social media graphic) for every one of
+their events in a couple of minutes, from a shared template.
+
+This is the MVP route chosen in
+[issue #847](https://github.com/geeksforsocialchange/PlaceCal/issues/847):
+Canva's Autofill API is Enterprise-only, but Bulk Create just needs a CSV and
+a paid Canva plan — and [Canva for Nonprofits](https://www.canva.com/nonprofits/)
+gives registered charities all the paid features for free.
+
+## Getting the CSV
+
+- On a partner's page, follow **Download events as CSV** (or request
+  `/partners/<slug>.csv` directly).
+- The file contains the partner's upcoming events, one row per event.
+
+### Columns
+
+| Header      | Contents                                        |
+| ----------- | ----------------------------------------------- |
+| Title       | Event name                                      |
+| Date        | e.g. `1 Jan 2026`                               |
+| Time        | e.g. `09:00 – 10:00`                            |
+| Location    | Venue address (falls back to organiser address) |
+| Organiser   | Partner name                                    |
+| More info   | Link to the event's PlaceCal page               |
+| Description | Event description, flattened to one line        |
+
+The headers come from the `events.csv_export.headers` locale keys and the rows
+are built in `app/services/events_csv.rb`. **Canva templates connect fields by
+header name**, so renaming a header breaks existing templates — change both
+together.
+
+Everything is text: Canva Bulk Create does not fetch images from URLs in CSV
+cells (it treats them as plain text), so the export deliberately contains no
+image columns.
+
+## Using it in Canva
+
+1. Open the poster template (or make your own — any design with text
+   placeholders works). Bulk Create needs a paid plan: Pro, Teams, Education,
+   or the free-for-charities Nonprofits plan.
+2. In the editor sidebar choose **Apps → Bulk Create**.
+3. **Upload data** and pick the downloaded CSV.
+4. Connect each text placeholder to a column: select the element, then
+   **Connect data** and choose e.g. _Title_.
+5. **Continue → Generate designs** — one poster per event (up to 300 rows per
+   run).
+6. Tweak individual posters as needed, then download or print.
+
+## Shared PlaceCal template
+
+We plan to maintain a shared PlaceCal poster template with fields already
+connected to the CSV columns — link it here once it exists.

--- a/spec/requests/public/partner_csv_export_spec.rb
+++ b/spec/requests/public/partner_csv_export_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Partner events CSV export", type: :request do
+  let(:partner) { create(:riverside_partner) }
+  let(:calendar) { create(:calendar, organiser: partner) }
+
+  describe "GET /partners/:id.csv" do
+    let!(:upcoming_event) do
+      create(:event,
+             organiser: partner,
+             calendar: calendar,
+             summary: "Tea Dance",
+             description: 'Dancing\, tea\; and \"biscuits\"\nAll welcome',
+             dtstart: 2.days.from_now.at_beginning_of_hour,
+             dtend: 2.days.from_now.at_beginning_of_hour + 2.hours)
+    end
+    let!(:past_event) do
+      create(:event,
+             organiser: partner,
+             calendar: calendar,
+             summary: "Ancient History",
+             dtstart: 2.days.ago.at_beginning_of_hour,
+             dtend: 2.days.ago.at_beginning_of_hour + 1.hour)
+    end
+
+    def parsed_csv
+      get partner_url(partner, host: "lvh.me", format: :csv)
+      expect(response).to be_successful
+      CSV.parse(response.body, headers: true)
+    end
+
+    it "returns a CSV attachment" do
+      get partner_url(partner, host: "lvh.me", format: :csv)
+      expect(response).to be_successful
+      expect(response.media_type).to eq("text/csv")
+      expect(response.headers["Content-Disposition"]).to include("#{partner.slug}-events.csv")
+    end
+
+    it "has the Canva Bulk Create header row" do
+      expect(parsed_csv.headers).to eq(
+        ["Title", "Date", "Time", "Location", "Organiser", "More info", "Description"]
+      )
+    end
+
+    it "includes upcoming events with poster-ready fields" do
+      row = parsed_csv.find { |r| r["Title"] == "Tea Dance" }
+      expect(row).to be_present
+      expect(row["Date"]).to eq(upcoming_event.dtstart.strftime("%e %b %Y").strip)
+      expect(row["Time"]).to eq(upcoming_event.time)
+      expect(row["Location"]).to eq(upcoming_event.location)
+      expect(row["Organiser"]).to eq(partner.name)
+      expect(row["More info"]).to eq("https://placecal.org/events/#{upcoming_event.id}")
+    end
+
+    it "unescapes iCal sequences and flattens the description to one line" do
+      row = parsed_csv.find { |r| r["Title"] == "Tea Dance" }
+      expect(row["Description"]).to eq('Dancing, tea; and "biscuits" All welcome')
+    end
+
+    it "excludes past events" do
+      titles = parsed_csv.map { |r| r["Title"] }
+      expect(titles).not_to include("Ancient History")
+    end
+
+    context "when the partner has no events" do
+      let(:empty_partner) { create(:partner) }
+
+      it "returns just the header row" do
+        get partner_url(empty_partner, host: "lvh.me", format: :csv)
+        expect(response).to be_successful
+        rows = CSV.parse(response.body, headers: true)
+        expect(rows.count).to eq(0)
+        expect(rows.headers).to include("Title")
+      end
+    end
+
+    context "when the partner is hidden" do
+      let(:hidden_partner) { create(:partner, hidden: true, hidden_reason: "Test", hidden_blame_id: 1) }
+
+      it "redirects instead of serving the CSV" do
+        get partner_url(hidden_partner, host: "lvh.me", format: :csv)
+        expect(response).to redirect_to(root_path)
+      end
+
+      # Regression: redirect_to without return used to raise DoubleRenderError
+      # for any non-HTML format on hidden partners.
+      it "redirects the iCal feed too" do
+        get partner_url(hidden_partner, host: "lvh.me", format: :ics)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "with awkward characters in event fields" do
+      let!(:awkward_event) do
+        create(:event,
+               organiser: partner,
+               calendar: calendar,
+               summary: %(Knit, natter & "craft" night),
+               dtstart: 3.days.from_now.at_beginning_of_hour,
+               dtend: 3.days.from_now.at_beginning_of_hour + 1.hour)
+      end
+
+      it "round-trips commas and quotes safely" do
+        titles = parsed_csv.map { |r| r["Title"] }
+        expect(titles).to include(%(Knit, natter & "craft" night))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #847 (MVP route).

## What

- **`GET /partners/:slug.csv`** — downloads the partner's upcoming events as a CSV, one row per event, with columns designed to feed a [Canva Bulk Create](https://www.canva.com/help/bulk-create/) poster template: Title, Date, Time, Location, Organiser, More info (event URL), Description.
- Download links on both the **local-site partner page** (meta bar, next to the iCal link, only when the partner has events) and the **directory partner sidebar** (Share & subscribe card).
- CSV downloads tracked in AppSignal/Plausible the same way as iCal feeds, so we can see whether the feature gets used.
- Partner-facing how-to at `doc/canva-posters.md`.

## Why CSV + Bulk Create (research summary)

- Canva's **Autofill/Connect API is Enterprise-gated** — both the integration and every end user must be in a Canva Enterprise org. Dead end for community partners.
- **Bulk Create** generates one design per CSV row (300 rows/run) and works on any paid plan — including [Canva for Nonprofits](https://www.canva.com/nonprofits/), which is **free for registered charities**, i.e. most PlaceCal partners.
- Bulk Create treats URLs in cells as plain text, so the export is deliberately text-only (no image columns).
- Future options (out of scope): self-hosted poster rendering on the existing `OgImage` libvips pipeline; a Canva Apps SDK app pulling events via GraphQL.

## Also fixes

Hidden partners 500'd (`DoubleRenderError`) on any non-HTML format (`.ics` included) because `show`'s redirect never returned. Now redirects properly; regression-tested.

## Verification

- New request spec `spec/requests/public/partner_csv_export_spec.rb` (9 examples); full `spec/requests` suite green (544 examples).
- Exercised live against a dev server: CSV content, filename, content-type, past-event exclusion, per-site event URLs, and both download links verified on directory + subdomain hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)