### PR TITLE
Never render empty parens in user display names

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,8 +122,11 @@ class User < ApplicationRecord
     "#{name} <#{email}>".strip
   end
 
-  # @return [String] "Firstname Lastname (email)"
+  # @return [String] "Firstname Lastname (email)", degrading gracefully when
+  #   either part is missing so we never render a bare "Name ()" (#3241)
   def display_name
+    return full_name.presence || "#{self.class.model_name.human} ##{id}" if email.blank?
+
     name = full_name.presence || email.split('@').first
     "#{name} (#{email})"
   end

--- a/app/views/admin/sites/form_tab_basic.rb
+++ b/app/views/admin/sites/form_tab_basic.rb
@@ -45,11 +45,7 @@ class Views::Admin::Sites::FormTabBasic < Views::Admin::Base
     fieldset(class: 'fieldset') do
       raw form.label(:site_admin_id, t('admin.sites.fields.site_admin'), class: 'fieldset-legend')
       raw form.select(:site_admin_id,
-                      User.order(:last_name, :first_name).map { |u|
-                        full_name = [u.first_name, u.last_name].compact.join(' ').presence
-                        label_text = full_name ? "#{full_name} (#{u.email})" : u.email
-                        [label_text, u.id]
-                      },
+                      User.order(:last_name, :first_name).map { |u| [u.display_name, u.id] },
                       { include_blank: t('admin.placeholders.select_model', model: t('admin.models.admin.one').downcase) },
                       { class: 'select select-bordered w-full', 'aria-label': t('admin.sites.fields.site_admin'), data: { controller: 'tom-select' } })
     end
@@ -57,12 +53,7 @@ class Views::Admin::Sites::FormTabBasic < Views::Admin::Base
 
   def render_readonly_admin_field(site)
     admin = site.site_admin
-    admin_display = if admin
-                      full_name = [admin.first_name, admin.last_name].compact.join(' ').presence
-                      full_name ? "#{full_name} (#{admin.email})" : admin.email
-                    else
-                      t('admin.labels.none')
-                    end
+    admin_display = admin ? admin.display_name : t('admin.labels.none')
 
     div(class: 'card bg-base-200/50 border border-base-300 p-3') do
       p(class: 'text-sm') do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -145,6 +145,36 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#display_name" do
+    let(:user) { build(:user, email: "test@example.com") }
+
+    it "returns name with email in parens" do
+      user.first_name = "Joan"
+      user.last_name = "Jones"
+      expect(user.display_name).to eq("Joan Jones (test@example.com)")
+    end
+
+    it "falls back to the email prefix when name is blank" do
+      user.first_name = ""
+      user.last_name = ""
+      expect(user.display_name).to eq("test (test@example.com)")
+    end
+
+    # Regression for #3241: a blank email must not render as "Name ()"
+    it "returns just the name when email is blank" do
+      user.first_name = "Joan"
+      user.last_name = "Jones"
+      user.email = ""
+      expect(user.display_name).to eq("Joan Jones")
+    end
+
+    it "falls back to a model label when name and email are both blank" do
+      user = create(:user, first_name: "", last_name: "")
+      user.email = nil
+      expect(user.display_name).to eq("User ##{user.id}")
+    end
+  end
+
   describe "role predicates" do
     it "#root? returns true for root role" do
       user = build(:user, role: :root)


### PR DESCRIPTION
Resolves #3241

## Description

The Site Admin select on the site edit form built its option labels inline as `"#{full_name} (#{u.email})"`, so a user with a blank email rendered as **"Name ()"** — the bug in the issue screenshot.

This hardens `User#display_name` to degrade gracefully:

- name + email → `Name (email)` (unchanged)
- name, blank email → `Name`
- blank name, email → `prefix (email)` (unchanged)
- both blank → `User #id` (via `model_name.human`, so it stays i18n-friendly)

and uses it for both the editable select and the readonly admin card in `app/views/admin/sites/form_tab_basic.rb`, replacing the duplicated inline label logic. `display_name` previously also crashed outright (`nil.split`) when email was `nil`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- New model specs for `User#display_name` covering all four cases, including a regression case for the empty-parens rendering.
- Verified in the browser (admin.lvh.me): created a user, blanked their email via `update_columns` to reproduce the issue state, and confirmed the site edit select now shows just their name with no `()`, while normal users still show `Name (email)`.
- Full `spec/models/user_spec.rb` and admin sites request/system specs pass; RuboCop clean.

### How Will This Be Deployed?

Standard deploy, no infrastructure or config changes.