### PR TITLE
Port server-side iCal/CSV download tracking from Plausible to Matomo

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -282,6 +282,7 @@ jobs:
           MAILERSEND_PASSWORD: ${{ secrets.MAILERSEND_PASSWORD }}
           APPSIGNAL_PUSH_API_KEY: ${{ secrets.APPSIGNAL_PUSH_API_KEY }}
           EVENTBRITE_TOKEN: ${{ secrets.EVENTBRITE_TOKEN }}
+          MATOMO_TOKEN_AUTH: ${{ secrets.MATOMO_TOKEN_AUTH }}
           # SSL (Cloudflare Origin CA certificate — per-destination)
           SSL_CERTIFICATE_PEM: ${{ steps.dest.outputs.destination == 'production' && secrets.PRODUCTION_SSL_CERTIFICATE_PEM || secrets.STAGING_SSL_CERTIFICATE_PEM }}
           SSL_PRIVATE_KEY_PEM: ${{ steps.dest.outputs.destination == 'production' && secrets.PRODUCTION_SSL_PRIVATE_KEY_PEM || secrets.STAGING_SSL_PRIVATE_KEY_PEM }}

--- a/.kamal/secrets-common
+++ b/.kamal/secrets-common
@@ -31,6 +31,9 @@ APPSIGNAL_PUSH_API_KEY=$APPSIGNAL_PUSH_API_KEY
 # Third-party APIs
 EVENTBRITE_TOKEN=$EVENTBRITE_TOKEN
 
+# Matomo server-side download tracking (dedicated user, write access on site 1 only)
+MATOMO_TOKEN_AUTH=$MATOMO_TOKEN_AUTH
+
 # SSL (Cloudflare Origin CA certificate for use behind Cloudflare proxy)
 SSL_CERTIFICATE_PEM=$SSL_CERTIFICATE_PEM
 SSL_PRIVATE_KEY_PEM=$SSL_PRIVATE_KEY_PEM

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -187,18 +187,12 @@ class ApplicationController < ActionController::Base
     token = ENV.fetch('MATOMO_TOKEN_AUTH', nil)
     return if token.blank?
 
-    # Read everything off the request before spawning the thread: the request
-    # object is not safe to touch once the response has been sent. cip and ua
-    # are only honoured by Matomo when token_auth is valid; without them every
-    # download would record as the app server itself.
-    params = {
-      idsite: '1', rec: '1', apiv: '1',
-      url: request.original_url,
-      download: request.original_url,
-      ua: request.user_agent.to_s,
-      cip: request.remote_ip,
-      token_auth: token
-    }
+    # Request state is read before the thread spawns: the request object is
+    # not safe to touch once the response is sent. cip/ua are only honoured
+    # with a valid token_auth, else every download records as the app server.
+    params = { idsite: '1', rec: '1', apiv: '1', token_auth: token,
+               url: request.original_url, download: request.original_url,
+               ua: request.user_agent.to_s, cip: request.remote_ip }
     Thread.new do
       Net::HTTP.post_form(URI('https://stats.gfsc.community/matomo.php'), params)
     rescue StandardError => e

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -166,9 +166,10 @@ class ApplicationController < ActionController::Base
         .gsub('\\\\', '\\')
   end
 
-  # Track iCal feed downloads in AppSignal and Plausible.
-  # Sets a distinct AppSignal action name and sends a server-side pageview
-  # to Plausible (iCal clients don't execute JavaScript).
+  # Track iCal feed downloads in AppSignal and Matomo.
+  # Sets a distinct AppSignal action name and sends a server-side hit to
+  # Matomo (iCal clients don't execute JavaScript, so the JS tracker never
+  # sees these requests).
   def track_ical_download
     track_file_download('ical_feed')
   end
@@ -183,17 +184,25 @@ class ApplicationController < ActionController::Base
 
     return unless Rails.env.production?
 
+    token = ENV.fetch('MATOMO_TOKEN_AUTH', nil)
+    return if token.blank?
+
+    # Read everything off the request before spawning the thread: the request
+    # object is not safe to touch once the response has been sent. cip and ua
+    # are only honoured by Matomo when token_auth is valid; without them every
+    # download would record as the app server itself.
+    params = {
+      idsite: '1', rec: '1', apiv: '1',
+      url: request.original_url,
+      download: request.original_url,
+      ua: request.user_agent.to_s,
+      cip: request.remote_ip,
+      token_auth: token
+    }
     Thread.new do
-      uri = URI('https://plausible.io/api/event')
-      Net::HTTP.post(
-        uri,
-        { name: 'pageview', url: request.original_url, domain: 'placecal.org' }.to_json,
-        'Content-Type' => 'application/json',
-        'User-Agent' => request.user_agent.to_s,
-        'X-Forwarded-For' => request.remote_ip
-      )
+      Net::HTTP.post_form(URI('https://stats.gfsc.community/matomo.php'), params)
     rescue StandardError => e
-      Rails.logger.warn("Plausible tracking failed: #{e.message}")
+      Rails.logger.warn("Matomo tracking failed: #{e.message}")
     end
   end
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -64,6 +64,7 @@ env:
     - APPSIGNAL_PUSH_API_KEY
     - EVENTBRITE_TOKEN
     - SITE_DOMAIN
+    - MATOMO_TOKEN_AUTH
 
 volumes:
   - "/data/placecal/uploads:/rails/public/uploads"


### PR DESCRIPTION
`track_file_download` now posts to Matomo's HTTP tracking API (stats.gfsc.community, site 1) instead of Plausible's Events API, keeping visibility of calendar-subscription traffic (iCal clients never execute the JS tracker). Hits are sent as Matomo Download actions with the real visitor IP and user agent via `cip`/`ua`, which Matomo only honours with a valid `token_auth`.

Safe to merge before the secret exists: the method no-ops when `MATOMO_TOKEN_AUTH` is unset (and on staging, which runs with RAILS_ENV=staging). Also hoists request reads out of the tracking thread, which previously touched the request object after the response could have been sent.

Setup to activate it:
1. In Matomo, create a dedicated user with write access on site 1 only, and generate an auth token for it.
2. Add `MATOMO_TOKEN_AUTH` to this repo's GitHub Actions secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)