### PR TITLE
Fix blank maps in Safari: load map libraries from jsdelivr, not esm.sh

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -15,13 +15,16 @@ pin '@hotwired/turbo-rails', to: 'https://cdn.jsdelivr.net/npm/@hotwired/turbo-r
 pin '@hotwired/turbo', to: 'https://cdn.jsdelivr.net/npm/@hotwired/turbo@8.0.12/+esm'
 
 # External dependencies
-# jsdelivr bundles ESM with sub-dependencies inline (more reliable than esm.sh)
+# jsdelivr bundles ESM with sub-dependencies inline (more reliable than esm.sh).
+# Maps must use jsdelivr, not esm.sh: esm.sh serves a different build per browser
+# via User-Agent sniffing, and Safari's transitive maplibre-gl fetch hangs forever,
+# so the map's dynamic import() rejects and nothing renders (works fine in Chrome).
 pin 'tom-select', to: 'https://cdn.jsdelivr.net/npm/tom-select@2.4.3/+esm', preload: false
-pin 'leaflet', to: 'https://esm.sh/leaflet@1.9.4', preload: false
+pin 'leaflet', to: 'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/+esm', preload: false
 
 # MapLibre GL for vector tile rendering with custom styles
-pin 'maplibre-gl', to: 'https://esm.sh/maplibre-gl@4.7.1', preload: false
-pin '@maplibre/maplibre-gl-leaflet', to: 'https://esm.sh/@maplibre/maplibre-gl-leaflet@0.0.22', preload: false
+pin 'maplibre-gl', to: 'https://cdn.jsdelivr.net/npm/maplibre-gl@4.7.1/+esm', preload: false
+pin '@maplibre/maplibre-gl-leaflet', to: 'https://cdn.jsdelivr.net/npm/@maplibre/maplibre-gl-leaflet@0.0.22/+esm', preload: false
 
 # Marker clustering for directory overview map
 pin 'leaflet.markercluster', to: 'https://cdn.jsdelivr.net/npm/leaflet.markercluster@1.5.3/+esm', preload: false

--- a/doc/ai/context.md
+++ b/doc/ai/context.md
@@ -96,7 +96,7 @@ Both admin and public interfaces use **importmap-rails** with native ES modules 
 - **Controller mixins**: `app/javascript/controllers/mixins/*.js`
 - **Configuration**: `config/importmap.rb`
 - Changes take effect on browser refresh (no build needed)
-- External dependencies loaded from CDN (esm.sh, jsdelivr):
+- External dependencies loaded from CDN (jsdelivr `/+esm`; avoid esm.sh, whose per-User-Agent builds break maps in Safari):
   - `tom-select` - Enhanced select inputs
   - `leaflet` - Map rendering
   - `maplibre-gl` - Vector tile map styling


### PR DESCRIPTION
## What

Maps are completely blank in Safari on production (homepage cluster map and partner-page maps): no tiles, no zoom controls, no attribution. This repoints the map libraries from **esm.sh** to **jsdelivr** `/+esm`.

```
leaflet, maplibre-gl, @maplibre/maplibre-gl-leaflet:  esm.sh  ->  cdn.jsdelivr.net/.../+esm
```

## Why

The maps lazy-load leaflet + maplibre via dynamic `import()`. esm.sh serves a **different JS build per browser** based on User-Agent. In Safari the transitive `maplibre-gl@^4.7.1` fetch from esm.sh **hangs indefinitely** (confirmed in Safari's Network tab: the request sits with a spinner, Transfer and Time never resolve). Because the request never completes, the map's `Promise.all([...])` dynamic import rejects with `TypeError: Importing a module script failed`, and the map never renders. Chromium receives a build that loads, which is why it only breaks in Safari.

jsdelivr's `/+esm` bundles inline their sub-dependencies into a single self-contained module with no per-UA nested import chain, so there's nothing for Safari to hang on. This is the same pattern the repo already uses successfully for `leaflet.markercluster` and `tom-select` (see the comment already on that block in `importmap.rb`).

## Verification

- Served importmap on the branch contains only jsdelivr URLs, zero esm.sh pins.
- All three jsdelivr `/+esm` URLs return 200; the maplibre-gl-leaflet bundle resolves its peers internally and shares the same `leaflet@1.9.4` instance as the app's pin, so the `L.maplibreGL` / markercluster wiring is unchanged.
- **Confirmed rendering in Safari** against `lvh.me:3000` on this branch: the homepage cluster map now shows tiles, cluster markers, zoom controls and attribution (it was blank before the change).

## Reviewer notes

- No app/JS code changed, only the CDN host in `config/importmap.rb`. All pins stay `preload: false` (lazy-loaded).
- On jsdelivr, `@maplibre/maplibre-gl-leaflet@0.0.22/+esm` inlines `maplibre-gl@4.5.0` for its own use. The separate `maplibre-gl` pin (4.7.1) is only a transitive specifier and isn't imported directly anywhere, so the leaflet plugin uses its bundled 4.5.0. Both are v4 and render identically; the reported bug was module *loading*, not a maplibre rendering regression, so no version bump is involved.
