### PR TITLE
Show API key field on the edit calendar Source tab

### DIFF
--- a/app/components/admin/source_input.rb
+++ b/app/components/admin/source_input.rb
@@ -6,13 +6,22 @@ class Components::Admin::SourceInput < Components::Admin::Base
   prop :show_importer, _Boolean, default: true
 
   def view_template
-    div(data_controller: 'source-validator', data_source_validator_test_url_value: @test_url) do
+    div(data_controller: 'source-validator',
+        data_source_validator_test_url_value: @test_url,
+        data_source_validator_api_token_parsers_value: api_token_modes.to_json) do
       render_source_field
-      render_importer_field if @show_importer
+      if @show_importer
+        render_importer_field
+        render_api_token_field
+      end
     end
   end
 
   private
+
+  def api_token_modes
+    CalendarImporter::CalendarImporter::PARSERS.select(&:requires_api_token?).map { |p| p::KEY }
+  end
 
   def render_source_field
     fieldset(class: 'fieldset') do
@@ -84,7 +93,38 @@ class Components::Admin::SourceInput < Components::Admin::Base
                             collection: options_for_importer,
                             selected: @form.object.importer_mode || 'auto',
                             class: 'select select-bordered w-full',
-                            data: { 'source-validator-target': 'importerModeSelect' }))
+                            data: {
+                              'source-validator-target': 'importerModeSelect',
+                              action: 'change->source-validator#importerModeChanged'
+                            }))
     end
+  end
+
+  # The API token field is only relevant for importers that authenticate with a key.
+  # It is hidden server-side unless the saved mode needs one (or a token is already stored),
+  # then shown/hidden by the source-validator controller as the mode changes.
+  def render_api_token_field
+    classes = %w[fieldset mt-4]
+    classes << 'hidden' unless api_token_field_visible?
+
+    fieldset(class: classes.join(' '), data: { 'source-validator-target': 'apiTokenSection' }) do
+      label(for: 'calendar_api_token', class: 'fieldset-legend') do
+        plain I18n.t('admin.calendars.fields.api_token')
+        whitespace
+        span(class: 'text-error') { I18n.t('admin.labels.required') }
+      end
+      raw(@form.input_field(:api_token,
+                            type: :password,
+                            class: 'input input-bordered w-full font-mono text-sm',
+                            placeholder: I18n.t('admin.calendars.fields.api_token_placeholder'),
+                            autocomplete: 'off',
+                            value: @form.object.api_token,
+                            'data-source-validator-target': 'apiTokenInput'))
+      p(class: 'fieldset-label') { I18n.t('admin.calendars.fields.api_token_hint') }
+    end
+  end
+
+  def api_token_field_visible?
+    @form.object.importer_mode.in?(api_token_modes) || @form.object.api_token.present?
   end
 end

--- a/app/javascript/controllers/source_validator_controller.js
+++ b/app/javascript/controllers/source_validator_controller.js
@@ -23,12 +23,15 @@ export default class extends Controller {
 		"testButtonText",
 		"importerModeSection",
 		"importerModeSelect",
+		"apiTokenSection",
+		"apiTokenInput",
 	];
 
 	static values = {
 		testUrl: String,
 		valid: { type: Boolean, default: false },
 		detectedFormat: { type: String, default: "" },
+		apiTokenParsers: { type: Array, default: [] },
 	};
 
 	connect() {
@@ -38,6 +41,36 @@ export default class extends Controller {
 		if (this.hasInputTarget && this.inputTarget.value.trim()) {
 			// Mark as provisionally valid for existing calendars
 			this.validValue = true;
+		}
+
+		this.updateApiTokenVisibility();
+	}
+
+	// Importers that require an API token (driven by server-side parser config)
+	get requiresApiToken() {
+		if (!this.hasImporterModeSelectTarget) return false;
+		return this.apiTokenParsersValue.includes(
+			this.importerModeSelectTarget.value,
+		);
+	}
+
+	// Called when the user picks a calendar type
+	importerModeChanged() {
+		this.updateApiTokenVisibility();
+	}
+
+	// Show or hide the API token field based on the selected importer.
+	// A token that is already saved keeps the field visible so it can be edited.
+	updateApiTokenVisibility() {
+		if (!this.hasApiTokenSectionTarget) return;
+
+		const hasToken =
+			this.hasApiTokenInputTarget && this.apiTokenInputTarget.value.trim();
+
+		if (this.requiresApiToken || hasToken) {
+			this.apiTokenSectionTarget.classList.remove("hidden");
+		} else {
+			this.apiTokenSectionTarget.classList.add("hidden");
 		}
 	}
 
@@ -108,6 +141,8 @@ export default class extends Controller {
 					}
 					this.detectedFormatValue = data.importer_name;
 				}
+
+				this.updateApiTokenVisibility();
 
 				this.dispatch("validated", {
 					detail: {

--- a/app/views/admin/calendars/form_tab_settings.rb
+++ b/app/views/admin/calendars/form_tab_settings.rb
@@ -6,8 +6,6 @@ class Views::Admin::Calendars::FormTabSettings < Views::Admin::Base
   def view_template
     calendar = form.object
 
-    render_api_token_section(calendar)
-
     DangerZone(
       title: t('admin.actions.delete_model', model: Calendar.model_name.human.downcase),
       description: t('admin.calendars.danger_zone.delete_description', count: calendar.events.count),
@@ -18,34 +16,5 @@ class Views::Admin::Calendars::FormTabSettings < Views::Admin::Base
                  count: calendar.events.count,
                  items: ::Event.model_name.human(count: 2).downcase)
     )
-  end
-
-  private
-
-  def render_api_token_section(calendar)
-    api_token_modes = CalendarImporter::CalendarImporter::PARSERS.select(&:requires_api_token?).map { |p| p::KEY }
-    return unless calendar.importer_mode.in?(api_token_modes) || calendar.api_token.present?
-
-    SectionHeader(
-      title: t('admin.calendars.fields.api_token'),
-      description: t('admin.calendars.fields.api_token_hint')
-    ) do |c|
-      c.with_icon { raw icon(:key, size: '5') }
-    end
-
-    div(class: 'max-w-xl') do
-      fieldset(class: 'fieldset') do
-        label(for: 'calendar_api_token', class: 'fieldset-legend') do
-          plain t('admin.calendars.fields.api_token')
-        end
-        raw form.input_field(:api_token,
-                             type: :password,
-                             class: 'input input-bordered w-full font-mono text-sm',
-                             placeholder: t('admin.calendars.fields.api_token_placeholder'),
-                             autocomplete: 'off',
-                             value: calendar.api_token)
-        p(class: 'fieldset-label') { t('admin.calendars.fields.api_token_hint') }
-      end
-    end
   end
 end

--- a/spec/requests/admin/calendars_spec.rb
+++ b/spec/requests/admin/calendars_spec.rb
@@ -141,6 +141,57 @@ RSpec.describe "Admin::Calendars", type: :request do
       get edit_admin_calendar_url(calendar, host: admin_host)
       expect(response.body).to include("ical")
     end
+
+    describe "the API token field" do
+      def api_token_fieldset(body)
+        Nokogiri::HTML(body).at_css('fieldset[data-source-validator-target="apiTokenSection"]')
+      end
+
+      it "renders the field exactly once so the form does not submit duplicates" do
+        get edit_admin_calendar_url(calendar, host: admin_host)
+        inputs = Nokogiri::HTML(response.body).css('input[name="calendar[api_token]"]')
+        expect(inputs.count).to eq(1)
+      end
+
+      it "shows the field for an importer that requires an API token" do
+        api_calendar = build(:calendar, organiser: partner2, importer_mode: "ticketsource")
+        allow(api_calendar).to receive(:check_source_reachable)
+        api_calendar.save!
+
+        get edit_admin_calendar_url(api_calendar, host: admin_host)
+
+        fieldset = api_token_fieldset(response.body)
+        expect(fieldset).to be_present
+        expect(fieldset["class"]).not_to include("hidden")
+      end
+
+      it "hides the field for an importer that does not require an API token" do
+        get edit_admin_calendar_url(calendar, host: admin_host)
+
+        fieldset = api_token_fieldset(response.body)
+        expect(fieldset).to be_present
+        expect(fieldset["class"]).to include("hidden")
+      end
+
+      it "shows the field when a token is already saved" do
+        tokened = build(:calendar, organiser: partner2, importer_mode: "ical", api_token: "skl-existing-token")
+        allow(tokened).to receive(:check_source_reachable)
+        tokened.save!
+
+        get edit_admin_calendar_url(tokened, host: admin_host)
+
+        fieldset = api_token_fieldset(response.body)
+        expect(fieldset["class"]).not_to include("hidden")
+      end
+
+      it "advertises the api token parsers to the source-validator controller" do
+        get edit_admin_calendar_url(calendar, host: admin_host)
+
+        root = Nokogiri::HTML(response.body).at_css('[data-controller="source-validator"]')
+        parsers = JSON.parse(root["data-source-validator-api-token-parsers-value"])
+        expect(parsers).to include("ticketsource")
+      end
+    end
   end
 
   describe "POST /admin/calendars/test_source" do


### PR DESCRIPTION
Resolves #3416

## Description

Adds the API key field to the **edit calendar** form's Source tab, directly under the Calendar Type select. It shows and hides as the type changes (visible for TicketSource and Ticket Tailor, hidden otherwise), mirroring what the new-calendar wizard already does. The field also stays visible whenever a key is already saved, so it can be reviewed or cleared.

The old copy of the field on the Settings tab is removed: all tabs live inside one form, so two `calendar[api_token]` inputs would silently overwrite each other on submit.

### Motivation and Context

Selecting "ticketsource" as the Calendar Type on the edit form gave you no API key field anywhere visible. The field only existed on the Settings tab, and only rendered server-side when `importer_mode` was *already saved* as an API-token mode, so anyone converting an existing calendar to TicketSource had nowhere to paste their key. Reported by a QueerLeeds admin trying to set up the Common Arts calendar.

Implementation: the parser keys that need a token come from the server (`PARSERS.select(&:requires_api_token?)`) as a Stimulus value on `SourceInput`, and `source_validator_controller.js` toggles the fieldset on select change, on connect, and after source auto-detection. Initial visibility is also rendered server-side, so the right state appears before (or without) JavaScript.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- New request specs in `spec/requests/admin/calendars_spec.rb`: field rendered exactly once; visible for `ticketsource`; hidden for `ical`; visible when a token is already saved; parser keys exposed to the Stimulus controller. `21 examples, 0 failures`.
- Verified live in the browser on the dev server: on an `auto` calendar the field is hidden, switching Calendar Type to TicketSource reveals it, switching to iCal hides it again.

### How Will This Be Deployed?

Normal deploy, no infrastructure or config changes.

### Screenshots

Edit form with TicketSource selected, API Key field now visible under Calendar Type:

(Verified in the browser; screenshot attached in a comment if needed. The field renders as "API Key" with placeholder "Enter your API key" and hint "Required for Ticket Tailor and TicketSource.")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
