### PR TITLE
Fix Release Drafter autolabeling (run the v7 autolabeler action)

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,12 +13,29 @@ permissions:
   contents: read
 
 jobs:
+  # Maintain the categorised draft release + resolved semver bump. Publishing
+  # that draft is what tags and deploys production (see test-and-deploy.yml).
   update_release_draft:
+    if: github.event_name == 'push'
     permissions:
       contents: write # create/update the draft release
-      pull-requests: write # apply autolabels
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Apply category labels to PRs from their title/branch. Since v7 the
+  # autolabeler is a SEPARATE action from the drafter above — the drafter no
+  # longer labels, so without this job PRs stay unlabelled and the draft can't
+  # categorise them or resolve the version bump. Reads .github/release-drafter.yml.
+  autolabel:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read # read the config
+      pull-requests: write # apply labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves the "things aren't being tagged by release drafter" report.

## Description

PRs merged to main were not getting their category labels (`fix`, `enhancement`, `docs`, `maintenance`, `breaking`), so the draft release could not categorise them and the semver bump always fell back to the default `patch`.

### Root cause

Since **release-drafter v7** the action was split in two:

- `release-drafter/release-drafter` — now **only drafts** the release (its `action.yml` description is literally "Drafts your next release notes"; entrypoint `dist/actions/drafter/run.js` contains no autolabeler code).
- `release-drafter/release-drafter/autolabeler` — a **separate action** that applies the labels.

Our workflow (added in c46c0986, ported from an older single-action setup) only invoked the drafter. So on `pull_request` events it ran the *releaser* against the PR merge ref — updating the draft pointlessly — and **never applied any labels**. You can see this in the run logs: the `pull_request`-triggered run only ever logs "Found N merged pull requests … Release updated!", with zero autolabeler activity, even though e.g. #3338's title *and* branch both matched the `fix` rule. Renovate PRs looked fine only because Renovate applies the `dependencies` label itself.

I confirmed the split by reading the pinned action's `action.yml`/bundle at the exact SHA (`4d75298`, = v7.5.1): the root entrypoint has no autolabeler, and `autolabeler/action.yml` exists as its own action at the same SHA.

### The fix

Split the workflow to match the v7 model:

- `update_release_draft` runs the drafter on **push to main**
- `autolabel` runs the new `release-drafter/release-drafter/autolabeler` action on **pull_request**

Both read the existing `.github/release-drafter.yml` (unchanged). Permissions are scoped per job (the drafter no longer needs `pull-requests: write`; the autolabeler does not need `contents: write`). The autolabeler action is pinned to the same v7.5.1 commit already used for the drafter.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a change to the deployment process (CI only — release notes now self-categorise)

### How Has This Been Tested?

- Validated the workflow YAML parses and both jobs resolve to the correct actions/permissions/event gating.
- Verified the pinned SHA dereferences to tag v7.5.1 and that `autolabeler/action.yml` + its bundle exist at that exact SHA.
- **This PR is its own end-to-end test:** for `pull_request` events GitHub uses the workflow from the PR head, so the new `autolabel` job runs on this PR. Its `fix/` branch and "Fix…" title match the `fix` rule — expect this PR to be auto-labelled `fix`. (Please confirm the label appears before merging.)

### How Will This Be Deployed?

Standard merge. No infra changes; takes effect for subsequent PRs. Existing already-merged unlabelled PRs in the current draft can be labelled by hand if you want them recategorised before the next publish.