### PR TITLE
WP 0.2: Site.theme via the registry (#3368)

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -8,7 +8,13 @@ class SitesController < ApplicationController
   before_action :set_places_with_free_wifi, only: [:index]
 
   def index
-    if current_site.slug == 'mossley'
+    # A theme registered by an extension may supply its own homepage view
+    # (#3368, D3); otherwise core's existing behaviour applies.
+    view_class = current_site.theme_definition&.homepage_view_class
+
+    if view_class
+      render view_class.new(site: @site)
+    elsif current_site.slug == 'mossley'
       render Views::Sites::Mossley.new(site: @site, places_to_get_online: @places_to_get_computer_access)
     else
       render Views::Sites::Default.new(

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -64,14 +64,10 @@ module MapHelper
     # site can be a Site object or a slug string
     site_record = site.is_a?(Site) ? site : Site.find_by(slug: site)
 
-    style_name = if site_record.nil?
-                   'pink'
-                 elsif site_record.theme.to_s == 'custom'
-                   # Custom themed sites use their slug (e.g., 'mossley')
-                   site_record.slug
-                 else
-                   site_record.theme.to_s
-                 end
+    # The theme definition resolves the style name (the legacy :custom theme
+    # resolves it from the site's slug, e.g. 'mossley'). Sites with no site
+    # record or an unregistered theme fall back to pink.
+    style_name = site_record&.theme_definition&.map_style_for(site_record) || 'pink'
 
     # Fall back to pink if style file doesn't exist
     style_path = Rails.public_path.join('map-styles', "#{style_name}.json")

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -61,12 +61,7 @@ class Site < ApplicationRecord
   DIRECTORY_URL = Rails.configuration.x.directory_url
 
   # ==== Enums / Enumerize ====
-  # Theme picker
-  enumerize :theme,
-            in: %i[pink orange green blue custom],
-            default: :pink
-  # theme -- managed by enumerize, attribute declaration skipped
-
+  # theme -- no enumerize: validated against the extension registry below (#3368, D2)
   enumerize :badge_zoom_level,
             in: %i[ward district],
             default: :ward
@@ -87,6 +82,7 @@ class Site < ApplicationRecord
   attribute :place_name,        :string                          # nullable
   attribute :slug,              :string                          # NOT NULL
   attribute :tagline,           :string                          # nullable
+  attribute :theme,             :string,  default: 'pink'        # nullable
   attribute :url,               :string                          # NOT NULL
 
   friendly_id :name, use: :slugged
@@ -127,6 +123,9 @@ class Site < ApplicationRecord
   validates :name, :slug, :url, presence: true
   validates :slug, uniqueness: true
   validates :hero_text, length: { maximum: 120 }
+  # Themes come from the extension registry, not a static list, so an
+  # extension can add one without touching this model (#3368, D2).
+  validates :theme, inclusion: { in: ->(_site) { PlaceCal::Extensions.theme_names } }
 
   # ==== Scopes ====
   scope :published, -> { where(is_published: true) }
@@ -229,16 +228,20 @@ class Site < ApplicationRecord
     refresh_events_count!
   end
 
-  # @return [String, nil] asset pipeline stylesheet path for this site's theme,
-  #   or nil when no stylesheet should be linked. For the :custom theme the
-  #   per-site asset (themes/custom/<slug>.css) may not exist in the pipeline;
-  #   in that case we return nil so the page renders with the default styling
-  #   instead of raising Propshaft::MissingAssetError (see issue #2936).
-  def stylesheet_link
-    return "themes/#{theme}" unless theme == :custom
+  # @return [PlaceCal::Theme, nil] the registered theme definition for this
+  #   site, or nil when the theme is blank or not registered. Callers fall
+  #   back to core's default behaviour when it is nil.
+  def theme_definition
+    PlaceCal::Extensions.find_theme(theme)
+  end
 
-    custom_path = "themes/custom/#{slug}"
-    custom_path if asset_present?("#{custom_path}.css")
+  # @return [String, nil] asset pipeline stylesheet path for this site's theme,
+  #   or nil when no stylesheet should be linked. The legacy :custom theme
+  #   resolves the per-site asset (themes/custom/<slug>.css) and returns nil
+  #   when it is missing from the pipeline, so the page renders with the
+  #   default styling instead of raising Propshaft::MissingAssetError (#2936).
+  def stylesheet_link
+    theme_definition&.stylesheet_for(self)
   end
 
   # @return [String, false] Open Graph image URL, or false
@@ -249,17 +252,6 @@ class Site < ApplicationRecord
   # @return [String, false] tagline for OG description, or false
   def og_description
     tagline && tagline.empty? ? false : tagline
-  end
-
-  private
-
-  # @param logical_path [String] asset logical path, e.g. "themes/custom/foo.css"
-  # @return [Boolean] whether the asset resolves in the pipeline. Uses the same
-  #   resolver that stylesheet_link_tag relies on (Propshaft::Helper#compute_asset_path),
-  #   so the guard matches link behaviour in both development (dynamic) and
-  #   production (static manifest) modes.
-  def asset_present?(logical_path)
-    Rails.application.assets&.resolver&.resolve(logical_path).present?
   end
 
   # ==== Class methods ====

--- a/app/views/admin/sites/form_tab_images.rb
+++ b/app/views/admin/sites/form_tab_images.rb
@@ -24,7 +24,7 @@ class Views::Admin::Sites::FormTabImages < Views::Admin::Base
     fieldset(class: 'fieldset max-w-xs mb-8') do
       legend(class: 'fieldset-legend') { attr_label(:site, :theme) }
       raw form.input_field(:theme, as: :select,
-                                   collection: Site.theme.values.map { |v| [v.to_s.titleize, v] },
+                                   collection: PlaceCal::Extensions.themes.map { |t| [t.label, t.name] },
                                    class: 'select select-bordered w-full')
     end
   end

--- a/spec/helpers/map_helper_spec.rb
+++ b/spec/helpers/map_helper_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe MapHelper, type: :helper do
     it "returns pink style for unknown slug string" do
       expect(helper.send(:style_url_for_site, "unknown-slug")).to eq("/map-styles/pink.json")
     end
+
+    it "falls back to pink style for a theme that is not registered" do
+      site = build(:site, theme: "nope")
+      expect(helper.send(:style_url_for_site, site)).to eq("/map-styles/pink.json")
+    end
+
+    it "uses the map style an extension registers", :theme_registry do
+      PlaceCal::Extensions.register_theme(:mapped) { |theme| theme.map_style "blue" }
+      site = build(:site, theme: "mapped")
+      expect(helper.send(:style_url_for_site, site)).to eq("/map-styles/blue.json")
+    end
   end
 
   describe "#center" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -152,6 +152,59 @@ RSpec.describe Site, type: :model do
       site = build(:site, theme: "pink")
       expect(site.theme).to eq("pink")
     end
+
+    it "defaults to pink" do
+      expect(described_class.new.theme).to eq("pink")
+    end
+
+    it "accepts every theme registered in the extension registry" do
+      PlaceCal::Extensions.theme_names.each do |name|
+        site = build(:site, theme: name)
+        expect(site).to be_valid, "expected theme #{name} to be valid: #{site.errors[:theme].inspect}"
+      end
+    end
+
+    it "rejects a theme that is not registered" do
+      site = build(:site, theme: "nope")
+      expect(site).not_to be_valid
+      expect(site.errors[:theme]).to be_present
+    end
+
+    it "accepts a theme registered by an extension", :theme_registry do
+      PlaceCal::Extensions.register_theme(:late_arrival)
+      expect(build(:site, theme: "late_arrival")).to be_valid
+    end
+
+    describe "#theme_definition" do
+      it "returns the registered theme" do
+        site = build(:site, theme: "orange")
+        expect(site.theme_definition).to eq(PlaceCal::Extensions.fetch_theme("orange"))
+      end
+
+      it "returns nil for an unregistered theme" do
+        expect(build(:site, theme: "nope").theme_definition).to be_nil
+      end
+
+      it "returns nil when the theme is blank" do
+        expect(build(:site, theme: nil).theme_definition).to be_nil
+      end
+    end
+
+    describe "#stylesheet_link" do
+      it "returns the core theme stylesheet" do
+        %w[pink orange green blue].each do |name|
+          expect(build(:site, theme: name).stylesheet_link).to eq("themes/#{name}")
+        end
+      end
+
+      it "returns nil for a custom theme with no per-site stylesheet" do
+        expect(build(:site, theme: "custom", slug: "nosuchsite").stylesheet_link).to be_nil
+      end
+
+      it "returns nil when the theme is not registered" do
+        expect(build(:site, theme: "nope").stylesheet_link).to be_nil
+      end
+    end
   end
 
   describe "configuration" do

--- a/spec/requests/extensions/theme_homepage_spec.rb
+++ b/spec/requests/extensions/theme_homepage_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# WP 0.2 (#3368, D3): a site whose theme registers a homepage view renders
+# that view at the site root, instead of core's default homepage.
+RSpec.describe "Extension theme homepage", type: :request do
+  let(:ward) { create(:riverside_ward) }
+
+  before do
+    site.neighbourhoods << ward
+  end
+
+  context "with a theme that registers a homepage view" do
+    let(:site) do
+      create(:site, slug: "exampled", theme: "example_theme", url: "https://exampled.lvh.me")
+    end
+
+    it "renders the theme's homepage view" do
+      get "http://exampled.lvh.me"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Example theme fixture homepage")
+      expect(response.body).to include(site.name)
+    end
+
+    it "links the theme's stylesheet" do
+      get "http://exampled.lvh.me"
+      expect(response.body).to match(%r{/assets/example_theme/theme-[0-9a-f]+\.css})
+    end
+  end
+
+  context "with a core theme" do
+    let(:site) do
+      create(:site, slug: "corely", theme: "pink", url: "https://corely.lvh.me")
+    end
+
+    it "renders core's default homepage" do
+      get "http://corely.lvh.me"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Example theme fixture homepage")
+      expect(response.body).to include(site.description)
+    end
+  end
+end


### PR DESCRIPTION
WP 0.2 of #3368, implemented by Opus, reviewed by the coordinator.

- `enumerize :theme` replaced by a plain string attribute (default `pink`) validated against `PlaceCal::Extensions.theme_names`.
- `Site#theme_definition`; `stylesheet_link` and `MapHelper#style_url_for_site` delegate to it; admin select reads the registry (labels from `themes.<name>.label`).
- `SitesController#index` renders `theme_definition.homepage_view_class.new(site:)` when present, else the existing Mossley/default branches, untouched.
- `site_policy.rb` unchanged (theme already permitted).

Gate (pasted from the implementer, final run):
```
rubocop: 247 files inspected, no offenses detected
rspec i18n_keys, models/site, helpers, lib/placecal, requests/extensions, requests/public/{sites,custom_theme,partners}: 223 examples, 0 failures
rspec spec/system/admin/sites_spec.rb --tag slow: 3 examples, 0 failures
cucumber features/admin/sites.feature: 4 scenarios (4 passed), 20 steps (20 passed)
bin/rails runner: ["pink", "orange", "green", "blue", "custom"] / pink / ["is not included in the list"]
```
Visual before/after of mossley and a pink site is taken by the coordinator after WP 0.3.