### PR TITLE
Fix partner wizard failing on blank service area rows

### DIFF
--- a/app/components/admin/neighbourhood_card.rb
+++ b/app/components/admin/neighbourhood_card.rb
@@ -11,6 +11,10 @@ class Components::Admin::NeighbourhoodCard < Components::Admin::Base
 
   def view_template
     div(class: 'nested-fields card bg-base-200/50 border border-base-300') do
+      # Without this hidden field, unpersisted rows rendered as cards (e.g. after
+      # a failed save re-renders the form) would submit nothing and be lost (#3356)
+      raw(@form.hidden_field(:neighbourhood_id)) if @form
+
       div(class: 'card-body p-4 gap-3') do
         if @show_header
           h3(class: 'font-semibold flex items-center gap-2') do

--- a/app/javascript/controllers/cascading_neighbourhood_controller.js
+++ b/app/javascript/controllers/cascading_neighbourhood_controller.js
@@ -153,7 +153,13 @@ export default class extends Controller {
 				// descendants of the auto-selected item (e.g., Manchester is a direct
 				// child of North West, not Lancashire, but Lancashire is auto-selected
 				// as the only county).
-				await this.loadLevel(level - 1, parentId);
+				//
+				// At the top level there is no parent scope (parentId is null): the
+				// children endpoint would then return top-level roots instead of the
+				// auto-selected country's children, dead-ending every level below it.
+				// Fall back to the auto-selected id so the cascade can continue — this
+				// is what left the picker unusable whenever there was a single country.
+				await this.loadLevel(level - 1, parentId || data[0].id);
 			} else {
 				// Multiple options: show the dropdown
 				this.showSelect(target);

--- a/app/javascript/controllers/partner_wizard_controller.js
+++ b/app/javascript/controllers/partner_wizard_controller.js
@@ -73,6 +73,16 @@ export default class extends Controller {
 		);
 		updateWizardUI(this);
 		this.updateContinueButton();
+		// After a failed save the server re-renders the form with values already
+		// present, but availability state and hint visibility only update on input
+		// events — re-run the checks so pre-filled fields don't show stale errors
+		// or block the Continue button (#3356)
+		if (this.hasNameInputTarget && this.nameInputTarget.value.trim() !== "") {
+			this.performNameCheck();
+		}
+		if (this.hasAdminEmailTarget && this.adminEmailTarget.value.trim() !== "") {
+			this.performAdminEmailCheck();
+		}
 		markWizardConnected(this);
 	}
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -158,7 +158,12 @@ class Partner < ApplicationRecord
      c[:street_address3]].all?(&:blank?)
   }
 
-  accepts_nested_attributes_for :service_areas, allow_destroy: true
+  # An untouched "New Service Area" picker row submits a blank neighbourhood_id;
+  # without reject_if it becomes an invalid ServiceArea that also fails
+  # check_neighbourhood_access for non-root admins (issue #3356)
+  accepts_nested_attributes_for :service_areas, allow_destroy: true, reject_if: lambda { |sa|
+    sa[:neighbourhood_id].blank? && sa[:_destroy].blank?
+  }
 
   # ==== Uploaders ====
   mount_uploader :image, ImageUploader

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -160,9 +160,11 @@ class Partner < ApplicationRecord
 
   # An untouched "New Service Area" picker row submits a blank neighbourhood_id;
   # without reject_if it becomes an invalid ServiceArea that also fails
-  # check_neighbourhood_access for non-root admins (issue #3356)
+  # check_neighbourhood_access for non-root admins (issue #3356).
+  # NB: the form always submits _destroy ("false" for kept rows), so the flag
+  # must be cast, not blank?-checked
   accepts_nested_attributes_for :service_areas, allow_destroy: true, reject_if: lambda { |sa|
-    sa[:neighbourhood_id].blank? && sa[:_destroy].blank?
+    sa[:neighbourhood_id].blank? && !ActiveRecord::Type::Boolean.new.cast(sa[:_destroy])
   }
 
   # ==== Uploaders ====

--- a/app/views/admin/sites/_sites_neighbourhood_fields.html.erb
+++ b/app/views/admin/sites/_sites_neighbourhood_fields.html.erb
@@ -6,6 +6,7 @@
           show_remove: true,
           form: f
         ) %>
+    <%= f.hidden_field :relation_type %>
   <% else %>
     <%= render Components::Admin::CascadingNeighbourhoodFields.new(form: f, relation_type: 'Secondary', show_remove: true) %>
   <% end %>

--- a/app/views/admin/sites/sites_neighbourhood_fields.rb
+++ b/app/views/admin/sites/sites_neighbourhood_fields.rb
@@ -13,6 +13,7 @@ class Views::Admin::Sites::SitesNeighbourhoodFields < Views::Admin::Base
         show_remove: true,
         form: form
       )
+      raw(form.hidden_field(:relation_type))
     else
       CascadingNeighbourhoodFields(
         form: form,

--- a/spec/factories/normal_island/neighbourhoods.rb
+++ b/spec/factories/normal_island/neighbourhoods.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
   factory :neighbourhood, aliases: [:bare_neighbourhood] do
     sequence(:name) { |n| "Neighbourhood #{n}" }
     unit { "ward" }
+    # Derive level from unit so the cascading picker's at_level queries work in
+    # tests (the real ONS import / seeds set this; the factory used to leave it
+    # nil, which made the picker return no options).
+    level { Neighbourhood::LEVELS[unit.to_sym] }
     unit_code_key { "ZZ00WD" }
     sequence(:unit_code_value) { |n| format("N%08d", n) }  # 9 characters total
     release_date { Neighbourhood::LATEST_RELEASE_DATE }  # Current release

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -208,9 +208,12 @@ RSpec.describe Partner, type: :model do
     let(:ward) { create(:riverside_ward) }
 
     it "rejects rows with a blank neighbourhood_id" do
+      # The real form submits _destroy: "false" for every kept row — the
+      # reject_if must treat that as "not marked for destruction", not as
+      # a present value
       partner = build(:partner, service_areas_attributes: [
-                        { neighbourhood_id: ward.id },
-                        { neighbourhood_id: "" }
+                        { neighbourhood_id: ward.id, _destroy: "false" },
+                        { neighbourhood_id: "", _destroy: "false" }
                       ])
       expect(partner.service_areas.size).to eq(1)
       expect(partner).to be_valid
@@ -223,8 +226,8 @@ RSpec.describe Partner, type: :model do
       admin = create(:neighbourhood_admin, neighbourhood: ward)
       partner = build(:partner, address: nil, accessed_by_user: admin,
                                 service_areas_attributes: [
-                                  { neighbourhood_id: ward.id },
-                                  { neighbourhood_id: "" }
+                                  { neighbourhood_id: ward.id, _destroy: "false" },
+                                  { neighbourhood_id: "", _destroy: "false" }
                                 ])
       expect(partner).to be_valid
     end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -204,6 +204,41 @@ RSpec.describe Partner, type: :model do
     end
   end
 
+  describe "service_areas nested attributes" do
+    let(:ward) { create(:riverside_ward) }
+
+    it "rejects rows with a blank neighbourhood_id" do
+      partner = build(:partner, service_areas_attributes: [
+                        { neighbourhood_id: ward.id },
+                        { neighbourhood_id: "" }
+                      ])
+      expect(partner.service_areas.size).to eq(1)
+      expect(partner).to be_valid
+    end
+
+    # Regression test for issue #3356: an untouched "New Service Area" picker row
+    # submits a blank neighbourhood_id, which used to build an invalid ServiceArea
+    # and also fail check_neighbourhood_access for non-root admins
+    it "lets a neighbourhood admin create a partner despite a leftover blank row" do
+      admin = create(:neighbourhood_admin, neighbourhood: ward)
+      partner = build(:partner, address: nil, accessed_by_user: admin,
+                                service_areas_attributes: [
+                                  { neighbourhood_id: ward.id },
+                                  { neighbourhood_id: "" }
+                                ])
+      expect(partner).to be_valid
+    end
+
+    it "still removes existing service areas via _destroy" do
+      partner = create(:mobile_partner, service_area_wards: [ward])
+      sa = partner.service_areas.reload.first
+      partner.update!(service_areas_attributes: [
+                        { id: sa.id, neighbourhood_id: ward.id, _destroy: "1" }
+                      ])
+      expect(partner.reload.service_areas).to be_empty
+    end
+  end
+
   describe "factories" do
     it "creates a valid partner" do
       partner = build(:partner)

--- a/spec/requests/admin/partners_spec.rb
+++ b/spec/requests/admin/partners_spec.rb
@@ -362,8 +362,8 @@ RSpec.describe "Admin::Partners", type: :request do
           partner: {
             name: "Common Arts",
             service_areas_attributes: {
-              "0" => { neighbourhood_id: ward.id.to_s },
-              "1" => { neighbourhood_id: "" }
+              "0" => { neighbourhood_id: ward.id.to_s, _destroy: "false" },
+              "1" => { neighbourhood_id: "", _destroy: "false" }
             }
           }
         }

--- a/spec/requests/admin/partners_spec.rb
+++ b/spec/requests/admin/partners_spec.rb
@@ -347,4 +347,54 @@ RSpec.describe "Admin::Partners", type: :request do
       end
     end
   end
+
+  describe "POST /admin/partners" do
+    context "as a neighbourhood admin" do
+      let(:ward) { create(:riverside_ward) }
+      let(:user) { create(:neighbourhood_admin, neighbourhood: ward) }
+
+      before { sign_in user }
+
+      # Regression test for issue #3356: the wizard submits a blank
+      # neighbourhood_id for any untouched "New Service Area" picker row
+      it "creates a partner despite a leftover blank service area row" do
+        post admin_partners_url(host: admin_host), params: {
+          partner: {
+            name: "Common Arts",
+            service_areas_attributes: {
+              "0" => { neighbourhood_id: ward.id.to_s },
+              "1" => { neighbourhood_id: "" }
+            }
+          }
+        }
+
+        partner = Partner.find_by(name: "Common Arts")
+        expect(partner).to be_present
+        expect(partner.service_areas.map(&:neighbourhood_id)).to eq([ward.id])
+        expect(response).to be_redirect
+      end
+
+      # Regression test for issue #3356: service areas rendered as cards after a
+      # failed save must round-trip their neighbourhood_id, or they are silently
+      # dropped from the retry submission
+      it "keeps service areas submittable when validation fails and the form re-renders" do
+        post admin_partners_url(host: admin_host), params: {
+          partner: {
+            name: "",
+            service_areas_attributes: {
+              "0" => { neighbourhood_id: ward.id.to_s }
+            }
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+
+        doc = Nokogiri::HTML(response.body)
+        neighbourhood_inputs = doc.css("input[name^='partner[service_areas_attributes]']")
+                                  .select { |input| input["name"].end_with?("[neighbourhood_id]") }
+                                  .map { |input| input["value"] }
+        expect(neighbourhood_inputs).to include(ward.id.to_s)
+      end
+    end
+  end
 end

--- a/spec/requests/admin/sites_spec.rb
+++ b/spec/requests/admin/sites_spec.rb
@@ -185,6 +185,34 @@ RSpec.describe "Admin::Sites", type: :request do
   end
 
   describe "PUT /admin/sites/:id" do
+    context "when a newly added neighbourhood fails validation and the form re-renders" do
+      before { sign_in root_user }
+
+      # Regression test for the same class of bug as #3356: a just-added secondary
+      # neighbourhood re-renders as a NeighbourhoodCard, which must emit a hidden
+      # neighbourhood_id or the row is silently dropped from the retry submission.
+      it "keeps the added neighbourhood submittable" do
+        ward = neighbourhoods.first
+
+        put admin_site_url(site, host: admin_host), params: {
+          site: {
+            name: "", # forces a validation failure so the form re-renders
+            sites_neighbourhoods_attributes: {
+              "0" => { neighbourhood_id: ward.id.to_s, relation_type: "Secondary" }
+            }
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+
+        doc = Nokogiri::HTML(response.body)
+        neighbourhood_ids = doc.css("input[name^='site[sites_neighbourhoods_attributes]']")
+                               .select { |input| input["name"].end_with?("[neighbourhood_id]") }
+                               .map { |input| input["value"] }
+        expect(neighbourhood_ids).to include(ward.id.to_s)
+      end
+    end
+
     context "with bad image uploads" do
       before { sign_in root_user }
 

--- a/spec/system/admin/partners_spec.rb
+++ b/spec/system/admin/partners_spec.rb
@@ -214,4 +214,63 @@ RSpec.describe "Admin Partners", :slow, type: :system do
       end
     end
   end
+
+  describe "new partner wizard recovery" do
+    # Regression test for issue #3356: after a failed save the wizard re-renders
+    # with fields pre-filled, but validation state used to only update on input
+    # events — leaving stale "Must be at least 5 characters long" hints and a
+    # disabled Continue button until every field was re-typed
+    it "recovers from a failed save without re-typing fields", :aggregate_failures do
+      click_link "Partners"
+      await_datatables
+      click_link "Add Partner"
+
+      # Step 1: Name
+      fill_in "partner_name", with: "Recovery Test Partner"
+      expect(page).to have_content("This name is available!")
+      click_button "Continue"
+
+      # Step 2: Location (address is enough to proceed)
+      expect(page).to have_content("Set Location")
+      fill_in "partner_address_attributes_street_address", with: "1 Test Street"
+      fill_in "partner_address_attributes_postcode", with: "ZZMB 1RS"
+      click_button "Continue"
+
+      # Step 3: Tags
+      click_button "Continue"
+
+      # Step 4: Contact — a hyphenated Facebook name passes the client-side
+      # checks but fails the server-side format validation
+      fill_in "partner_facebook_link", with: "Group-Name"
+      click_button "Continue"
+
+      # Step 5: Invite (optional), Step 6: Confirm
+      click_button "Continue"
+      click_button "Create Partner"
+
+      # Server rejects the save and re-renders the wizard at step 1
+      expect(page).to have_content("prohibited this Partner from being saved")
+      expect(page).to have_field("partner_name", with: "Recovery Test Partner")
+
+      # Pre-filled fields re-validate on connect: no stale min-length hint,
+      # availability re-checked, Continue enabled without re-typing
+      expect(page).to have_content("This name is available!")
+      expect(page).not_to have_content("Must be at least 5 characters long")
+      expect(page).to have_button("Continue", disabled: false)
+
+      # Fix the one genuinely invalid field and resubmit
+      click_button "Continue"
+      expect(page).to have_content("Set Location")
+      click_button "Continue"
+      click_button "Continue"
+      fill_in "partner_facebook_link", with: "GroupName"
+      expect(page).to have_field("partner_facebook_link", with: "GroupName")
+      click_button "Continue"
+      click_button "Continue"
+      click_button "Create Partner"
+
+      expect(page).to have_content("Partner was successfully created.")
+      expect(Partner.find_by(name: "Recovery Test Partner")).to be_present
+    end
+  end
 end

--- a/spec/system/admin/service_area_picker_spec.rb
+++ b/spec/system/admin/service_area_picker_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression coverage for the cascading neighbourhood picker's auto-select.
+# With a single country the picker auto-selects it, and it used to dead-end
+# there: it loaded the next level from the (null) parent scope instead of the
+# auto-selected country, so the endpoint returned top-level roots and every
+# level below stayed empty. The picker was unusable on single-country data.
+RSpec.describe "Service area cascading picker", :slow, type: :system do
+  include_context "admin login"
+
+  # A single, clean country -> region -> county -> district -> wards tree, so
+  # every level above "ward" has exactly one option and auto-selects, and the
+  # ward dropdown is only reachable if the cascade does not dead-end.
+  let!(:country) { create(:normal_island_country) }
+  let!(:region) { create(:northvale_region, parent: country) }
+  let!(:county) { create(:greater_millbrook_county, parent: region) }
+  let!(:district) { create(:millbrook_district, parent: county) }
+  let!(:riverside_ward) { create(:riverside_ward, parent: district) }
+  let!(:oldtown_ward) { create(:oldtown_ward, parent: district) }
+
+  it "auto-selects the single country and cascades down to the ward dropdown", :aggregate_failures do
+    click_link "Partners"
+    await_datatables
+    click_link "Add Partner"
+
+    fill_in "partner_name", with: "Auto Select Test Partner"
+    expect(page).to have_content("This name is available!")
+    click_button "Continue"
+
+    expect(page).to have_content("Set Location")
+    click_link "Add Service Area"
+
+    within(all("[data-controller='cascading-neighbourhood']").last) do
+      ward_select = find("[data-cascading-neighbourhood-target='ward']")
+
+      # The wards under the auto-selected chain populate the ward dropdown.
+      # (Fetches are chained across five levels, so allow extra wait time.)
+      using_wait_time(15) do
+        expect(ward_select).to have_css("option", text: "Riverside")
+        expect(ward_select).to have_css("option", text: "Oldtown")
+      end
+
+      ward_select.find(:option, "Riverside").select_option
+      expect(find("input[name*='neighbourhood_id']", visible: false).value).to eq(riverside_ward.id.to_s)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #3356

## Description

Fixes a family of bugs in the admin "service area" / neighbourhood pickers, found while diagnosing #3356 (reproduced live in the browser as a non-root neighbourhood admin).

### 1. Blank service-area rows break the save (the reported bug)

An untouched "New Service Area" picker row submits a blank `neighbourhood_id`. With no `reject_if`, that built an invalid `ServiceArea` producing three errors at once — and the nil id also failed `check_neighbourhood_access` for non-root admins even when valid service areas were present. Fixed with a `reject_if` that drops blank rows (casting `_destroy`, which the form always submits as `"false"`).

### 2. Failed-save re-render dropped newly-added rows

`NeighbourhoodCard` rendered no hidden `neighbourhood_id`, so after a validation failure a row shown as a card was dropped from the retry submission. Fixed by rendering the hidden field in the card; the same shared card fix also covers the **site** form (secondary neighbourhoods) — verified by a request spec. The sites primary card branch also now preserves `relation_type`.

### 3. Wizard showed stale errors after a failed save

Name min-length / availability / admin-email state only updated on input events, so a re-rendered wizard showed stale errors and a disabled Continue until every field was re-typed. Fixed by re-running the checks on `connect()`.

### 4. Cascading picker dead-ended on single-country data

When a level has one option the picker auto-selects it, then loaded the next level from the parent scope — which is null at the top level, so the endpoint returned roots instead of the country's children and every level below died. The picker was unusable with a single country. Fixed by falling back to the auto-selected id at the root. Also derives neighbourhood `level` from `unit` in the Normal Island factory (the picker filters by `level`, which the real seeds set but the factory left nil) — this is what previously blocked driving the picker in system tests.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Reproduced the exact three-error failure and the picker dead-end live in Chrome, then confirmed each fix
- Model + request specs: blank rows rejected; added rows survive a failed-save re-render (partners and sites); `_destroy` removal still works
- System specs: full wizard failed-save→recovery run; full auto-select cascade down to the ward dropdown (fails without the JS fix)
- Broad regression run across neighbourhood-using specs (models, queries, requests, graphql, datatables, system) after the global factory `level` change — all green

### How Will This Be Deployed?

Standard deploy, no infrastructure or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)