### PR TITLE
Retry dropped tab clicks and raise CI Capybara wait time

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -9,7 +9,9 @@ Capybara.disable_animation = true
 
 # Configure default host for system tests
 Capybara.configure do |config|
-  config.default_max_wait_time = 5
+  # CI runs the JS-heavy system suite on 2-core runners where waits that are
+  # comfortable locally get missed under load (issue #3341).
+  config.default_max_wait_time = ENV["CI"] ? 10 : 5
   config.server = :puma, { Silent: true }
   config.always_include_port = true
 end

--- a/spec/support/tab_helpers.rb
+++ b/spec/support/tab_helpers.rb
@@ -26,14 +26,9 @@ module TabHelpers
     click_tab_matching("input.tab[aria-label='#{tab_label}']")
   end
 
-  # Click a tab radio and wait for it to become :checked, re-clicking if the
-  # click didn't register. CI failure screenshots (issue #3341) show Selenium
-  # occasionally dropping the click on a loaded runner: the page is healthy
-  # and clean but the radio never switches. A bounded re-click targets exactly
-  # that, without masking a genuine failure (an intercepted or reverted click
-  # still fails the final assertion).
-  # NOTE: not for clicks that trigger a confirm() (unsaved changes) — those
-  # must stay inside accept_confirm/dismiss_confirm blocks with a raw click.
+  # Click a tab radio and wait for :checked, re-clicking if Selenium dropped
+  # the click on a loaded CI runner (#3341). Not for clicks that trigger a
+  # confirm() — those need a raw click inside accept_confirm/dismiss_confirm.
   def click_tab_matching(selector)
     wait_for_form_tabs
     3.times do

--- a/spec/support/tab_helpers.rb
+++ b/spec/support/tab_helpers.rb
@@ -17,20 +17,30 @@ module TabHelpers
   end
 
   # Click a tab by its data-hash attribute and wait for it to be selected.
-  # Uses a retryable CSS selector for the assertion instead of checking the
-  # already-resolved element — avoids CI flakiness where the checked state
-  # lags behind the click in headless Chrome.
   def click_tab(hash)
-    wait_for_form_tabs
-    find("input.tab[data-hash='#{hash}']").click
-    expect(page).to have_css("input.tab[data-hash='#{hash}']:checked", wait: 5)
+    click_tab_matching("input.tab[data-hash='#{hash}']")
   end
 
   # Navigate to a partner form tab by its aria-label (includes emoji prefix)
   def go_to_partner_tab(tab_label)
+    click_tab_matching("input.tab[aria-label='#{tab_label}']")
+  end
+
+  # Click a tab radio and wait for it to become :checked, re-clicking if the
+  # click didn't register. CI failure screenshots (issue #3341) show Selenium
+  # occasionally dropping the click on a loaded runner: the page is healthy
+  # and clean but the radio never switches. A bounded re-click targets exactly
+  # that, without masking a genuine failure (an intercepted or reverted click
+  # still fails the final assertion).
+  # NOTE: not for clicks that trigger a confirm() (unsaved changes) — those
+  # must stay inside accept_confirm/dismiss_confirm blocks with a raw click.
+  def click_tab_matching(selector)
     wait_for_form_tabs
-    find("input.tab[aria-label='#{tab_label}']").click
-    expect(page).to have_css("input.tab[aria-label='#{tab_label}']:checked", wait: 5)
+    3.times do
+      find(selector).click
+      return if page.has_css?("#{selector}:checked", wait: 2)
+    end
+    expect(page).to have_css("#{selector}:checked")
   end
 
   def go_to_basic_info_tab = go_to_partner_tab("📋 Basic Info")

--- a/spec/system/admin/partner_save_bar_spec.rb
+++ b/spec/system/admin/partner_save_bar_spec.rb
@@ -200,8 +200,8 @@ RSpec.describe "Partner Save Bar", :slow, type: :system do
     end
 
     it "navigates to previous tab when clicking Back without changes" do
-      # Go to Location tab first
-      find('input[aria-label="📍 Location"]').click
+      # Go to Location tab first (re-clicks if the click is dropped, #3341)
+      go_to_place_tab
       expect(page).to have_button("Back", visible: :visible)
 
       click_button "Back"

--- a/spec/system/admin/sites_spec.rb
+++ b/spec/system/admin/sites_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe "Admin Sites", :slow, type: :system do
       # Wait for the page to load
       find("button", text: "Save")
 
-      # Navigate to Neighbourhoods tab
-      find("input.tab[aria-label*='Neighbourhoods']").click
+      # Navigate to Neighbourhoods tab (re-clicks if the click is dropped, #3341)
+      click_tab_matching("input.tab[aria-label*='Neighbourhoods']")
 
       # The site has a primary neighbourhood (sites_neighbourhood created in setup)
       # Check that the nested form for additional neighbourhoods only has the "Add" button,


### PR DESCRIPTION
Part of #3341 (applies candidate remediations 1 and 2; leaves the issue open as the tracking log).

## Description

Two targeted changes to the system-test support code:

- `spec/support/tab_helpers.rb`: `click_tab` and `go_to_partner_tab` now share a `click_tab_matching` helper that re-clicks the tab radio (up to 3 attempts, 2s check each) if it doesn't become `:checked`, then falls through to a normal failing assertion. Genuine failures still fail; only the dropped-click race is absorbed. Clicks that trigger the unsaved-changes `confirm()` must stay as raw clicks inside `accept_confirm`/`dismiss_confirm` blocks, and the helper documents that.
- Converted the two remaining unguarded raw tab clicks to the helper (`partner_save_bar_spec.rb`, `sites_spec.rb`). The three raw clicks inside confirm blocks are left alone deliberately.
- `spec/support/capybara.rb`: `default_max_wait_time` is now 10s on CI, 5s locally.

### Motivation and Context

The dominant flavour of the #3341 flakes (3 of 5 logged occurrences, most recently the 2026-08-19 main deploy blocker, run 32267024076, seed 1542) is now pinned by two CI failure screenshots: Selenium occasionally drops a click on a tab radio on a loaded 2-core runner. The page is healthy, the form is clean, nothing intercepts the click, the radio just never switches. The bounded re-click targets exactly that mechanism. The raised CI wait softens the other two flavours (server boot timeouts, slow element appearance), which share a resource-starvation signature.

App code is untouched; this is test-support only.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran both affected spec files locally (`RUN_SLOW_TESTS=true bundle exec rspec spec/system/admin/partner_save_bar_spec.rb spec/system/admin/sites_spec.rb`): 15 examples, 0 failures. The flake itself only reproduces on loaded CI runners (40+ local attempts and a 10-seed CI matrix never caught it), so the real test is watching #3341 occurrence rates after merge.

### How Will This Be Deployed?

No infrastructure or config changes; ships with the normal test-and-deploy pipeline.