### PR TITLE
feat: add Matomo tracking alongside Plausible

### DIFF
--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -33,6 +33,7 @@ class Views::Layouts::Application < Phlex::HTML
         script { raw safe("if(!HTMLScriptElement.supports||!HTMLScriptElement.supports('importmap')){var s=document.createElement('script');s.src='#{shim_url}';s.async=true;document.head.appendChild(s)}") }
         javascript_importmap_tags
         script(defer: true, 'data-domain': 'placecal.org', src: 'https://plausible.io/js/plausible.js') if Rails.env.production?
+        script { raw safe(matomo_tracking_js) } if Rails.env.production?
         meta(name: 'turbo-refresh-method', content: 'morph')
       end
 
@@ -152,6 +153,26 @@ class Views::Layouts::Application < Phlex::HTML
 
   def preload_font(path)
     link(rel: 'preload', href: asset_path(path), as: 'font', type: 'font/woff2', crossorigin: 'anonymous')
+  end
+
+  # Matomo (stats.gfsc.community, site 1). Runs alongside Plausible while the
+  # two are compared; Plausible is cancelled after that.
+  # disableCookies must be pushed before trackPageView — after it the cookie is
+  # already set. Cookieless keeps parity with Plausible, so no consent banner.
+  def matomo_tracking_js
+    <<~JS
+      var _paq = window._paq = window._paq || [];
+      _paq.push(['disableCookies']);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u = "https://stats.gfsc.community/";
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+        g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+      })();
+    JS
   end
 
   def site


### PR DESCRIPTION
Part of geeksforsocialchange/gfsc-infrastructure#152 — migrating off paid Plausible before the 27 Aug 2026 renewal.

Adds the Matomo snippet for **placecal.org** (`stats.gfsc.community`, site 1) to the layout, in the same `Rails.env.production?` guard as the Plausible tag beside it. Follows the existing `script { raw safe(...) }` pattern already used for the importmap shim.

**Plausible is deliberately left in place.** Both run in parallel for a week so the numbers can be compared before anything is switched off.

## Notes

- **`disableCookies`** — Matomo defaults to first-party cookies; Plausible never set any. Cookieless keeps the current privacy position, so no consent banner is needed.
- **`enableLinkTracking`** covers outbound links and file downloads.
- Expect a 10–20% gap between the two tools during the parallel run; they differ on bot filtering and session definition.
- Matomo is self-hosted on placecal-prod, so this adds no third-party origin the site was not already talking to.

## Not in this PR

**`ApplicationController#track_file_download` still posts to Plausible’s Events API** (`app/controllers/application_controller.rb`), which is how iCal feed and CSV export downloads get counted — those clients never run JavaScript, so the snippet above cannot see them. Porting it needs Matomo’s HTTP Tracking API plus a `token_auth` credential (without one, `cip` is ignored and every download records as the server’s own IP). Separate PR once the token exists.

`app/content/privacy.md` and `app/views/homepage/privacy.rb` also name Plausible, and should describe Matomo once Plausible is removed: self-hosted, cookieless, IPs anonymised to 2 bytes, raw logs deleted after 180 days.