### PR TITLE
Fix admin datatable sorting for multi-word columns

### DIFF
--- a/app/components/admin/datatable.rb
+++ b/app/components/admin/datatable.rb
@@ -264,7 +264,9 @@ class Components::Admin::Datatable < Components::Admin::Base
     align_class = col_config&.dig(:align) == :center ? 'text-center' : 'text-left'
     sort_default_dir = col_config&.dig(:sort_default)
 
-    attrs = { data_column: @columns[index],
+    # to_s matters: Phlex dasherizes Symbol attribute values, and the JS
+    # compares data-column against the underscored names in columns_json
+    attrs = { data_column: @columns[index].to_s,
               class: "px-4 py-3 #{align_class} text-xs font-semibold text-gray-600 uppercase tracking-wider " \
                      "#{width_class} #{'cursor-pointer hover:bg-gray-100 select-none' if sortable}" }
     attrs[:data_action] = 'click->admin-table#sort' if sortable
@@ -286,7 +288,7 @@ class Components::Admin::Datatable < Components::Admin::Base
   def render_sort_icon(index)
     span(class: 'text-gray-400 opacity-0 group-hover:opacity-100',
          data_admin_table_target: 'sortIcon',
-         data_column: @columns[index]) do
+         data_column: @columns[index].to_s) do
       icon(:arrow_up_down, size: nil)
     end
   end

--- a/spec/system/admin/partners_datatable_spec.rb
+++ b/spec/system/admin/partners_datatable_spec.rb
@@ -169,6 +169,24 @@ RSpec.describe "Admin Partners Datatable", :slow, type: :system do
 
       expect(page).not_to have_button("Reset sort")
     end
+
+    # Regression: Phlex dasherizes Symbol data-attribute values, so multi-word
+    # columns rendered data-column="updated-at" and the JS fell back to sorting
+    # by the first column (#3336)
+    it "sorts by a multi-word column (updated_at) when clicking its header" do
+      partner_gamma.update_columns(updated_at: 3.days.ago)
+      partner_beta.update_columns(updated_at: 2.days.ago)
+      partner_alpha.update_columns(updated_at: 1.day.ago)
+
+      # Default sort is already updated_at desc, so one click toggles to asc
+      find("th[data-column='updated_at']").click
+      wait_for_datatable
+      expect(page).to have_css("[data-admin-table-target='tbody'] tr:first-child", text: "Gamma")
+
+      find("th[data-column='updated_at']").click
+      wait_for_datatable
+      expect(page).to have_css("[data-admin-table-target='tbody'] tr:first-child", text: "Alpha")
+    end
   end
 
   describe "calendar status filter" do


### PR DESCRIPTION
Resolves #3336

## Description

Clicking the **Last Login** or **Last Updated** headers on admin datatables silently re-sorted by *name* instead of the clicked column.

Root cause: Phlex dasherizes **Symbol** attribute values, so `data_column: @columns[index]` rendered `data-column="last-sign-in-at"` while the `admin-table` Stimulus controller's `columnsValue` JSON held `"last_sign_in_at"`. The `findIndex` lookup in `loadData` never matched and fell back to column 0. The same mismatch stopped the sort-direction arrow from finding its column.

The fix passes the column name as a String (`.to_s`) in both `data-column` attributes in `Components::Admin::Datatable`, with a comment explaining why the `.to_s` matters. This affects every multi-word column in every admin datatable — single-word columns like `name` were unaffected, which is why it looked like only the timestamp columns were broken.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- New system spec: clicks the `updated_at` header on the partners table and asserts rows re-order in both directions, with timestamps arranged so alphabetical order cannot accidentally pass. Verified it fails on the unfixed code (the `th[data-column='updated_at']` selector does not exist there) and passes with the fix.
- Verified live in the browser (admin.lvh.me): before the fix, clicking Last Login fired `order[0][column]=0&sort_column=last-sign-in-at`; after, it fires `order[0][column]=2&sort_column=last_sign_in_at` and the table visibly re-sorts both directions with the header indicator working.
- Full `spec/system/admin/partners_datatable_spec.rb` and `spec/requests/admin/users_datatable_spec.rb` pass; RuboCop clean.

### How Will This Be Deployed?

Standard deploy, no infrastructure or config changes.