### PR TITLE
WP 1.5: per-site sitemap and robots (#3368)

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+# Serves sitemaps for the nationwide directory and for each local site.
+#
+# The directory (no Site row) lists everything: all visible partners, all
+# upcoming events, the partnerships index, and the static/news pages.
+#
+# A local site lists only its own content, with every URL built from the site's
+# own base URL (Site#url), so a site's sitemap never points at placecal.org.
+# Unpublished sites are still served rather than 404'd, matching robots.txt:
+# crawl blocking is SiteRobots' job, and an unlinked sitemap costs nothing.
 class SitemapsController < ApplicationController
   CACHE_TTL = 1.day
   MAX_URLS_PER_SITEMAP = 50_000
@@ -9,69 +18,87 @@ class SitemapsController < ApplicationController
   skip_before_action :set_navigation
 
   before_action :set_site
-  before_action :require_directory
 
   def index
-    render xml: cached_xml('sitemap/index') { build_index }
+    render xml: cached_xml('index') { build_index }
   end
 
   def partners
-    render xml: cached_xml('sitemap/partners') { build_partners }
+    render xml: cached_xml('partners') { build_partners }
   end
 
   def events
-    render xml: cached_xml('sitemap/events') { build_events }
+    render xml: cached_xml('events') { build_events }
   end
 
   def partnerships
-    render xml: cached_xml('sitemap/partnerships') { build_partnerships }
+    render xml: cached_xml('partnerships') { build_partnerships }
   end
 
   def pages
-    render xml: cached_xml('sitemap/pages') { build_pages }
+    render xml: cached_xml('pages') { build_pages }
   end
 
   private
 
-  def require_directory
-    head :not_found unless directory_request?
+  # Base URL every entry hangs off: the site's own URL on a site, the
+  # directory's otherwise.
+  def base_url
+    @base_url ||= current_site ? current_site.directory_url.chomp('/') : BASE
   end
 
-  def cached_xml(key, &)
+  def cached_xml(section, &)
     expires_in CACHE_TTL, public: true
-    Rails.cache.fetch(key, expires_in: CACHE_TTL, &)
+    Rails.cache.fetch("sitemap/#{current_site&.slug || 'directory'}/#{section}", expires_in: CACHE_TTL, &)
+  end
+
+  # Partnerships are a directory-only concept (the index of every local site),
+  # so a site's sitemap index omits that section.
+  def index_sections
+    current_site ? %w[partners events pages] : %w[partners events partnerships pages]
   end
 
   def build_index
     xml = +''
     xml << '<?xml version="1.0" encoding="UTF-8"?>'
     xml << '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
-    %w[partners events partnerships pages].each do |section|
-      xml << "<sitemap><loc>#{BASE}/sitemap/#{section}.xml</loc></sitemap>"
+    index_sections.each do |section|
+      xml << "<sitemap><loc>#{base_url}/sitemap/#{section}.xml</loc></sitemap>"
     end
     xml << '</sitemapindex>'
   end
 
+  def partners_scope
+    current_site ? PartnersQuery.new(site: current_site).call.reorder(nil) : Partner.visible
+  end
+
   def build_partners
-    urls = Partner.visible.pluck(:slug, :updated_at).map do |slug, updated_at|
-      url_entry("#{BASE}/partners/#{slug}", updated_at)
+    urls = partners_scope.pluck(:slug, :updated_at).uniq.map do |slug, updated_at|
+      url_entry("#{base_url}/partners/#{slug}", updated_at)
     end
     wrap_urlset(urls)
+  end
+
+  def events_scope
+    current_site ? EventsQuery.new(site: current_site).scope : Event.all
   end
 
   def build_events
     # Only events that aren't over (dtend-aware, matching Event#past?) —
     # past event pages are noindexed, and a sitemap listing noindexed URLs
     # draws "submitted URL marked noindex" warnings in Search Console.
-    urls = Event.where('COALESCE(dtend, dtstart) >= ?', DateTime.current.beginning_of_day)
-                .order(dtstart: :desc)
-                .limit(MAX_URLS_PER_SITEMAP)
-                .pluck(:id, :updated_at)
-                .map { |id, updated_at| url_entry("#{BASE}/events/#{id}", updated_at) }
+    urls = events_scope.where('COALESCE(dtend, dtstart) >= ?', DateTime.current.beginning_of_day)
+                       .reorder(dtstart: :desc)
+                       .limit(MAX_URLS_PER_SITEMAP)
+                       .pluck('events.id', 'events.updated_at')
+                       .uniq
+                       .map { |id, updated_at| url_entry("#{base_url}/events/#{id}", updated_at) }
     wrap_urlset(urls)
   end
 
   def build_partnerships
+    return wrap_urlset([]) if current_site
+
     urls = []
     urls << url_entry("#{BASE}/partnerships")
 
@@ -83,22 +110,43 @@ class SitemapsController < ApplicationController
     wrap_urlset(urls)
   end
 
+  # terms-of-use is directory-only; privacy and get-in-touch resolve on both.
+  def static_page_slugs
+    current_site ? %w[privacy get-in-touch] : %w[privacy terms-of-use get-in-touch]
+  end
+
+  def articles_scope
+    current_site ? Article.for_site(current_site).published : Article.published
+  end
+
   def build_pages
     urls = []
 
-    urls << url_entry(BASE)
-    urls << url_entry("#{BASE}/partners")
-    urls << url_entry("#{BASE}/events")
+    urls << url_entry(base_url)
+    urls << url_entry("#{base_url}/partners")
+    urls << url_entry("#{base_url}/events")
 
-    %w[privacy terms-of-use get-in-touch].each do |page|
-      urls << url_entry("#{BASE}/#{page}")
+    static_page_slugs.each do |page|
+      urls << url_entry("#{base_url}/#{page}")
     end
 
-    Article.published.pluck(:slug, :updated_at).each do |slug, updated_at|
-      urls << url_entry("#{BASE}/news/#{slug}", updated_at)
+    articles_scope.pluck(:slug, :updated_at).uniq.each do |slug, updated_at|
+      urls << url_entry("#{base_url}/news/#{slug}", updated_at)
     end
+
+    urls.concat(site_page_entries)
 
     wrap_urlset(urls)
+  end
+
+  # Editable per-site pages (WP 1.1). Guarded so this stays inert until the
+  # Page model and the Site#pages association land.
+  def site_page_entries
+    return [] unless current_site && defined?(Page) && current_site.respond_to?(:pages)
+
+    current_site.pages.published.pluck(:slug, :updated_at).map do |slug, updated_at|
+      url_entry("#{base_url}/#{slug}", updated_at)
+    end
   end
 
   def url_entry(loc, lastmod = nil)

--- a/app/models/concerns/site_robots.rb
+++ b/app/models/concerns/site_robots.rb
@@ -6,7 +6,9 @@ module SiteRobots
   # @return [String] robots.txt content, blocking crawlers if unpublished
   def robots
     if is_published?
-      self.class.published_robots
+      # A site advertises its own sitemap, not the directory's. The directory's
+      # sitemap lists nothing under this site's hostname.
+      self.class.published_robots(directory_url.chomp('/'))
     else
       <<~TXT
         #{self.class.robots_config}
@@ -21,12 +23,13 @@ module SiteRobots
     # has no Site row and is always publicly crawlable.
     # @return [String]
     def directory_robots
-      published_robots
+      published_robots(self::DIRECTORY_URL)
     end
 
+    # @param base_url [String] host the sitemap is served from, no trailing slash
     # @return [String] the permissive robots.txt template plus sitemap reference
-    def published_robots
-      "#{robots_config}\nSitemap: #{self::DIRECTORY_URL}/sitemap.xml\n"
+    def published_robots(base_url = self::DIRECTORY_URL)
+      "#{robots_config}\nSitemap: #{base_url}/sitemap.xml\n"
     end
 
     # @return [String] contents of the environment's robots.txt template

--- a/spec/requests/public/robots_spec.rb
+++ b/spec/requests/public/robots_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe "Public Robots", type: :request do
         # Should not have a blanket disallow for all user agents
         expect(response.body).not_to match(%r{^User-agent: \*\nDisallow: /$})
       end
+
+      it "advertises the site's own sitemap, not the directory's" do
+        get "http://#{published_site.slug}.lvh.me/robots.txt"
+        expect(response.body).to include("Sitemap: #{published_site.url.chomp('/')}/sitemap.xml")
+        expect(response.body).not_to include("Sitemap: #{Site::DIRECTORY_URL}/sitemap.xml")
+      end
+    end
+
+    context "on the apex directory" do
+      it "advertises the directory sitemap" do
+        get "http://lvh.me/robots.txt"
+        expect(response.body).to include("Sitemap: #{Site::DIRECTORY_URL}/sitemap.xml")
+      end
     end
   end
 end

--- a/spec/requests/public/sitemaps_spec.rb
+++ b/spec/requests/public/sitemaps_spec.rb
@@ -85,16 +85,114 @@ RSpec.describe "Public Sitemaps", type: :request do
   end
 
   describe "on a local site" do
-    it "returns 404" do
-      get "/sitemap.xml", headers: { "Host" => "mossley.lvh.me" }
-      expect(response).to have_http_status(:not_found)
+    let(:host) { "mossley.lvh.me" }
+
+    let!(:site_neighbourhood) { create(:neighbourhood) }
+    let!(:other_neighbourhood) { create(:neighbourhood) }
+
+    let!(:site_partner) do
+      create(:partner, slug: "site-partner", address: create(:address, neighbourhood: site_neighbourhood))
+    end
+    let!(:other_partner) do
+      create(:partner, slug: "other-site-partner", address: create(:address, neighbourhood: other_neighbourhood))
+    end
+
+    let!(:site_event) do
+      create(:event, organiser: site_partner, dtstart: 1.week.from_now, dtend: 1.week.from_now + 1.hour)
+    end
+    let!(:other_event) do
+      create(:event, organiser: other_partner, dtstart: 1.week.from_now, dtend: 1.week.from_now + 1.hour)
+    end
+
+    let!(:site_article) do
+      article = create(:article, slug: "site-news", is_draft: false)
+      create(:article_partner, article: article, partner: site_partner)
+      article
+    end
+
+    before do
+      create(:sites_neighbourhood, site: local_site, neighbourhood: site_neighbourhood)
+      create(:site, slug: "other", is_published: true, url: "https://other.placecal.org/").tap do |other|
+        create(:sites_neighbourhood, site: other, neighbourhood: other_neighbourhood)
+      end
+    end
+
+    describe "GET /sitemap.xml" do
+      it "lists the site's own sections under the site's URL" do
+        get "/sitemap.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.content_type).to include("xml")
+        %w[partners events pages].each do |section|
+          expect(response.body).to include("https://mossley.placecal.org/sitemap/#{section}.xml")
+        end
+      end
+
+      it "does not advertise the directory or the partnerships section" do
+        get "/sitemap.xml", headers: { "Host" => host }
+        expect(response.body).not_to include("https://placecal.org/")
+        expect(response.body).not_to include("partnerships")
+      end
+    end
+
+    describe "GET /sitemap/partners.xml" do
+      it "includes the site's partners with a lastmod" do
+        get "/sitemap/partners.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.body).to include("https://mossley.placecal.org/partners/site-partner")
+        expect(response.body).to match(%r{<lastmod>\d{4}-\d{2}-\d{2}</lastmod>})
+      end
+
+      it "excludes partners belonging to another site" do
+        get "/sitemap/partners.xml", headers: { "Host" => host }
+        expect(response.body).not_to include("other-site-partner")
+      end
+    end
+
+    describe "GET /sitemap/events.xml" do
+      it "includes the site's upcoming events" do
+        get "/sitemap/events.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.body).to include("https://mossley.placecal.org/events/#{site_event.id}")
+      end
+
+      it "excludes events belonging to another site" do
+        get "/sitemap/events.xml", headers: { "Host" => host }
+        expect(response.body).not_to include("events/#{other_event.id}")
+      end
+    end
+
+    describe "GET /sitemap/pages.xml" do
+      it "includes the site's static pages and news" do
+        get "/sitemap/pages.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.body).to include("<loc>https://mossley.placecal.org</loc>")
+        expect(response.body).to include("https://mossley.placecal.org/partners")
+        expect(response.body).to include("https://mossley.placecal.org/events")
+        expect(response.body).to include("https://mossley.placecal.org/privacy")
+        expect(response.body).to include("https://mossley.placecal.org/get-in-touch")
+        expect(response.body).to include("https://mossley.placecal.org/news/site-news")
+      end
+
+      it "does not link to the directory" do
+        get "/sitemap/pages.xml", headers: { "Host" => host }
+        expect(response.body).not_to include("https://placecal.org/")
+      end
+    end
+
+    describe "GET /sitemap/partnerships.xml" do
+      it "is empty (partnerships are a directory concept)" do
+        get "/sitemap/partnerships.xml", headers: { "Host" => host }
+        expect(response).to be_successful
+        expect(response.body).not_to include("<url>")
+      end
     end
   end
 
   describe "robots.txt" do
-    it "includes sitemap directive for published sites" do
+    it "advertises the site's own sitemap for published sites" do
       get "/robots.txt", headers: { "Host" => "mossley.lvh.me" }
-      expect(response.body).to include("Sitemap: https://placecal.org/sitemap.xml")
+      expect(response.body).to include("Sitemap: https://mossley.placecal.org/sitemap.xml")
+      expect(response.body).not_to include("Sitemap: https://placecal.org/sitemap.xml")
     end
 
     it "serves a crawlable robots.txt with sitemap on the apex" do


### PR DESCRIPTION
WP 1.5 of #3368, implemented by Opus, reviewed by the coordinator.

- `SitemapsController` serves sites too: base URL from the site's URL, per-site cache keys, partners/events/news scoped through `PartnersQuery`, `EventsQuery` and `Article.for_site`; partnerships section omitted on sites; site Pages included behind a guard until WP 1.1 lands.
- `SiteRobots#published_robots(base_url)`: a published site advertises its own `/sitemap.xml`.
- Directory output unchanged (existing assertions untouched).

Gate (pasted from implementer):
```
rubocop: 5 files inspected, no offenses detected
rspec i18n_keys, requests/public/{sitemaps,robots}, models/site, requests/extensions: 79 examples, 0 failures
```