### PR TITLE
WP 0.1: theme registry (#3368)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,10 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# The extension registry must exist before any extension engine's
+# initializers run, and lib/ is not autoloaded, so it is required here.
+require_relative '../lib/placecal/extensions'
+
 module PlaceCal
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Core's built-in themes, registered through the same registry that
+# extensions use (#3368, D1). The registry itself is required from
+# config/application.rb so that extension engines, whose initializers run
+# before this file, can register into it.
+#
+# Each built-in stylesheet is app/assets/stylesheets/themes/<name>.scss,
+# built by dartsass (config/initializers/dartsass.rb), with a matching
+# public/map-styles/<name>.json.
+%w[pink orange green blue].each do |name|
+  PlaceCal::Extensions.register_theme(name, core: true) do |theme|
+    theme.stylesheet "themes/#{name}"
+    theme.map_style name
+  end
+end
+
+# Legacy per-site theme: the stylesheet and map style are looked up by the
+# site's slug (themes/custom/<slug>.css, public/map-styles/<slug>.json).
+# Only Mossley uses it. Kept so existing sites work untouched; new bespoke
+# sites should be extensions instead.
+PlaceCal::Extensions.register_theme(:custom, core: true) do |theme|
+  theme.stylesheet do |site|
+    path = "themes/custom/#{site.slug}"
+    # The per-site asset may not exist in the pipeline (#2936): link nothing
+    # rather than raise Propshaft::MissingAssetError.
+    path if Rails.application.assets&.resolver&.resolve("#{path}.css").present?
+  end
+  theme.map_style(&:slug)
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,19 @@
 # Contains: ActiveRecord models/attributes, site metadata, and shared strings
 
 en:
+  # Theme labels for the admin site form; extensions may add their own
+  # themes.<name>.label (PlaceCal::Theme#label falls back to a titleized name).
+  themes:
+    pink:
+      label: Pink
+    orange:
+      label: Orange
+    green:
+      label: Green
+    blue:
+      label: Blue
+    custom:
+      label: Custom (legacy, per-site stylesheet)
   # ===========================================================================
   # SITE METADATA
   # ===========================================================================

--- a/lib/placecal/extensions.rb
+++ b/lib/placecal/extensions.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative 'theme'
+
+module PlaceCal
+  # Registry that extensions (Rails engines) register into. Core knows
+  # nothing about individual extensions: it only reads the registry.
+  # See doc/extensions.md and #3368 (D1, D2).
+  #
+  # Core's built-in themes register through the same API at boot in
+  # config/initializers/extensions.rb, so there is exactly one code path.
+  module Extensions
+    class UnknownTheme < KeyError; end
+
+    module_function
+
+    # Register (or replace) a theme definition.
+    #
+    # @param name [Symbol, String]
+    # @param core [Boolean] see PlaceCal::Theme#initialize
+    # @yield [theme] the PlaceCal::Theme to configure
+    # @return [PlaceCal::Theme]
+    def register_theme(name, core: false)
+      theme = Theme.new(name, core: core)
+      yield theme if block_given?
+      registry[theme.name] = theme
+      theme
+    end
+
+    # @return [Array<PlaceCal::Theme>] core themes first, then extension
+    #   themes, each group in registration order
+    def themes
+      core, extension = registry.values.partition(&:core?)
+      core + extension
+    end
+
+    # @return [Array<String>]
+    def theme_names
+      themes.map(&:name)
+    end
+
+    # @param name [Symbol, String, nil]
+    # @return [PlaceCal::Theme, nil]
+    def find_theme(name)
+      return nil if name.blank?
+
+      registry[name.to_s]
+    end
+
+    # @param name [Symbol, String]
+    # @return [PlaceCal::Theme]
+    # @raise [UnknownTheme]
+    def fetch_theme(name)
+      find_theme(name) || raise(UnknownTheme, "no theme registered as #{name.inspect}")
+    end
+
+    # Empty the registry. For specs; pair with #snapshot / #restore.
+    def reset!
+      registry.clear
+    end
+
+    # @return [Hash] a copy of the registry state, for #restore
+    def snapshot
+      registry.dup
+    end
+
+    # @param state [Hash] a value from #snapshot
+    def restore(state)
+      registry.replace(state)
+    end
+
+    def registry
+      @registry ||= {}
+    end
+    private_class_method :registry
+  end
+end

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module PlaceCal
+  # A theme definition: what an extension (or core) registers for a Site
+  # theme name. Pure value object with a small DSL; no Rails model, no
+  # database. See doc/extensions.md and #3368 (D1).
+  #
+  #   PlaceCal::Extensions.register_theme(:transdimension) do |theme|
+  #     theme.stylesheet    'transdimension/theme'
+  #     theme.homepage_view 'Transdimension::Views::Home'
+  #     theme.map_style     'transdimension'
+  #     theme.head          'Transdimension::Components::Head'
+  #     theme.event_filter_style :day_strip
+  #   end
+  #
+  # Each setting is optional. `stylesheet` and `map_style` may also be given
+  # a block that receives the Site, for lookups that depend on the record
+  # (the legacy :custom theme resolves by site slug that way).
+  class Theme
+    EVENT_FILTER_STYLES = %i[date_picker day_strip].freeze
+
+    attr_reader :name
+
+    # @param name [Symbol, String]
+    # @param core [Boolean] true for the built-in themes shipped by core; they
+    #   sort first in the registry so admin selects list them before extensions.
+    def initialize(name, core: false)
+      @name = name.to_s
+      @core = core
+      @stylesheet = nil
+      @homepage_view = nil
+      @map_style = nil
+      @head = nil
+      @event_filter_style = :date_picker
+    end
+
+    def core?
+      @core
+    end
+
+    # ---- DSL: each method sets when given a value or block, reads otherwise.
+
+    # @param value [String, nil] asset logical path without extension, e.g. "themes/pink"
+    def stylesheet(value = nil, &block)
+      return @stylesheet if value.nil? && block.nil?
+
+      @stylesheet = block || value.to_s
+    end
+
+    # @param value [String, nil] Phlex view class name, resolved lazily so
+    #   registration can happen before autoloading is set up.
+    def homepage_view(value = nil)
+      return @homepage_view if value.nil?
+
+      @homepage_view = value.to_s
+    end
+
+    # @param value [String, nil] name of public/map-styles/<name>.json
+    def map_style(value = nil, &block)
+      return @map_style if value.nil? && block.nil?
+
+      @map_style = block || value.to_s
+    end
+
+    # @param value [String, nil] Phlex component class name rendered in <head>
+    def head(value = nil)
+      return @head if value.nil?
+
+      @head = value.to_s
+    end
+
+    # @param value [Symbol, nil] one of EVENT_FILTER_STYLES
+    def event_filter_style(value = nil)
+      return @event_filter_style if value.nil?
+
+      value = value.to_sym
+      raise ArgumentError, "unknown event_filter_style #{value.inspect}, expected one of #{EVENT_FILTER_STYLES.inspect}" unless EVENT_FILTER_STYLES.include?(value)
+
+      @event_filter_style = value
+    end
+
+    # ---- Resolution
+
+    # @param site [Site]
+    # @return [String, nil] stylesheet logical path for this site, or nil
+    def stylesheet_for(site)
+      resolve(@stylesheet, site)
+    end
+
+    # @param site [Site]
+    # @return [String, nil] map style name for this site, or nil
+    def map_style_for(site)
+      resolve(@map_style, site)
+    end
+
+    # @return [Class, nil] the homepage Phlex view class, or nil when the
+    #   theme uses core's default homepage
+    def homepage_view_class
+      @homepage_view&.constantize
+    end
+
+    # @return [Class, nil] the head Phlex component class, or nil
+    def head_class
+      @head&.constantize
+    end
+
+    # Human label for admin selects. Themes may translate `themes.<name>.label`.
+    def label
+      I18n.t("themes.#{name}.label", default: name.titleize)
+    end
+
+    def to_s
+      name
+    end
+
+    private
+
+    def resolve(setting, site)
+      value = setting.respond_to?(:call) ? setting.call(site) : setting
+      value&.to_s.presence
+    end
+  end
+end

--- a/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
+++ b/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
@@ -21,5 +21,15 @@ module ExampleTheme
         namespace: ExampleTheme::Components
       )
     end
+
+    # Register the theme (D1). Runs before core's config/initializers, which
+    # is why core requires the registry from config/application.rb.
+    initializer "example_theme.register_theme" do
+      PlaceCal::Extensions.register_theme(:example_theme) do |theme|
+        theme.stylesheet "example_theme/theme"
+        theme.homepage_view "ExampleTheme::Views::Home"
+        theme.head "ExampleTheme::Components::Head"
+      end
+    end
   end
 end

--- a/spec/lib/placecal/extensions_spec.rb
+++ b/spec/lib/placecal/extensions_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlaceCal::Extensions do
+  describe "boot-time registry" do
+    it "contains the built-in themes plus the test fixture extension" do
+      expect(described_class.theme_names).to eq(%w[pink orange green blue custom example_theme])
+    end
+
+    it "lists built-in themes as core" do
+      expect(described_class.themes.select(&:core?).map(&:name)).to eq(%w[pink orange green blue custom])
+      expect(described_class.find_theme(:example_theme)).not_to be_core
+    end
+
+    it "resolves built-in stylesheets and map styles" do
+      site = build(:site, slug: "hulme")
+      pink = described_class.find_theme(:pink)
+      expect(pink.stylesheet_for(site)).to eq("themes/pink")
+      expect(pink.map_style_for(site)).to eq("pink")
+      expect(pink.homepage_view_class).to be_nil
+    end
+
+    it "resolves the legacy custom theme by site slug" do
+      custom = described_class.find_theme(:custom)
+      site = build(:site, slug: "mossley")
+      expect(custom.map_style_for(site)).to eq("mossley")
+      resolver = Rails.application.assets.resolver
+      allow(resolver).to receive(:resolve).with("themes/custom/mossley.css").and_return("/assets/themes/custom/mossley-abc.css")
+      expect(custom.stylesheet_for(site)).to eq("themes/custom/mossley")
+      allow(resolver).to receive(:resolve).with("themes/custom/mossley.css").and_return(nil)
+      expect(custom.stylesheet_for(site)).to be_nil
+    end
+  end
+
+  describe "mutation", :theme_registry do
+    it "registers a theme and yields it for configuration" do
+      theme = described_class.register_theme(:sample) { |t| t.stylesheet "sample/theme" }
+      expect(theme).to be_a(PlaceCal::Theme)
+      expect(described_class.theme_names).to include("sample")
+      expect(described_class.find_theme("sample").stylesheet).to eq("sample/theme")
+    end
+
+    it "replaces an existing registration with the same name" do
+      described_class.register_theme(:sample) { |t| t.map_style "one" }
+      described_class.register_theme(:sample) { |t| t.map_style "two" }
+      expect(described_class.theme_names.count("sample")).to eq(1)
+      expect(described_class.find_theme(:sample).map_style).to eq("two")
+    end
+
+    it "orders core themes before extension themes regardless of registration order" do
+      described_class.reset!
+      described_class.register_theme(:ext)
+      described_class.register_theme(:pink, core: true)
+      expect(described_class.theme_names).to eq(%w[pink ext])
+    end
+
+    it "finds themes by symbol or string and returns nil for unknown or blank" do
+      expect(described_class.find_theme(:pink)).to eq(described_class.find_theme("pink"))
+      expect(described_class.find_theme(:nope)).to be_nil
+      expect(described_class.find_theme(nil)).to be_nil
+      expect(described_class.find_theme("")).to be_nil
+    end
+
+    it "raises from fetch_theme for unknown names" do
+      expect { described_class.fetch_theme(:nope) }.to raise_error(PlaceCal::Extensions::UnknownTheme, /nope/)
+    end
+
+    it "reset! empties the registry" do
+      described_class.reset!
+      expect(described_class.theme_names).to be_empty
+    end
+  end
+
+  it "restores the registry after a mutating example" do
+    expect(described_class.theme_names).to eq(%w[pink orange green blue custom example_theme])
+  end
+end

--- a/spec/lib/placecal/theme_spec.rb
+++ b/spec/lib/placecal/theme_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlaceCal::Theme do
+  subject(:theme) { described_class.new(:sample) }
+
+  it "stores its name as a string" do
+    expect(theme.name).to eq("sample")
+    expect(theme.to_s).to eq("sample")
+    expect(theme).not_to be_core
+  end
+
+  it "defaults every setting to nil and the date picker filter style" do
+    expect(theme.stylesheet).to be_nil
+    expect(theme.homepage_view).to be_nil
+    expect(theme.map_style).to be_nil
+    expect(theme.head).to be_nil
+    expect(theme.event_filter_style).to eq(:date_picker)
+  end
+
+  it "sets and reads values through the DSL" do
+    theme.stylesheet "sample/theme"
+    theme.homepage_view "Views::Sites::Default"
+    theme.map_style "sample"
+    theme.head "Components::Footer"
+    theme.event_filter_style :day_strip
+
+    expect(theme.stylesheet).to eq("sample/theme")
+    expect(theme.homepage_view).to eq("Views::Sites::Default")
+    expect(theme.map_style).to eq("sample")
+    expect(theme.head).to eq("Components::Footer")
+    expect(theme.event_filter_style).to eq(:day_strip)
+  end
+
+  it "rejects unknown event filter styles" do
+    expect { theme.event_filter_style :carousel }.to raise_error(ArgumentError, /carousel/)
+  end
+
+  describe "resolution against a site" do
+    let(:site) { build(:site, slug: "hulme") }
+
+    it "returns static stylesheet and map style values" do
+      theme.stylesheet "themes/pink"
+      theme.map_style "pink"
+      expect(theme.stylesheet_for(site)).to eq("themes/pink")
+      expect(theme.map_style_for(site)).to eq("pink")
+    end
+
+    it "calls a block with the site when one was given" do
+      theme.stylesheet { |s| "themes/custom/#{s.slug}" }
+      theme.map_style(&:slug)
+      expect(theme.stylesheet_for(site)).to eq("themes/custom/hulme")
+      expect(theme.map_style_for(site)).to eq("hulme")
+    end
+
+    it "returns nil when nothing is set or the block returns nil" do
+      expect(theme.stylesheet_for(site)).to be_nil
+      theme.stylesheet { |_s| nil }
+      expect(theme.stylesheet_for(site)).to be_nil
+    end
+
+    it "resolves view class names lazily" do
+      expect(theme.homepage_view_class).to be_nil
+      expect(theme.head_class).to be_nil
+      theme.homepage_view "Views::Sites::Default"
+      theme.head "Components::Footer"
+      expect(theme.homepage_view_class).to eq(Views::Sites::Default)
+      expect(theme.head_class).to eq(Components::Footer)
+    end
+  end
+
+  describe "#label" do
+    it "uses the locale label when present" do
+      expect(described_class.new(:pink).label).to eq("Pink")
+    end
+
+    it "falls back to a titleized name" do
+      expect(described_class.new(:night_sky).label).to eq("Night Sky")
+    end
+  end
+end

--- a/spec/support/theme_registry.rb
+++ b/spec/support/theme_registry.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Isolate specs that mutate the theme registry (PlaceCal::Extensions):
+# tag an example or group with `theme_registry: true` and it starts from
+# the boot-time registry and is restored afterwards.
+RSpec.configure do |config|
+  config.around(:each, :theme_registry) do |example|
+    state = PlaceCal::Extensions.snapshot
+    begin
+      example.run
+    ensure
+      PlaceCal::Extensions.restore(state)
+    end
+  end
+end


### PR DESCRIPTION
WP 0.1 of #3368. `PlaceCal::Theme` value object and `PlaceCal::Extensions` registry; built-ins and legacy `custom` registered in `config/initializers/extensions.rb`.

Design notes:
- Registry is required from `config/application.rb` (one line) because engine `initializer` blocks run before the app's `config/initializers`; without this an extension could not register.
- Core themes carry `core: true` and sort first in `theme_names`, so ordering is deterministic whichever engines are loaded.
- `custom` resolves stylesheet and map style by site slug, preserving the #2936 missing-asset guard.
- `snapshot`/`restore` plus a `:theme_registry` spec tag isolate registry-mutating specs.

Gate:
```
RAILS_ENV=test bundle exec rspec spec/lib/placecal spec/requests/extensions spec/i18n_keys_spec.rb spec/models/site_spec.rb spec/helpers/map_helper_spec.rb
88 examples, 0 failures
bin/rails runner 'puts PlaceCal::Extensions.theme_names.inspect'
["pink", "orange", "green", "blue", "custom"]
bundle exec rubocop lib/placecal config/initializers/extensions.rb config/application.rb spec/lib/placecal spec/support/theme_registry.rb spec/fixtures/extensions
no offenses
```