### PR TITLE
WP 0.5: doc/extensions.md (#3368)

### DIFF
--- a/doc/ai/context.md
+++ b/doc/ai/context.md
@@ -24,6 +24,7 @@ When working on this project:
 - Keep models focused with single responsibilities
 - Extract complex business logic to service objects (e.g., `app/queries/`)
 - Ensure proper database indexing for foreign keys and queries
+- For site-specific features: see @doc/extensions.md — extensions are Rails engines with no models or migrations; they register themes (stylesheets, views, components, locales)
 
 ## CRITICAL: Internationalization (i18n)
 

--- a/doc/ai/context.md
+++ b/doc/ai/context.md
@@ -24,7 +24,7 @@ When working on this project:
 - Keep models focused with single responsibilities
 - Extract complex business logic to service objects (e.g., `app/queries/`)
 - Ensure proper database indexing for foreign keys and queries
-- For site-specific features: see @doc/extensions.md — extensions are Rails engines with no models or migrations; they register themes (stylesheets, views, components, locales)
+- For site-specific features: see @doc/extensions.md. Extensions are Rails engines with no models or migrations; they register themes (stylesheets, views, components, locales)
 
 ## CRITICAL: Internationalization (i18n)
 

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -74,7 +74,7 @@ initializer "my_ext.register_theme" do
 end
 ```
 
-All settings are optional. `stylesheet` and `map_style` may receive a block that gets the Site, for dynamic lookups (e.g. by site slug or partner).
+All settings are optional. `stylesheet` and `map_style` may receive a block that gets the Site, for lookups that depend on the record (core's legacy `custom` theme resolves by site slug that way).
 
 ## Locale files
 
@@ -109,7 +109,7 @@ Themes are Tailwind plus CSS custom properties. Create a Tailwind source file in
 }
 ```
 
-Build the CSS with `@tailwindcss/cli` (pinned in core's `package.json`), scanning only the extension's views:
+Build the CSS with `@tailwindcss/cli`, pinned in the extension's own `package.json`, scanning only the extension's views:
 
 ```bash
 tailwindcss -i ./app/tailwind/my_ext_tailwind.css \
@@ -122,18 +122,19 @@ Commit the built `app/assets/builds/my_ext/theme.css` to the engine repo. The en
 
 ## Installation and Gemfile
 
-Extensions live in separate git repos until a private installation package server exists. List each extension in the public repo's `Gemfile` under a clearly labelled `group :extensions do ... end` block:
+Each extension lives in its own git repo. Until a private installation repo exists, placecal.org's installation is the public PlaceCal repo itself, so an extension is listed in the public `Gemfile` under a clearly labelled `group :extensions do ... end` block, with a comment saying it is installation-specific and removable, pinned to a git tag in the extension repo:
 
 ```ruby
+# Installation-specific extensions for placecal.org. Not part of core: a
+# self-hosted PlaceCal can delete this block.
 group :extensions do
-  # Installation-specific themes. Remove any you do not need.
   gem 'placecal-theme-transdimension',
-      git: 'https://github.com/geeksforsocialchange/placecal-theme-transdimension.git',
-      branch: 'main'
+      github: 'geeksforsocialchange/placecal-theme-transdimension',
+      tag: 'v0.1.0'
 end
 ```
 
-Use a single block so removing an extension is one edit. Pin each to a git tag in production deployments.
+Keep it a single block so removing it is one edit. The Dockerfile needs no Node build step for extensions because each engine ships its CSS prebuilt.
 
 ## Engine specs
 
@@ -159,11 +160,10 @@ Require the extension before `Rails.application.initialize!` so that its engine 
 
 ## Build and deploy
 
-The Dockerfile builds extensions automatically as part of `yarn build`:
+Core's Dockerfile is unchanged by extensions:
 
-1. The core `package.json` pins `@tailwindcss/cli`
-2. Each extension's CI fails if its committed CSS is stale (the build task should run before commit)
-3. The Dockerfile runs `yarn build`, which only rebuilds core's CSS; extension CSS is already committed
-4. Propshaft fingerprints all CSS (core and extension) during `assets:precompile`
+1. Each extension's CI fails if its committed CSS is stale (run the build before committing)
+2. The Dockerfile runs core's `yarn build`, which only rebuilds core's CSS; extension CSS is already committed in the gem
+3. Propshaft fingerprints all CSS (core and extension) during `assets:precompile`
 
-No separate Node build step for extensions is needed. The committed CSS and the registry API mean extensions are deploy-ready as soon as they merge to their repo.
+Bumping the tag in the `group :extensions` block and running `bundle lock` is the whole deploy step for an extension change.

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -1,0 +1,169 @@
+# Writing Extensions
+
+PlaceCal extensions are Rails engines that plug into the core application without modifying it. An extension registers a theme: a set of stylesheets, views, components, locale files, and configuration that customize PlaceCal's appearance and behaviour for a specific site or installation.
+
+## The extension contract
+
+If a second partnership could want it, it is a core feature and gets built generically. If only this site wants it, it is views, CSS, assets and copy in an extension. Extensions contain no models, no migrations, no business logic.
+
+Extensions are Rails engines generated with `rails plugin new --full` (NOT `--mountable`: the engine must not isolate its namespace or routes, it plugs into the host app) and trimmed to the layout below.
+
+## Layout
+
+```
+<ext>/
+  lib/
+    <ext>.rb              # Module definition and namespace
+    <ext>/engine.rb       # Rails engine with Phlex autoload and theme registration
+  app/
+    views/<ext>/          # Phlex views (autoloaded as <Ext>::Views)
+    components/<ext>/     # Phlex components (autoloaded as <Ext>::Components)
+    assets/builds/<ext>/  # Prebuilt CSS (committed to repo)
+  config/
+    locales/en.yml        # Locale strings (loaded automatically by Rails)
+```
+
+The engine's `app/controllers` and `config/routes.rb` exist only in core's fixture engine (for testing); real extensions have neither.
+
+## Phlex namespaces
+
+Create a module namespace in `lib/<ext>.rb` and register Phlex kits in the engine initializer:
+
+```ruby
+# lib/<ext>.rb
+module MyExt
+  module Views; end
+  module Components
+    extend Phlex::Kit
+  end
+end
+require_relative "my_ext/engine"
+
+# lib/<ext>/engine.rb
+module MyExt
+  class Engine < ::Rails::Engine
+    initializer "my_ext.phlex_namespaces", before: :set_autoload_paths do
+      Rails.autoloaders.main.push_dir(
+        root.join("app/views/my_ext"),
+        namespace: MyExt::Views
+      )
+      Rails.autoloaders.main.push_dir(
+        root.join("app/components/my_ext"),
+        namespace: MyExt::Components
+      )
+    end
+  end
+end
+```
+
+Views inherit `Views::Base` to get Rails helpers, `t()` translations, and the core `Components` kit. Components inherit `Components::Base`.
+
+## Theme registration
+
+The engine registers a theme during initialization (before core's `config/initializers` run):
+
+```ruby
+initializer "my_ext.register_theme" do
+  PlaceCal::Extensions.register_theme(:my_ext) do |theme|
+    theme.stylesheet    "my_ext/theme"           # logical path, see CSS build below
+    theme.homepage_view "MyExt::Views::Home"     # Phlex view class name
+    theme.map_style     "my_ext"                 # name of public/map-styles/<name>.json
+    theme.head          "MyExt::Components::Head" # Phlex component rendered in <head>
+    theme.event_filter_style :day_strip          # :date_picker (default) or :day_strip
+  end
+end
+```
+
+All settings are optional. `stylesheet` and `map_style` may receive a block that gets the Site, for dynamic lookups (e.g. by site slug or partner).
+
+## Locale files
+
+Rails automatically loads an engine's `config/locales/**/*.yml` into the I18n path. An extension's strings should live under its own namespace to avoid collisions (`my_ext.*`). If an extension needs to override a core string, append an override file in `config.after_initialize`:
+
+```ruby
+# lib/<ext>/engine.rb
+config.after_initialize do
+  I18n.load_path << root.join('config/locales/overrides.en.yml')
+  I18n.reload!
+end
+```
+
+## Stylesheet and CSS build
+
+Themes are Tailwind plus CSS custom properties. Create a Tailwind source file in `app/tailwind/<ext>_tailwind.css` that imports the core theme variables and builds custom CSS:
+
+```css
+/* app/tailwind/my_ext_tailwind.css */
+@import "tailwindcss/theme";
+@import "tailwindcss/utilities";
+
+:root {
+	/* Override core theme tokens; see app/tailwind/public/_theme.css */
+	--color-primary: #abc123;
+	--color-background: #f5f1eb;
+}
+
+/* Component-level CSS (optional) */
+.my-ext-card {
+	@apply rounded-lg border border-gray-300;
+}
+```
+
+Build the CSS with `@tailwindcss/cli` (pinned in core's `package.json`), scanning only the extension's views:
+
+```bash
+tailwindcss -i ./app/tailwind/my_ext_tailwind.css \
+  -o ./app/assets/builds/my_ext/theme.css \
+  --content './app/views/my_ext/**/*.rb' \
+  --minify
+```
+
+Commit the built `app/assets/builds/my_ext/theme.css` to the engine repo. The engine's CI should fail if it is stale. Propshaft picks up the engine's `app/assets/*` directories automatically and fingerprints the CSS for production.
+
+## Installation and Gemfile
+
+Extensions live in separate git repos until a private installation package server exists. List each extension in the public repo's `Gemfile` under a clearly labelled `group :extensions do ... end` block:
+
+```ruby
+group :extensions do
+  # Installation-specific themes. Remove any you do not need.
+  gem 'placecal-theme-transdimension',
+      git: 'https://github.com/geeksforsocialchange/placecal-theme-transdimension.git',
+      branch: 'main'
+end
+```
+
+Use a single block so removing an extension is one edit. Pin each to a git tag in production deployments.
+
+## Engine specs
+
+An extension's own test suite requires core's Rails environment. In `spec/rails_helper.rb`, boot core by requiring its `config/application` and `config/environment` (using an env var for the core path, defaulting to `../PlaceCal`):
+
+```ruby
+# spec/rails_helper.rb (in the extension gem)
+require 'spec_helper'
+
+# Bootstrap core's Rails app
+PLACECAL_CORE = ENV.fetch('PLACECAL_CORE_PATH', '../PlaceCal')
+require File.expand_path('config/application', PLACECAL_CORE)
+require 'rspec/rails'
+
+# Require the engine (this file's directory goes on the load path)
+require File.expand_path('../../lib/<ext>', __FILE__)
+
+# Finish loading core's environment
+Rails.application.initialize! unless Rails.application.initialized?
+```
+
+Require the extension before `Rails.application.initialize!` so that its engine initializers run and register the theme. The extension's `spec/` directory is part of the engine repo and may have factories, fixtures and helper modules shared with core's tests.
+
+## Build and deploy
+
+The Dockerfile builds extensions automatically as part of `yarn build`:
+
+1. The core `package.json` pins `@tailwindcss/cli`
+2. Each extension's CI fails if its committed CSS is stale (the build task should run before commit)
+3. The Dockerfile runs `yarn build`, which only rebuilds core's CSS; extension CSS is already committed
+4. Propshaft fingerprints all CSS (core and extension) during `assets:precompile`
+
+No separate Node build step for extensions is needed. The committed CSS and the registry API mean extensions are deploy-ready as soon as they merge to their repo.


### PR DESCRIPTION
WP 0.5 of #3368. Extension authoring guide plus cross-link from doc/ai/context.md. Written by Haiku, reviewed and tightened by the coordinator (tag pinning, Gemfile compromise wording, engine-owned Tailwind build). Gate: prettier --check clean.