### PR TITLE
Fix log retention and ship logs to AppSignal (production + staging)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ This file configures AI coding assistants for PlaceCal. Review the context file 
 - **When the user says something is wrong, believe them** - Trust the user over your assumptions.
 - **Debug properly** - If a fix doesn't work, investigate why rather than assuming it did.
 
+## Environment Config
+
+Staging runs its own `config/environments/staging.rb`, a near-duplicate of `production.rb`. Changes to production env config (logging, caching, mailers, etc.) must be mirrored in `staging.rb` or they won't reach staging.
+
 ## Development URLs
 
 The admin interface uses a subdomain. Access it at:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This file configures AI coding assistants for PlaceCal. Review the context file 
 
 ## Environment Config
 
-Staging runs its own `config/environments/staging.rb`, a near-duplicate of `production.rb`. Changes to production env config (logging, caching, mailers, etc.) must be mirrored in `staging.rb` or they won't reach staging.
+Staging runs its own `config/environments/staging.rb`, a near-duplicate of `production.rb`. Shared logging lives in `config/log_config.rb` (called from both); other production env config (caching, mailers, storage) still must be mirrored in `staging.rb` or it won't reach staging.
 
 ## Development URLs
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -32,6 +32,13 @@ proxy:
     responses: true
     max_request_body: 10_000_000 # 10MB — replaces nginx client_max_body_size
 
+# Raise Docker's default 10m log cap so `docker logs` keeps a useful window.
+logging:
+  driver: json-file
+  options:
+    max-size: 100m
+    max-file: 5
+
 registry:
   server: ghcr.io
   username:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../log_config'
+
 Rails.application.configure do
   host = ENV.fetch('SITE_DOMAIN', 'placecal.org')
   routes.default_url_options = { host: host, protocol: 'https' }
@@ -47,11 +49,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # :info drops the per-query SQL noise that was filling the log buffer.
-  config.log_level = (ENV['RAILS_LOG_LEVEL'].presence || 'info').to_sym
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
+  LogConfig.apply(config)
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -72,24 +70,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
-    stdout_logger = ActiveSupport::Logger.new($stdout)
-    stdout_logger.formatter = config.log_formatter
-    logger = ActiveSupport::BroadcastLogger.new(ActiveSupport::TaggedLogging.new(stdout_logger))
-
-    # Ship to AppSignal too for durable, searchable retention.
-    logger.broadcast_to(Appsignal::Logger.new('app')) if ENV['APPSIGNAL_PUSH_API_KEY'].present?
-
-    config.logger = logger
-  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,9 +47,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # :info drops the per-query SQL noise that was filling the log buffer.
+  config.log_level = (ENV['RAILS_LOG_LEVEL'].presence || 'info').to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -82,9 +81,14 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    stdout_logger = ActiveSupport::Logger.new($stdout)
+    stdout_logger.formatter = config.log_formatter
+    logger = ActiveSupport::BroadcastLogger.new(ActiveSupport::TaggedLogging.new(stdout_logger))
+
+    # Ship to AppSignal too for durable, searchable retention.
+    logger.broadcast_to(Appsignal::Logger.new('app')) if ENV['APPSIGNAL_PUSH_API_KEY'].present?
+
+    config.logger = logger
   end
 
   # Do not dump schema after migrations.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,9 +41,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # :info drops the per-query SQL noise that was filling the log buffer.
+  config.log_level = (ENV['RAILS_LOG_LEVEL'].presence || 'info').to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -94,9 +93,14 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
+    stdout_logger = ActiveSupport::Logger.new($stdout)
+    stdout_logger.formatter = config.log_formatter
+    logger = ActiveSupport::BroadcastLogger.new(ActiveSupport::TaggedLogging.new(stdout_logger))
+
+    # Ship to AppSignal too for durable, searchable retention.
+    logger.broadcast_to(Appsignal::Logger.new('app')) if ENV['APPSIGNAL_PUSH_API_KEY'].present?
+
+    config.logger = logger
   end
 
   # Do not dump schema after migrations.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../log_config'
+
 Rails.application.configure do
   host = ENV.fetch('SITE_DOMAIN', 'placecal-staging.org')
   routes.default_url_options = { host: host, protocol: 'https' }
@@ -41,11 +43,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # :info drops the per-query SQL noise that was filling the log buffer.
-  config.log_level = (ENV['RAILS_LOG_LEVEL'].presence || 'info').to_sym
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
+  LogConfig.apply(config)
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -84,24 +82,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
-    stdout_logger = ActiveSupport::Logger.new($stdout)
-    stdout_logger.formatter = config.log_formatter
-    logger = ActiveSupport::BroadcastLogger.new(ActiveSupport::TaggedLogging.new(stdout_logger))
-
-    # Ship to AppSignal too for durable, searchable retention.
-    logger.broadcast_to(Appsignal::Logger.new('app')) if ENV['APPSIGNAL_PUSH_API_KEY'].present?
-
-    config.logger = logger
-  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/log_config.rb
+++ b/config/log_config.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Shared production/staging logging, loaded from their environment files.
+# INFO by default (drops per-query SQL noise), request-id tagged, broadcast to
+# stdout and — when the push key is set — AppSignal for durable retention.
+module LogConfig
+  def self.apply(config)
+    config.log_level = (ENV['RAILS_LOG_LEVEL'].presence || 'info').to_sym
+    config.log_tags = [:request_id]
+    config.log_formatter = ::Logger::Formatter.new
+
+    return if ENV['RAILS_LOG_TO_STDOUT'].blank?
+
+    stdout_logger = ActiveSupport::Logger.new($stdout)
+    stdout_logger.formatter = config.log_formatter
+    logger = ActiveSupport::BroadcastLogger.new(ActiveSupport::TaggedLogging.new(stdout_logger))
+    logger.broadcast_to(Appsignal::Logger.new('app')) if ENV['APPSIGNAL_PUSH_API_KEY'].present?
+    config.logger = logger
+  end
+end


### PR DESCRIPTION
## Description

Production logs were effectively undiagnosable after the fact. The app logged at `:debug`, so the per-query SQL firehose filled the container's default Docker `json-file` buffer (`max-size=10m`) within **~47 seconds** — by the time anyone looked, the relevant request had already rolled off. This is why the recent partner-wizard incident (#3356) and the earlier user-invite one (#3337) both hit a wall: "log retention has already rolled past."

This makes production logs both leaner and durable:

- **Default the production log level to `:info`** — keeps the request-lifecycle lines that actually matter for diagnosis (`Started POST …`, `Processing by …`, `Parameters: {…}`, `Completed 200 OK`) while dropping the per-query SQL `DEBUG` noise that was ~90% of the volume. Overridable via `RAILS_LOG_LEVEL` when deeper detail is needed temporarily.
- **Broadcast logs to AppSignal** (`Appsignal::Logger`) alongside stdout, using `ActiveSupport::BroadcastLogger` (the Rails 8 / AppSignal-recommended pattern). This gives searchable logs with real retention, independent of the container buffer — the account already has a log source and the push key is already provisioned. Guarded on `APPSIGNAL_PUSH_API_KEY`, so development, test, and any unconfigured environment keep stdout-only logging unchanged.
- **Raise the Kamal `json-file` cap to `100m × 5`** so `docker logs` also keeps a useful window (AppSignal holds the durable copy).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a change to the deployment process (Kamal `logging:` block; picked up on next deploy)

### How Has This Been Tested?

Booted the production environment locally (`RAILS_ENV=production RAILS_LOG_TO_STDOUT=true`) and inspected the constructed logger:

- With the push key set: `Rails.logger` is an `ActiveSupport::BroadcastLogger` over `[ActiveSupport::Logger (stdout), Appsignal::Logger]`, at level `INFO`, with `request_id` tags still rendering and `DEBUG` filtered.
- Without the key: stdout-only (`[ActiveSupport::Logger]`), no AppSignal sink.
- `RAILS_LOG_LEVEL=warn` override respected (level → `WARN`).
- Dev/test are untouched — the whole block is gated on `RAILS_LOG_TO_STDOUT`, which they don't set.

### How Will This Be Deployed?

Standard deploy. The `logging:` block applies to all containers (web + job_worker) on the next Kamal deploy. `APPSIGNAL_PUSH_API_KEY` is already in the deploy secrets, so the AppSignal broadcast activates automatically; no new config needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)