### PR TITLE
WP 0.3: layout theme head hook (#3368)

### DIFF
--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -24,6 +24,7 @@ class Views::Layouts::Application < Phlex::HTML
         stylesheet_link_tag 'home', media: 'all', 'data-turbo-track': 'reload' if content_for?(:home_styles)
         stylesheet_link_tag site.stylesheet_link, media: 'all', 'data-turbo-track': 'reload' if site&.stylesheet_link
         stylesheet_link_tag 'print', media: 'print', 'data-turbo-track': 'reload'
+        render_theme_head
         preload_font('rawline/rawline-500.woff2')
         preload_font('rawline/rawline-700.woff2')
         preload_font('rawline/rawline-800.woff2')
@@ -70,6 +71,18 @@ class Views::Layouts::Application < Phlex::HTML
   end
 
   private
+
+  # Theme head hook (#3368 D1/D3): a theme may register a Phlex component
+  # (`theme.head "Foo::Components::Head"`) rendered here, after the stylesheet
+  # chain, for fonts, manifest links and the like. The component is constructed
+  # with no arguments; one that needs the site can read it from view_context the
+  # way this layout does, or the theme's views can push markup through
+  # content_for(:theme_head), which also works alongside a head component.
+  def render_theme_head
+    head_class = site&.theme_definition&.head_class
+    render head_class.new if head_class
+    raw content_for(:theme_head) if content_for?(:theme_head)
+  end
 
   def render_meta
     title_text = compute_title

--- a/spec/fixtures/extensions/example_theme/app/components/example_theme/head.rb
+++ b/spec/fixtures/extensions/example_theme/app/components/example_theme/head.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # Fixture head component: what a theme pushes into <head> (its stylesheet,
-# fonts, manifest link). WP 0.3 gives the layout a theme head hook that
-# renders this in <head>; until then the fixture view renders it inline,
-# which is enough to prove the component autoloads and the asset resolves.
+# fonts, manifest link). The core layout renders this for any site whose
+# theme registers a head component (#3368 D1/D3), so it only appears on
+# pages served for an example_theme site.
 class ExampleTheme::Components::Head < Components::Base
   include Phlex::Rails::Helpers::AssetPath
 

--- a/spec/fixtures/extensions/example_theme/app/views/example_theme/home.rb
+++ b/spec/fixtures/extensions/example_theme/app/views/example_theme/home.rb
@@ -7,7 +7,6 @@ class ExampleTheme::Views::Home < Views::Base
 
   def view_template
     content_for(:title) { t("example_theme.home.title") }
-    render ExampleTheme::Components::Head.new
     section(class: "example-theme-home") do
       h1 { t("example_theme.home.heading") }
       p { site ? site.name : t("example_theme.home.no_site") }

--- a/spec/requests/extensions/example_theme_spec.rb
+++ b/spec/requests/extensions/example_theme_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe "Example theme extension engine", type: :request do
     expect(response.body).to include("<title>Example theme | PlaceCal</title>")
     expect(response.body).to include("Example theme fixture homepage")
     expect(response.body).to include("Rendered without a site")
-    expect(response.body).to match(%r{<link rel="stylesheet" href="/assets/example_theme/theme-[0-9a-f]+\.css" data-example-theme="head">})
+    # The theme head component is a layout concern (#3368 D1/D3): this page has
+    # no site, so no theme definition and no head component output.
+    expect(response.body).not_to include("data-example-theme")
     # Core layout chrome is present around the engine view.
     expect(response.body).to include('stylesheet" href="/assets/public_tailwind')
   end

--- a/spec/requests/extensions/theme_head_spec.rb
+++ b/spec/requests/extensions/theme_head_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Homepage view for the content_for(:theme_head) fallback case: a theme with no
+# registered head component whose view pushes its own markup into <head>.
+class ThemeHeadFallbackHome < Views::Base
+  prop :site, _Nilable(Site), reader: :private
+
+  def view_template
+    content_for(:theme_head) do
+      meta(name: "theme-head-fallback", content: "pushed")
+    end
+    h1 { "Fallback theme homepage" }
+  end
+end
+
+# WP 0.3 (#3368, D1/D3): the core layout renders a theme's head component,
+# and content_for(:theme_head), inside <head> after the stylesheet chain.
+RSpec.describe "Theme head hook", type: :request do
+  let(:ward) { create(:riverside_ward) }
+
+  def head_html
+    response.body[%r{<head>.*?</head>}m]
+  end
+
+  context "with a theme that registers a head component" do
+    let!(:site) do
+      create(:site, slug: "headly", theme: "example_theme", url: "https://headly.lvh.me").tap do |s|
+        s.neighbourhoods << ward
+      end
+    end
+
+    it "renders the head component inside <head>, after the print stylesheet" do
+      get "http://headly.lvh.me"
+      expect(response).to have_http_status(:ok)
+
+      head = head_html
+      expect(head).to match(%r{<link rel="stylesheet" href="/assets/example_theme/theme-[0-9a-f]+\.css" data-example-theme="head">})
+      expect(head.index("data-example-theme")).to be > head.index('media="print"')
+    end
+  end
+
+  context "with a core theme" do
+    let!(:site) do
+      create(:site, slug: "pinkly", theme: "pink", url: "https://pinkly.lvh.me").tap do |s|
+        s.neighbourhoods << ward
+      end
+    end
+
+    it "adds no theme head output and keeps the stylesheet chain intact" do
+      get "http://pinkly.lvh.me"
+      expect(response).to have_http_status(:ok)
+
+      head = head_html
+      expect(head).not_to include("data-example-theme")
+      expect(head).not_to include("theme-head-fallback")
+      chain = head.scan(%r{/assets/(application|public_tailwind|themes/pink|print)-[0-9a-f]+\.css}).flatten
+      expect(chain).to eq(%w[application public_tailwind themes/pink print])
+    end
+  end
+
+  context "with a theme that pushes head markup through content_for", :theme_registry do
+    it "renders the pushed markup inside <head>" do
+      PlaceCal::Extensions.register_theme(:head_fallback) do |theme|
+        theme.homepage_view "ThemeHeadFallbackHome"
+      end
+      site = create(:site, slug: "fally", theme: "head_fallback", url: "https://fally.lvh.me")
+      site.neighbourhoods << ward
+
+      get "http://fally.lvh.me"
+      expect(response).to have_http_status(:ok)
+      expect(head_html).to include('<meta name="theme-head-fallback" content="pushed">')
+    end
+  end
+end

--- a/spec/requests/extensions/theme_homepage_spec.rb
+++ b/spec/requests/extensions/theme_homepage_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe "Extension theme homepage", type: :request do
       get "http://exampled.lvh.me"
       expect(response.body).to match(%r{/assets/example_theme/theme-[0-9a-f]+\.css})
     end
+
+    it "renders the theme's head component in <head> (#3368 D1/D3)" do
+      get "http://exampled.lvh.me"
+      head = response.body[%r{<head>.*?</head>}m]
+      expect(head).to match(%r{<link rel="stylesheet" href="/assets/example_theme/theme-[0-9a-f]+\.css" data-example-theme="head">})
+      expect(head.index("data-example-theme")).to be > head.index("public_tailwind")
+    end
   end
 
   context "with a core theme" do


### PR DESCRIPTION
WP 0.3 of #3368, implemented by Opus, reviewed by the coordinator.

Layout renders `site.theme_definition.head_class.new` after the stylesheet chain, then `content_for(:theme_head)` as a fallback (both may apply). Fixture engine no longer renders its head component inline. New `spec/requests/extensions/theme_head_spec.rb` covers the component, the pink-site no-op (stylesheet chain order asserted), and the content_for fallback.

Gate (pasted from the implementer):
```
rubocop app/views/layouts/application.rb spec/fixtures/extensions spec/requests/extensions: 10 files inspected, no offenses detected
rspec i18n_keys, requests/extensions, requests/public/{sites,custom_theme,events,partners,articles,pages}: 150 examples, 0 failures
```