### PR TITLE
Add calendar detection rules API for the browser extension

### DIFF
--- a/app/controllers/calendar_detection_rules_controller.rb
+++ b/app/controllers/calendar_detection_rules_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Public, unauthenticated JSON export of the calendar parsers' URL detection
+# rules, consumed by the PlaceCal browser extension. Lives under /api/ so the
+# existing CORS (config/application.rb) and rate-limit rules apply.
+class CalendarDetectionRulesController < ApplicationController
+  skip_before_action :set_supporters
+  skip_before_action :set_navigation
+
+  def show
+    payload = CalendarDetectionRules.as_json
+    expires_in 6.hours, public: true
+    render json: payload if stale?(etag: payload)
+  end
+end

--- a/app/jobs/calendar_importer/parsers/base.rb
+++ b/app/jobs/calendar_importer/parsers/base.rb
@@ -12,6 +12,15 @@ module CalendarImporter::Parsers
     NAME = ''
     KEY = ''
 
+    # URL detection patterns, declared as data in the shared Ruby/JavaScript
+    # regex subset (^ $ \. [...] (a|b) * + ? {n}) so they can be exported
+    # verbatim to the browser extension via /api/v1/calendar_detection_rules
+    # and compiled with JavaScript's `new RegExp(pattern, flags)`. Ruby-only
+    # constructs (\A \z \h, inline flags, POSIX classes) are rejected by
+    # spec/jobs/calendar_importer/detection_rules_spec.rb.
+    # Each entry is { pattern: String, flags: '' | 'i' }.
+    URL_PATTERNS = [].freeze
+
     # Third-party event sources intermittently return rate-limit (429) and
     # server-error (5xx) responses. These are transient upstream failures, not
     # problems with our request, so they're worth retrying with backoff before
@@ -51,6 +60,27 @@ module CalendarImporter::Parsers
       'image_url' => { '@id' => 'http://schema.org/image', '@type' => '@id' },
       'url' => { '@id' => 'http://schema.org/url', '@type' => '@id' }
     }.freeze
+
+    def self.url_patterns
+      self::URL_PATTERNS
+    end
+
+    def self.allowlist_pattern
+      # Regexp.union of an empty list never matches, so parsers with no URL
+      # patterns (LdJson) correctly fail the URL check.
+      Regexp.union(
+        url_patterns.map do |p|
+          Regexp.new(p[:pattern], p[:flags].include?('i') ? Regexp::IGNORECASE : 0)
+        end
+      )
+    end
+
+    # Set on parsers whose detection needs page content rather than a URL
+    # pattern (:squarespace / :wix / :ld_json). Exported to the browser
+    # extension, which implements the corresponding DOM checks itself.
+    def self.content_detection
+      nil
+    end
 
     def self.handles_url?(calendar)
       calendar.source =~ allowlist_pattern

--- a/app/jobs/calendar_importer/parsers/eventbrite.rb
+++ b/app/jobs/calendar_importer/parsers/eventbrite.rb
@@ -29,9 +29,11 @@ module CalendarImporter::Parsers
       RestClient::TooManyRequests         # 429 rate limit
     ].freeze
 
-    def self.allowlist_pattern
-      %r{^https://www\.eventbrite\.(com|co\.uk)/o/[A-Za-z0-9-]+}
-    end
+    # Match Eventbrite organizer pages like:
+    # https://www.eventbrite.co.uk/o/organiser-name-12345
+    URL_PATTERNS = [
+      { pattern: '^https://www\.eventbrite\.(com|co\.uk)/o/[A-Za-z0-9-]+', flags: '' }
+    ].freeze
 
     def organizer_id
       path = URI.parse(@url).path

--- a/app/jobs/calendar_importer/parsers/ics.rb
+++ b/app/jobs/calendar_importer/parsers/ics.rb
@@ -19,18 +19,15 @@ module CalendarImporter::Parsers
       webcal://
     ].freeze
 
-    def self.allowlist_pattern
-      allowlists = {
-        gcal: %r{^https?://calendar\.google\.com.*},
-        outlook: %r{^https?://outlook\.(office365|live)\.com/owa/calendar/.*},
-        webcal: %r{^webcal://},
-        mossley: %r{^https?://mossleycommunitycentre\.org\.uk},
-        teamup: %r{^https?://ics\.teamup\.com/feed/.*},
-        consortium: %r{^https://www\.consortium\.lgbt/events/.*},
-        generic: %r{^https?://.*\.ics$}
-      }
-      Regexp.union(allowlists.values)
-    end
+    URL_PATTERNS = [
+      { pattern: '^https?://calendar\.google\.com.*', flags: '' },                        # gcal
+      { pattern: '^https?://outlook\.(office365|live)\.com/owa/calendar/.*', flags: '' }, # outlook
+      { pattern: '^webcal://', flags: '' },                                               # webcal
+      { pattern: '^https?://mossleycommunitycentre\.org\.uk', flags: '' },                # mossley
+      { pattern: '^https?://ics\.teamup\.com/feed/.*', flags: '' },                       # teamup
+      { pattern: '^https://www\.consortium\.lgbt/events/.*', flags: '' },                 # consortium
+      { pattern: '^https?://.*\.ics$', flags: '' }                                        # generic .ics
+    ].freeze
 
     def download_calendar
       res = Base.read_http_source @url

--- a/app/jobs/calendar_importer/parsers/ld_json.rb
+++ b/app/jobs/calendar_importer/parsers/ld_json.rb
@@ -5,6 +5,12 @@ module CalendarImporter::Parsers
     NAME = 'LD+JSON'
     KEY = 'ld-json'
 
+    # No URL pattern — detection downloads the page and looks for schema.org
+    # event data (see handles_url? below).
+    def self.content_detection
+      :ld_json
+    end
+
     def initialize(calendar, options = {})
       super
     end

--- a/app/jobs/calendar_importer/parsers/manchester_uni.rb
+++ b/app/jobs/calendar_importer/parsers/manchester_uni.rb
@@ -10,9 +10,9 @@ module CalendarImporter::Parsers
     NAME = 'Manchester University'
     DOMAINS = %w[events.manchester.ac.uk].freeze
 
-    def self.allowlist_pattern
-      %r{^https?://events\.manchester\.ac\.uk/f3vf/calendar/.*}
-    end
+    URL_PATTERNS = [
+      { pattern: '^https?://events\.manchester\.ac\.uk/f3vf/calendar/.*', flags: '' }
+    ].freeze
 
     def import_events_from(data)
       events = data.xpath('//ns:event').map do |event|

--- a/app/jobs/calendar_importer/parsers/meetup.rb
+++ b/app/jobs/calendar_importer/parsers/meetup.rb
@@ -10,9 +10,11 @@ module CalendarImporter::Parsers
     KEY = 'meetup'
     DOMAINS = %w[www.meetup.com].freeze
 
-    def self.allowlist_pattern
-      %r{^https://www\.meetup\.com/[^/]*/?$}
-    end
+    # Match Meetup group pages (not individual event pages) like:
+    # https://www.meetup.com/group-name
+    URL_PATTERNS = [
+      { pattern: '^https://www\.meetup\.com/[^/]*/?$', flags: '' }
+    ].freeze
 
     def download_calendar
       group_name = (@url =~ %r{^https://www\.meetup\.com/([^/]*)/?$}) && Regexp.last_match(1)

--- a/app/jobs/calendar_importer/parsers/outsavvy.rb
+++ b/app/jobs/calendar_importer/parsers/outsavvy.rb
@@ -13,9 +13,9 @@ module CalendarImporter::Parsers
       end
     end
 
-    def self.allowlist_pattern
-      %r{^https://www\.outsavvy\.com/organiser/[^/]*/?$}
-    end
+    URL_PATTERNS = [
+      { pattern: '^https://www\.outsavvy\.com/organiser/[^/]*/?$', flags: '' }
+    ].freeze
 
     # Get event URLs from an organiser page
 

--- a/app/jobs/calendar_importer/parsers/resident_advisor.rb
+++ b/app/jobs/calendar_importer/parsers/resident_advisor.rb
@@ -6,11 +6,12 @@ module CalendarImporter::Parsers
     KEY = 'residentadvisor'
     DOMAINS = %w[ra.co].freeze
     RA_ENDPOINT = 'https://ra.co/graphql'
-    RA_REGEX = %r{^https://ra\.co/(promoters|clubs)/(\d+)$} # Accept club or promoter URLs
 
-    def self.allowlist_pattern
-      RA_REGEX
-    end
+    # Accept club or promoter URLs
+    URL_PATTERNS = [
+      { pattern: '^https://ra\.co/(promoters|clubs)/(\d+)$', flags: '' }
+    ].freeze
+    RA_REGEX = Regexp.new(URL_PATTERNS.first[:pattern])
 
     def download_calendar
       ra_entity = ra_entity(@url)

--- a/app/jobs/calendar_importer/parsers/squarespace.rb
+++ b/app/jobs/calendar_importer/parsers/squarespace.rb
@@ -12,8 +12,12 @@ module CalendarImporter
       KEY = 'squarespace'
       DOMAINS = %w[squarespace.com].freeze
 
-      def self.allowlist_pattern
-        %r{^https://.*\.squarespace\.com/[^/]*/?$}
+      URL_PATTERNS = [
+        { pattern: '^https://.*\.squarespace\.com/[^/]*/?$', flags: '' }
+      ].freeze
+
+      def self.content_detection
+        :squarespace
       end
 
       def self.handles_url?(calendar)

--- a/app/jobs/calendar_importer/parsers/ticketsolve.rb
+++ b/app/jobs/calendar_importer/parsers/ticketsolve.rb
@@ -10,9 +10,9 @@ module CalendarImporter::Parsers
     KEY = 'ticket-solve'
     DOMAINS = %w[*.ticketsolve.com].freeze
 
-    def self.allowlist_pattern
-      %r{^https?://([^.]*)\.ticketsolve\.com/?}
-    end
+    URL_PATTERNS = [
+      { pattern: '^https?://([^.]*)\.ticketsolve\.com/?', flags: '' }
+    ].freeze
 
     def import_events_from(data)
       @events = []

--- a/app/jobs/calendar_importer/parsers/ticketsource.rb
+++ b/app/jobs/calendar_importer/parsers/ticketsource.rb
@@ -17,9 +17,9 @@ module CalendarImporter
       # Match TicketSource venue pages like:
       # https://www.ticketsource.co.uk/fairfield-house
       # https://ticketsource.co.uk/some-venue
-      def self.allowlist_pattern
-        %r{^https://(www\.)?ticketsource\.co\.uk/[^/]+/?$}i
-      end
+      URL_PATTERNS = [
+        { pattern: '^https://(www\.)?ticketsource\.co\.uk/[^/]+/?$', flags: 'i' }
+      ].freeze
 
       def user_agent
         USER_AGENT

--- a/app/jobs/calendar_importer/parsers/tickettailor.rb
+++ b/app/jobs/calendar_importer/parsers/tickettailor.rb
@@ -15,9 +15,9 @@ module CalendarImporter
       # Match TicketTailor box office pages like:
       # https://www.tickettailor.com/events/queerrunclub
       # https://tickettailor.com/events/some-org
-      def self.allowlist_pattern
-        %r{^https://(www\.)?tickettailor\.com/events/[^/]+/?$}i
-      end
+      URL_PATTERNS = [
+        { pattern: '^https://(www\.)?tickettailor\.com/events/[^/]+/?$', flags: 'i' }
+      ].freeze
 
       def import_events_from(data)
         return [] unless data.is_a?(Array)

--- a/app/jobs/calendar_importer/parsers/wix.rb
+++ b/app/jobs/calendar_importer/parsers/wix.rb
@@ -7,6 +7,14 @@ module CalendarImporter
       KEY = 'wix'
       DOMAINS = %w[wixsite.com].freeze
 
+      URL_PATTERNS = [
+        { pattern: '^https://[^.]+\.wixsite\.com/', flags: 'i' }
+      ].freeze
+
+      def self.content_detection
+        :wix
+      end
+
       # Detects Wix sites by:
       # 1. URL pattern for wixsite.com subdomains
       # 2. Checking page content for Wix generator meta tag (for custom domains)
@@ -72,11 +80,6 @@ module CalendarImporter
         hash['id'].present? &&
           hash['title'].present? &&
           hash.dig('scheduling', 'config', 'startDate').present?
-      end
-
-      # Keep for backwards compatibility, but handles_url? now does custom detection
-      def self.allowlist_pattern
-        %r{^https://[^.]+\.wixsite\.com/}i
       end
 
       def download_calendar

--- a/app/services/calendar_detection_rules.rb
+++ b/app/services/calendar_detection_rules.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Exports the calendar parsers' URL detection rules as a JSON-friendly hash
+# for the browser extension (via /api/v1/calendar_detection_rules), so the
+# extension and the Rails importer share a single source of truth. Patterns
+# come from each parser's URL_PATTERNS, which are declared in the shared
+# Ruby/JavaScript regex subset (see CalendarImporter::Parsers::Base).
+class CalendarDetectionRules
+  # Bump when the shape of the payload changes incompatibly; the extension
+  # rejects versions it doesn't understand.
+  SCHEMA_VERSION = 1
+
+  def self.as_json
+    {
+      version: SCHEMA_VERSION,
+      parsers: CalendarImporter::CalendarImporter::PARSERS
+               .select { |parser| parser::PUBLIC }
+               .map { |parser| parser_json(parser) }
+    }
+  end
+
+  def self.parser_json(parser)
+    {
+      key: parser::KEY,
+      name: parser::NAME,
+      domains: parser::DOMAINS,
+      url_patterns: parser.url_patterns,
+      requires_api_token: parser.requires_api_token?,
+      content_detection: parser.content_detection
+    }
+  end
+end

--- a/app/views/layouts/admin/application.rb
+++ b/app/views/layouts/admin/application.rb
@@ -143,6 +143,7 @@ class Views::Layouts::Admin::Application < Phlex::HTML
   def leftbar_support_links
     leftbar_section(t('admin.leftbar.get_support')) do
       admin_nav_link(t('admin.leftbar.handbook'), 'https://handbook.placecal.org/', :book)
+      admin_nav_link(t('admin.leftbar.browser_extension'), 'https://handbook.placecal.org/browser-extension', :external_link)
       admin_nav_link(t('admin.leftbar.discord'), 'http://discord.gfsc.studio/', :chat)
       admin_nav_link(t('admin.leftbar.report_bug'), 'https://github.com/geeksforsocialchange/PlaceCal/issues/new?assignees=&labels=&template=bug_report.md', :bug)
       li do

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -174,6 +174,7 @@ en:
       sign_out: "Sign out"
 
     leftbar:
+      browser_extension: "Browser extension"
       build: "Build"
       content_types: "Content types"
       discord: "Discord"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,9 @@ Rails.application.routes.draw do
   get '/api/v1/graphql', to: 'graphql#execute'
   post '/api/v1/graphql', to: 'graphql#execute'
 
+  # Calendar source detection rules for the browser extension
+  get '/api/v1/calendar_detection_rules', to: 'calendar_detection_rules#show'
+
   mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/api/v1/graphql' if Rails.env.development?
   # Lookbook auto-mounts at /lookbook in development
 end

--- a/spec/jobs/calendar_importer/detection_rules_spec.rb
+++ b/spec/jobs/calendar_importer/detection_rules_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Guards the contract that every parser's URL_PATTERNS stay in the shared
+# Ruby/JavaScript regex subset, since they are exported verbatim to the
+# browser extension via /api/v1/calendar_detection_rules and compiled there
+# with JavaScript's `new RegExp(pattern, flags)`.
+RSpec.describe "calendar parser detection rules" do
+  # Ruby-only regex constructs that JavaScript's RegExp either rejects or
+  # silently interprets differently.
+  JS_UNSAFE_CONSTRUCTS = [
+    '\A', '\z', '\Z', # string anchors — use ^ and $
+    '\h', '\H',       # hex digit classes
+    '\G',             # match start anchor
+    "(?-", "(?i",     # inline flag groups (Regexp.union embeds these)
+    "(?~",            # absence operator
+    "[[:"             # POSIX character classes
+  ].freeze
+
+  CalendarImporter::CalendarImporter::PARSERS.each do |parser|
+    describe parser.name do
+      it "declares url_patterns as an array of pattern/flags hashes" do
+        expect(parser.url_patterns).to be_an(Array)
+
+        parser.url_patterns.each do |entry|
+          expect(entry.keys).to contain_exactly(:pattern, :flags)
+          expect(entry[:pattern]).to be_a(String)
+          expect(entry[:flags]).to match(/\Ai?\z/)
+        end
+      end
+
+      it "uses only JavaScript-compatible regex syntax" do
+        parser.url_patterns.each do |entry|
+          # must compile as a Ruby regex
+          expect { Regexp.new(entry[:pattern]) }.not_to raise_error
+
+          JS_UNSAFE_CONSTRUCTS.each do |construct|
+            expect(entry[:pattern]).not_to include(construct),
+                                           "#{parser.name} pattern #{entry[:pattern].inspect} contains " \
+                                           "JS-unsafe construct #{construct.inspect}"
+          end
+        end
+      end
+
+      it "has a parser key and name when public" do
+        next unless parser::PUBLIC
+
+        expect(parser::KEY).to be_present
+        expect(parser::NAME).to be_present
+      end
+    end
+  end
+
+  describe "allowlist_pattern derivation" do
+    sample_urls = {
+      "eventbrite" => "https://www.eventbrite.co.uk/o/organiser-name-12345",
+      "ical" => "https://example.com/feed.ics",
+      "ticketsource" => "https://www.ticketsource.co.uk/fairfield-house",
+      "meetup" => "https://www.meetup.com/some-group",
+      "outsavvy" => "https://www.outsavvy.com/organiser/some-org",
+      "residentadvisor" => "https://ra.co/promoters/12345",
+      "squarespace" => "https://example.squarespace.com/events",
+      "ticket-solve" => "https://venue.ticketsolve.com/",
+      "tickettailor" => "https://www.tickettailor.com/events/queerrunclub",
+      "wix" => "https://user123.wixsite.com/mysite"
+    }.freeze
+
+    sample_urls.each do |key, url|
+      it "matches the documented #{key} URL shape" do
+        parser = CalendarImporter::CalendarImporter::PARSERS.find { |p| p::KEY == key }
+        expect(parser).to be_present
+        expect(parser.allowlist_pattern).to match(url)
+      end
+    end
+
+    it "never matches a URL for parsers without URL patterns" do
+      expect(CalendarImporter::Parsers::LdJson.allowlist_pattern).not_to match("https://example.com/anything")
+    end
+  end
+end

--- a/spec/requests/admin/home_spec.rb
+++ b/spec/requests/admin/home_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe "Admin::Home", type: :request do
         expect(response.body).to include("<title>Dashboard | PlaceCal Admin</title>")
       end
 
+      it "links to the browser extension in the support sidebar" do
+        get "http://#{admin_host}"
+        expect(response).to be_successful
+        expect(response.body).to include("Browser extension")
+        expect(response.body).to include("https://handbook.placecal.org/browser-extension")
+      end
+
       it "shows all sites when no sites assigned" do
         get "http://#{admin_host}"
         expect(response).to be_successful

--- a/spec/requests/public/calendar_detection_rules_spec.rb
+++ b/spec/requests/public/calendar_detection_rules_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Calendar detection rules API", type: :request do
+  describe "GET /api/v1/calendar_detection_rules" do
+    let(:public_parsers) do
+      CalendarImporter::CalendarImporter::PARSERS.select { |parser| parser::PUBLIC }
+    end
+
+    let(:parsed) { response.parsed_body }
+
+    before { get "http://lvh.me/api/v1/calendar_detection_rules" }
+
+    it "returns a versioned JSON payload" do
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/json")
+      expect(parsed["version"]).to eq(CalendarDetectionRules::SCHEMA_VERSION)
+    end
+
+    it "includes every public parser and no private ones" do
+      keys = parsed["parsers"].map { |parser| parser["key"] }
+      expect(keys).to match_array(public_parsers.map { |parser| parser::KEY })
+      expect(parsed["parsers"].length).to eq(public_parsers.length)
+    end
+
+    it "exports url patterns with pattern and flags" do
+      eventbrite = parsed["parsers"].find { |parser| parser["key"] == "eventbrite" }
+      expect(eventbrite["url_patterns"]).to eq(
+        [{ "pattern" => '^https://www\.eventbrite\.(com|co\.uk)/o/[A-Za-z0-9-]+', "flags" => "" }]
+      )
+      expect(eventbrite["domains"]).to include("www.eventbrite.co.uk")
+    end
+
+    it "flags exactly the API-token parsers" do
+      token_keys = parsed["parsers"].select { |parser| parser["requires_api_token"] }.map { |parser| parser["key"] }
+      expect(token_keys).to contain_exactly("ticketsource", "tickettailor")
+    end
+
+    it "flags exactly the content-detection parsers" do
+      detection = parsed["parsers"].filter_map do |parser|
+        [parser["key"], parser["content_detection"]] if parser["content_detection"]
+      end
+      expect(detection).to contain_exactly(
+        %w[squarespace squarespace],
+        %w[wix wix],
+        %w[ld-json ld_json]
+      )
+    end
+
+    it "allows cross-origin requests from browser extensions" do
+      get "http://lvh.me/api/v1/calendar_detection_rules",
+          headers: { "Origin" => "moz-extension://0000-1111" }
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+    end
+
+    it "is publicly cacheable and supports conditional requests" do
+      expect(response.headers["Cache-Control"]).to include("public")
+      etag = response.headers["ETag"]
+      expect(etag).to be_present
+
+      get "http://lvh.me/api/v1/calendar_detection_rules", headers: { "If-None-Match" => etag }
+      expect(response).to have_http_status(:not_modified)
+    end
+  end
+end


### PR DESCRIPTION
Part of #1546.

## What

- **Parsers declare URL patterns as data.** Each calendar parser now declares a `URL_PATTERNS` constant (pattern string + flags, written in the shared Ruby/JavaScript regex subset) instead of a bespoke `allowlist_pattern` method; `Parsers::Base.allowlist_pattern` is derived from it. Behaviour is unchanged — the full importer suite passes untouched — and a new spec (`spec/jobs/calendar_importer/detection_rules_spec.rb`) rejects Ruby-only regex constructs so the patterns stay JS-compatible.
- **New public endpoint `GET /api/v1/calendar_detection_rules`** exporting every `PUBLIC` parser's key/name/domains/URL patterns, whether it needs an API token, and a content-detection hint (`squarespace`/`wix`/`ld_json`). Unauthenticated, ETag/`expires_in` cacheable, and picked up by the existing `/api/*` CORS + rate-limit rules.
- **Admin sidebar gets a "Browser extension" link** under Get support, pointing at `handbook.placecal.org/browser-extension` so the eventual add-on store URL never needs a PlaceCal deploy.

## Why

The browser extension (issue #1546) detects PlaceCal-compatible calendars on pages an organiser visits. Fetching the rules from PlaceCal — generated from the same parser classes the importer uses — means the extension can never hold a different version of the truth than the site (the drift concern raised in the issue thread).

The extension itself lives in a separate repo (scaffolded, pending team sign-off on the repo name and permanent gecko extension ID before first AMO submission).

## Reviewer notes

- `Squarespace`/`Wix` keep their overridden content-sniffing `handles_url?`; their `URL_PATTERNS` carry the previous `allowlist_pattern` verbatim. `LdJson` has no URL patterns (`Regexp.union([])` never matches), only the content hint.
- The Ics patterns include the one-off `mossleycommunitycentre.org.uk` / `consortium.lgbt` allowlist hacks, which are now publicly visible in the endpoint output. Flagging in case we'd rather filter site-specific entries out of the export.
- `RA_REGEX` (used for capture groups in `ResidentAdvisor#ra_entity`) is now compiled from `URL_PATTERNS` rather than duplicated.

## Verification

- Full RSpec suite: 1974 examples, 0 failures; RuboCop clean.
- `curl -i -H 'Origin: moz-extension://test' http://lvh.me:3000/api/v1/calendar_detection_rules` → 200, `access-control-allow-origin: *`, correct payload (cache headers confirmed via the request spec; rack-mini-profiler masks them in dev).
- The exported patterns were compiled with JavaScript `new RegExp` and tested against sample URLs for all 10 pattern-bearing parsers, including the "Meetup event page must not match" case.

## Handbook

Needs a `handbook.placecal.org/browser-extension` page (install link + "use the organiser's main page" guidance) — currently the sidebar link 404s until that exists.