### PR TITLE
Silence SimpleCov add_group deprecation in spec output

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,12 @@ require "simplecov"
 require "simplecov_json_formatter"
 SimpleCov.start "rails" do
   enable_coverage :branch
-  add_group "Datatables", "app/datatables"
-  add_group "GraphQL", "app/graphql"
-  add_group "Importers", "app/jobs/calendar_importer"
-  add_group "Components", "app/components"
-  add_group "Policies", "app/policies"
-  add_group "Uploaders", "app/uploaders"
+  group "Datatables", "app/datatables"
+  group "GraphQL", "app/graphql"
+  group "Importers", "app/jobs/calendar_importer"
+  group "Components", "app/components"
+  group "Policies", "app/policies"
+  group "Uploaders", "app/uploaders"
 
   if ENV["CI"]
     formatter SimpleCov::Formatter::MultiFormatter.new([


### PR DESCRIPTION
## What & why

Every rspec run logs six `[DEPRECATION] SimpleCov.add_group is deprecated. Replace with SimpleCov.group` lines from `spec/spec_helper.rb`, cluttering CI output. SimpleCov renamed the DSL method; `group` takes the same arguments and behaves identically.

## Change

Swaps the six `add_group` calls to `group` in the `SimpleCov.start` block. No behaviour change to coverage grouping.

## Verification

Ran the exact SimpleCov block from `spec_helper.rb` in isolation against the bundled SimpleCov: the updated `group` form runs clean, and `add_group` was confirmed to be the deprecated method. (Full local rspec is currently blocked by an unrelated strict_ivars boot issue on Ruby 4.0.3; CI covers the suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)