### PR TITLE
Retry connection-level failures in the Eventbrite importer

### DIFF
--- a/app/jobs/calendar_importer/parsers/eventbrite.rb
+++ b/app/jobs/calendar_importer/parsers/eventbrite.rb
@@ -28,19 +28,16 @@ module CalendarImporter::Parsers
       RestClient::GatewayTimeout,         # 504
       RestClient::TooManyRequests,        # 429 rate limit
 
-      # Network-level failures below never get an HTTP status: the connection
-      # itself dropped. RestClient lets them propagate raw, so without these the
-      # retry loop and the graceful-degrade rescues are both bypassed and the
-      # whole import crashes (AppSignal incident #279, Errno::ECONNRESET during
-      # SSL_connect). All requests here are GETs, so retrying is safe. The
-      # HTTParty parsers get the same treatment in Base.read_http_source.
-      RestClient::Exceptions::Timeout,    # covers open + read timeouts
+      # Dropped-connection errors never get an HTTP status and RestClient lets
+      # them propagate raw, so without these the retry loop and the graceful
+      # degrade are both bypassed and the whole import crashes (AppSignal
+      # incident #279, Errno::ECONNRESET during SSL_connect). All requests here
+      # are GETs, so retrying is safe. Timeouts, SSL and DNS errors are
+      # deliberately NOT listed: CalendarImporterJob's rescue_from backstop
+      # already maps those to bad_source/unreachable (see issue #3100).
       Errno::ECONNRESET,
       Errno::ECONNREFUSED,
-      Errno::EPIPE,
-      Errno::ETIMEDOUT,
-      SocketError,                        # DNS resolution failures
-      OpenSSL::SSL::SSLError              # TLS negotiation failures
+      Errno::EPIPE
     ].freeze
 
     def self.allowlist_pattern

--- a/app/jobs/calendar_importer/parsers/eventbrite.rb
+++ b/app/jobs/calendar_importer/parsers/eventbrite.rb
@@ -26,7 +26,21 @@ module CalendarImporter::Parsers
       RestClient::BadGateway,             # 502
       RestClient::ServiceUnavailable,     # 503
       RestClient::GatewayTimeout,         # 504
-      RestClient::TooManyRequests         # 429 rate limit
+      RestClient::TooManyRequests,        # 429 rate limit
+
+      # Network-level failures below never get an HTTP status: the connection
+      # itself dropped. RestClient lets them propagate raw, so without these the
+      # retry loop and the graceful-degrade rescues are both bypassed and the
+      # whole import crashes (AppSignal incident #279, Errno::ECONNRESET during
+      # SSL_connect). All requests here are GETs, so retrying is safe. The
+      # HTTParty parsers get the same treatment in Base.read_http_source.
+      RestClient::Exceptions::Timeout,    # covers open + read timeouts
+      Errno::ECONNRESET,
+      Errno::ECONNREFUSED,
+      Errno::EPIPE,
+      Errno::ETIMEDOUT,
+      SocketError,                        # DNS resolution failures
+      OpenSSL::SSL::SSLError              # TLS negotiation failures
     ].freeze
 
     def self.allowlist_pattern

--- a/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
+++ b/spec/jobs/calendar_importer/eventbrite_parser_spec.rb
@@ -79,6 +79,18 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
           .exactly(max_retries + 1).times
       end
 
+      it "treats connection-level failures as transient (AppSignal incident #279)" do
+        # A dropped connection (e.g. ECONNRESET during SSL_connect) never gets
+        # an HTTP status, so it must be retried and degraded like a 5xx rather
+        # than crashing the whole import.
+        allow(EventbriteSDK::Organizer).to receive(:retrieve)
+          .and_raise(Errno::ECONNRESET, "Connection reset by peer - SSL_connect")
+
+        expect(parser.download_calendar).to eq([])
+        expect(EventbriteSDK::Organizer).to have_received(:retrieve)
+          .exactly(max_retries + 1).times
+      end
+
       it "does not retry or swallow non-transient errors" do
         allow(EventbriteSDK::Organizer).to receive(:retrieve)
           .and_raise(RestClient::Unauthorized)
@@ -90,6 +102,17 @@ RSpec.describe CalendarImporter::Parsers::Eventbrite do
       describe "#fetch_event_description" do
         it "skips the description (returns nil) when one event keeps failing" do
           allow(parser).to receive(:get_event_description).and_raise(RestClient::InternalServerError)
+
+          expect(parser.fetch_event_description("123")).to be_nil
+          expect(parser).to have_received(:get_event_description)
+            .exactly(max_retries + 1).times
+        end
+
+        it "skips the description when the connection keeps dropping" do
+          # The description endpoint is where incident #279's ECONNRESET was
+          # actually raised — a flaky connection must not lose the whole event.
+          allow(parser).to receive(:get_event_description)
+            .and_raise(Errno::ECONNRESET, "Connection reset by peer - SSL_connect")
 
           expect(parser.fetch_event_description("123")).to be_nil
           expect(parser).to have_received(:get_event_description)


### PR DESCRIPTION
## Description

Adds dropped-connection errors (`Errno::ECONNRESET`, `Errno::ECONNREFUSED`, `Errno::EPIPE`) to the Eventbrite parser's `TRANSIENT_HTTP_ERRORS` list, so they get the same retry-with-backoff → graceful-degrade treatment as 429/5xx responses.

Timeouts, SSL and DNS errors are deliberately **not** included: `CalendarImporterJob`'s `rescue_from` backstop already maps those to `bad_source`/unreachable (the #3100 design), and CI rightly failed when the first version of this PR hijacked that path.

### Motivation and Context

Found via the new AppSignal MCP integration. The June importer hardening (88676b06, deployed to production 10 Jul) fixed the 429/5xx incidents — [#311](https://appsignal.com/geeks-for-social-change/sites/66d70197fecf05ed145d26c9/exceptions/incidents/311) (92 occurrences) and #336 have not recurred since. But [incident #279](https://appsignal.com/geeks-for-social-change/sites/66d70197fecf05ed145d26c9/exceptions/incidents/279) (`Errno::ECONNRESET: Connection reset by peer - SSL_connect`, 13 occurrences) recurred **hours after** that deploy, at the description-fetch call.

The cause: RestClient lets dropped-connection errors propagate raw, so they aren't matched by `rescue *TRANSIENT_HTTP_ERRORS` (nor by the job-level backstop) — they bypass retry and degrade and crash the whole import job. All requests on this path are GETs, so retrying is safe.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Two new specs (organiser-listing path and description-fetch path, the latter being where #279 actually fired) raising `Errno::ECONNRESET` and asserting retry-then-degrade behaviour. Eventbrite parser spec, parser base spec, and the full CalendarImporterJob spec (incl. the #3100 timeout→bad_source cases) pass locally.

### How Will This Be Deployed?

Normal deploy, no infra or config changes.