### PR TITLE
WP 0.4: engine loading proof (#3368)

### DIFF
--- a/spec/fixtures/extensions/example_theme/app/assets/builds/example_theme/theme.css
+++ b/spec/fixtures/extensions/example_theme/app/assets/builds/example_theme/theme.css
@@ -1,0 +1,7 @@
+/* Committed, prebuilt stylesheet for the fixture extension (D4). */
+:root {
+	--color-primary: #123456;
+}
+.example-theme-home {
+	border: 1px solid var(--color-primary);
+}

--- a/spec/fixtures/extensions/example_theme/app/components/example_theme/head.rb
+++ b/spec/fixtures/extensions/example_theme/app/components/example_theme/head.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Fixture head component: what a theme pushes into <head> (its stylesheet,
+# fonts, manifest link). WP 0.3 gives the layout a theme head hook that
+# renders this in <head>; until then the fixture view renders it inline,
+# which is enough to prove the component autoloads and the asset resolves.
+class ExampleTheme::Components::Head < Components::Base
+  include Phlex::Rails::Helpers::AssetPath
+
+  def view_template
+    link(rel: "stylesheet", href: asset_path("example_theme/theme.css"), "data-example-theme": "head")
+  end
+end

--- a/spec/fixtures/extensions/example_theme/app/controllers/example_theme/proof_controller.rb
+++ b/spec/fixtures/extensions/example_theme/app/controllers/example_theme/proof_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Fixture-only controller. A real extension has no controllers: its homepage
+# view is rendered by core's SitesController through the theme registry
+# (WP 0.2). This route exists so WP 0.4 can prove engine loading before the
+# registry exists.
+class ExampleTheme::ProofController < ApplicationController
+  before_action :set_site
+
+  def show
+    render ExampleTheme::Views::Home.new(site: @site)
+  end
+end

--- a/spec/fixtures/extensions/example_theme/app/views/example_theme/home.rb
+++ b/spec/fixtures/extensions/example_theme/app/views/example_theme/home.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Fixture homepage view. Inherits the core Views::Base so it gets the Rails
+# helpers, t(), and the core Components kit.
+class ExampleTheme::Views::Home < Views::Base
+  prop :site, _Nilable(Site), reader: :private
+
+  def view_template
+    content_for(:title) { t("example_theme.home.title") }
+    render ExampleTheme::Components::Head.new
+    section(class: "example-theme-home") do
+      h1 { t("example_theme.home.heading") }
+      p { site ? site.name : t("example_theme.home.no_site") }
+    end
+  end
+end

--- a/spec/fixtures/extensions/example_theme/config/locales/en.yml
+++ b/spec/fixtures/extensions/example_theme/config/locales/en.yml
@@ -1,0 +1,6 @@
+en:
+  example_theme:
+    home:
+      title: Example theme
+      heading: Example theme fixture homepage
+      no_site: Rendered without a site

--- a/spec/fixtures/extensions/example_theme/config/routes.rb
+++ b/spec/fixtures/extensions/example_theme/config/routes.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# A non-isolated engine draws straight into the host application's routes.
+Rails.application.routes.draw do
+  get "/example-theme-proof", to: "example_theme/proof#show", as: :example_theme_proof
+end

--- a/spec/fixtures/extensions/example_theme/lib/example_theme.rb
+++ b/spec/fixtures/extensions/example_theme/lib/example_theme.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Test-only fixture extension (WP 0.4 of #3368). Proves that a PlaceCal
+# extension engine can autoload its own Phlex namespaces, render inside the
+# core layout, have its committed CSS served by Propshaft and load its own
+# locale file, all without editing any core config file.
+#
+# It is required from spec/rails_helper.rb before the Rails environment
+# boots, exactly as a real extension gem would be required by Bundler.
+module ExampleTheme
+  # Phlex namespaces. Core keeps Views and Components; an extension owns
+  # <Extension>::Views and <Extension>::Components.
+  module Views; end
+
+  module Components
+    extend Phlex::Kit
+  end
+end
+
+require_relative "example_theme/engine"

--- a/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
+++ b/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ExampleTheme
+  class Engine < ::Rails::Engine
+    # Not isolate_namespace: an extension plugs into the host app's routes,
+    # helpers and layout rather than living behind a mount point.
+
+    # Phlex views live under app/views/<extension>/ and components under
+    # app/components/<extension>/. Rails does not autoload app/views, and it
+    # autoloads app/components under the top-level namespace, so the engine
+    # pushes its own directories with explicit namespaces. This mirrors what
+    # core does in config/initializers/phlex.rb for Views and Components,
+    # but stays entirely inside the engine.
+    initializer "example_theme.phlex_namespaces", before: :set_autoload_paths do
+      Rails.autoloaders.main.push_dir(
+        root.join("app/views/example_theme"),
+        namespace: ExampleTheme::Views
+      )
+      Rails.autoloaders.main.push_dir(
+        root.join("app/components/example_theme"),
+        namespace: ExampleTheme::Components
+      )
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,11 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
+# Test-only fixture extension (WP 0.4, #3368): required before the Rails
+# environment boots, the same way Bundler requires a real extension gem, so
+# its engine initializers, assets, routes and locales take part in boot.
+require_relative "../config/application"
+require_relative "fixtures/extensions/example_theme/lib/example_theme"
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/requests/extensions/example_theme_spec.rb
+++ b/spec/requests/extensions/example_theme_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# WP 0.4 (#3368): proves the extension engine contract with the fixture engine
+# under spec/fixtures/extensions/example_theme, with no core config edits.
+RSpec.describe "Example theme extension engine", type: :request do
+  it "autoloads the engine's own Phlex namespaces" do
+    expect(ExampleTheme::Views::Home.superclass).to eq(Views::Base)
+    expect(ExampleTheme::Components::Head.superclass).to eq(Components::Base)
+    expect(Rails.autoloaders.main.dirs(namespaces: true)).to include(
+      ExampleTheme::Engine.root.join("app/views/example_theme").to_s => ExampleTheme::Views,
+      ExampleTheme::Engine.root.join("app/components/example_theme").to_s => ExampleTheme::Components
+    )
+  end
+
+  it "eager loads the engine's directories without naming errors" do
+    expect { Rails.autoloaders.main.eager_load_dir(ExampleTheme::Engine.root.join("app/views/example_theme")) }
+      .not_to raise_error
+    expect { Rails.autoloaders.main.eager_load_dir(ExampleTheme::Engine.root.join("app/components/example_theme")) }
+      .not_to raise_error
+  end
+
+  it "loads the engine's locale file" do
+    expect(I18n.t("example_theme.home.heading")).to eq("Example theme fixture homepage")
+  end
+
+  it "serves the engine's committed stylesheet through Propshaft" do
+    path = ActionController::Base.helpers.asset_path("example_theme/theme.css")
+    expect(path).to match(%r{\A/assets/example_theme/theme-[0-9a-f]+\.css\z})
+
+    get path
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("text/css")
+    expect(response.body).to include("--color-primary: #123456")
+  end
+
+  it "renders the engine's homepage view inside the core layout" do
+    get "http://lvh.me/example-theme-proof"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("<title>Example theme | PlaceCal</title>")
+    expect(response.body).to include("Example theme fixture homepage")
+    expect(response.body).to include("Rendered without a site")
+    expect(response.body).to match(%r{<link rel="stylesheet" href="/assets/example_theme/theme-[0-9a-f]+\.css" data-example-theme="head">})
+    # Core layout chrome is present around the engine view.
+    expect(response.body).to include('stylesheet" href="/assets/public_tailwind')
+  end
+
+  it "renders the engine's homepage view for a site" do
+    site = create(:site, slug: "example", url: "https://example.lvh.me")
+    get "http://example.lvh.me/example-theme-proof"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(site.name)
+  end
+end


### PR DESCRIPTION
WP 0.4 of #3368. Throwaway engine under spec/fixtures/extensions/example_theme, required from rails_helper only.

Proven, with no core config edits:
- Engine autoloads ExampleTheme::Views::Home and ExampleTheme::Components::Head via Rails.autoloaders.main.push_dir in its own engine.rb (nested root dirs work: app/components stays Object-namespaced, app/components/example_theme is ExampleTheme::Components).
- Core layout renders the engine view (title, chrome, body).
- Propshaft serves the engine's committed app/assets/builds/example_theme/theme.css (asset path is fingerprinted, GET returns text/css with the file's bytes).
- Engine config/locales/en.yml loads.
- Engine config/routes.rb draws into the host routes (fixture-only proof route; real extensions have no controllers or routes).

Finding for WP 2.5: the engine's locale file is placed BEFORE core's in I18n.load_path (index 363 vs core en.yml at 367), so core wins on shared keys. Overriding core strings from an extension needs the engine to append its override file after boot (engine-side, no core change).

Gate:
```
RAILS_ENV=test bundle exec rspec spec/requests/extensions/example_theme_spec.rb
6 examples, 0 failures
RAILS_ENV=test bundle exec rspec spec/i18n_keys_spec.rb spec/requests/public/sites_spec.rb spec/requests/public/custom_theme_spec.rb spec/requests/extensions
20 examples, 0 failures
bundle exec rubocop spec/fixtures/extensions spec/requests/extensions spec/rails_helper.rb
8 files inspected, no offenses (after -A)
```