### PR TITLE
WP 1.3b: day strip event filter style (#3368)

### DIFF
--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -10,6 +10,11 @@ class Components::EventFilter < Components::Base
   prop :site, _Nilable(::Site), default: nil
   prop :selected_neighbourhood, _Nilable(String), default: nil
   prop :show_monthly, _Boolean, default: true
+  # Overrides the style derived from the site's theme (specs and previews).
+  prop :filter_style, _Nilable(Symbol), default: nil
+
+  # Today, tomorrow and five more days (D22).
+  DAY_STRIP_LENGTH = 7
 
   def after_initialize
     @sort ||= 'time'
@@ -17,12 +22,21 @@ class Components::EventFilter < Components::Base
   end
 
   def view_template
-    render_date_picker
+    if filter_style == :day_strip
+      render_day_strip
+    else
+      render_date_picker
+    end
     render_neighbourhood_filter if show_neighbourhood_filter?
     render_sort_filter
   end
 
   private
+
+  # @return [Symbol] :date_picker or :day_strip, from the site's theme (D22)
+  def filter_style
+    @filter_style || @site&.theme_definition&.event_filter_style || :date_picker
+  end
 
   def render_date_picker
     div(class: 'filters__toggle', data: { controller: 'date-picker' }) do
@@ -51,6 +65,74 @@ class Components::EventFilter < Components::Base
     hidden_field_tag(:period, @period, data: { date_picker_target: 'period' })
     hidden_field_tag(:sort, @sort, data: { date_picker_target: 'sort' })
     hidden_field_tag(:repeating, @repeating, data: { date_picker_target: 'repeating' })
+  end
+
+  # D22: Today / Tomorrow / next five days plus "All upcoming", linking to the
+  # existing dated event URLs. No new query parameters; sort and repeating ride
+  # along only when they differ from the controller defaults.
+  def render_day_strip
+    nav(class: 'day-strip min-w-0 overflow-x-auto', aria: { label: t('events.filter.day_strip.label') }) do
+      ul(class: 'flex list-none gap-2 whitespace-nowrap p-0 m-0') do
+        day_strip_dates.each_with_index do |date, index|
+          li(class: 'shrink-0') { render_day_strip_day(date, index) }
+        end
+        li(class: 'shrink-0') { render_day_strip_all_upcoming }
+      end
+    end
+  end
+
+  def render_day_strip_day(date, index)
+    current = @period == 'day' && @pointer == date
+    link_to(day_strip_label(date, index),
+            day_strip_day_url(date),
+            class: day_strip_link_class(current),
+            aria: { current: current ? 'date' : nil },
+            data: { turbo_frame: 'events-browser', turbo_action: 'advance' })
+  end
+
+  def render_day_strip_all_upcoming
+    current = @period == 'future'
+    link_to(t('events.filter.day_strip.all_upcoming'),
+            "#{events_path(**day_strip_params, period: 'future')}#paginator",
+            class: day_strip_link_class(current),
+            aria: { current: current ? 'true' : nil },
+            data: { turbo_frame: 'events-browser', turbo_action: 'advance' })
+  end
+
+  def day_strip_dates
+    today = Time.zone.today
+    (0...DAY_STRIP_LENGTH).map { |offset| today + offset }
+  end
+
+  def day_strip_label(date, index)
+    case index
+    when 0 then t('events.filter.day_strip.today')
+    when 1 then t('events.filter.day_strip.tomorrow')
+    else I18n.l(date, format: :day_strip)
+    end
+  end
+
+  def day_strip_day_url(date)
+    path = events_by_date_path(year: date.year, month: date.month, day: date.day,
+                               period: 'day', **day_strip_params)
+    "#{path}#paginator"
+  end
+
+  def day_strip_params
+    params = {}
+    params[:sort] = @sort if @sort.present? && @sort != 'time'
+    params[:repeating] = @repeating if @repeating.present? && @repeating != 'on'
+    params
+  end
+
+  def day_strip_link_class(current)
+    base = 'day-strip__link with-no-sass inline-flex items-center rounded-sm border-2 px-3 py-1.5 text-sm font-bold no-underline transition-colors'
+    state = if current
+              'bg-foreground text-background border-foreground'
+            else
+              'bg-background text-foreground border-rules hover:border-foreground'
+            end
+    "#{base} #{state}"
   end
 
   def render_neighbourhood_filter

--- a/app/tailwind/public/_components.css
+++ b/app/tailwind/public/_components.css
@@ -366,3 +366,14 @@ a.btn-home-outline:hover {
 .marker-cluster-large {
 	background: transparent !important;
 }
+
+/* Day strip event filter (D22). The legacy breadcrumb actions row is a
+   nowrap flex container sized to its content, so the strip would push the
+   sort filter off screen on narrow viewports. Cap it so the strip scrolls
+   inside the row, and let the sort filter wrap under it when space runs out. */
+.breadcrumb__actions:has(.day-strip) {
+	min-width: 0;
+	max-width: 100%;
+	flex-wrap: wrap;
+	row-gap: 0.5rem;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -319,6 +319,14 @@ en:
   # ===========================================================================
 
   events:
+    # Day strip event filter (D22): the Today / Tomorrow / next five days
+    # navigation rendered for themes with event_filter_style :day_strip.
+    filter:
+      day_strip:
+        label: "Filter events by day"
+        today: "Today"
+        tomorrow: "Tomorrow"
+        all_upcoming: "All upcoming"
     csv_export:
       link: "Download events as CSV"
       # Column headers for the events CSV (app/services/events_csv.rb).
@@ -341,6 +349,8 @@ en:
   date:
     formats:
       datetime: "%b %-d, %Y %l:%M"
+      # Day strip filter buttons, e.g. "Thu 13"
+      day_strip: "%a %-d"
 
   time:
     formats:

--- a/spec/components/event_filter_component_spec.rb
+++ b/spec/components/event_filter_component_spec.rb
@@ -277,6 +277,91 @@ RSpec.describe Components::EventFilter, type: :component do
     end
   end
 
+  describe "day strip filter style (D22)" do
+    let(:day_strip_attrs) { base_attrs.merge(filter_style: :day_strip) }
+
+    it "does not render the date picker chrome" do
+      render_inline(described_class.new(**day_strip_attrs))
+
+      expect(page).not_to have_button("Go to date")
+      expect(page).not_to have_css("[data-controller='date-picker']")
+    end
+
+    it "renders seven day links plus All upcoming" do
+      render_inline(described_class.new(**day_strip_attrs))
+
+      expect(page).to have_css("nav.day-strip a", count: 8)
+      expect(page).to have_link("Today")
+      expect(page).to have_link("Tomorrow")
+      expect(page).to have_link("All upcoming")
+    end
+
+    it "labels the remaining days with weekday and day number" do
+      render_inline(described_class.new(**day_strip_attrs))
+
+      expect(page).to have_link("Thu 10")
+      expect(page).to have_link("Mon 14")
+    end
+
+    it "links each day to its dated events URL" do
+      render_inline(described_class.new(**day_strip_attrs))
+
+      expect(page).to have_link("Today", href: "/events/2022/11/8?period=day#paginator")
+      expect(page).to have_link("Tomorrow", href: "/events/2022/11/9?period=day#paginator")
+      expect(page).to have_link("All upcoming", href: "/events?period=future#paginator")
+    end
+
+    it "carries non-default sort and repeating in the links" do
+      render_inline(described_class.new(**day_strip_attrs, sort: "summary", repeating: "off"))
+
+      expect(page).to have_link("Today", href: "/events/2022/11/8?period=day&repeating=off&sort=summary#paginator")
+      expect(page).to have_link("All upcoming", href: "/events?period=future&repeating=off&sort=summary#paginator")
+    end
+
+    it "highlights the current day" do
+      render_inline(described_class.new(**day_strip_attrs))
+
+      expect(page).to have_css("a[aria-current='date']", count: 1)
+      expect(page).to have_css("a[aria-current='date']", text: "Today")
+    end
+
+    it "highlights a navigated day rather than today" do
+      render_inline(described_class.new(**day_strip_attrs, pointer: today + 2))
+
+      expect(page).to have_css("a[aria-current='date']", text: "Thu 10")
+      expect(page).not_to have_css("a[aria-current='date']", text: "Today")
+    end
+
+    it "highlights All upcoming when the period is future" do
+      render_inline(described_class.new(**day_strip_attrs, period: "future"))
+
+      expect(page).not_to have_css("a[aria-current='date']")
+      expect(page).to have_css("a[aria-current='true']", text: "All upcoming")
+    end
+
+    it "keeps the sort and repeating filters" do
+      render_inline(described_class.new(**day_strip_attrs))
+
+      expect(page).to have_button("Filter and sort")
+      expect(page).to have_field("repeating_on", type: "radio")
+    end
+
+    it "scrolls horizontally on narrow viewports" do
+      render_inline(described_class.new(**day_strip_attrs))
+
+      expect(page).to have_css("nav.day-strip.overflow-x-auto ul.whitespace-nowrap")
+    end
+  end
+
+  describe "date picker filter style" do
+    it "is the default when no theme asks for the day strip" do
+      render_inline(described_class.new(**base_attrs))
+
+      expect(page).not_to have_css("nav.day-strip")
+      expect(page).to have_button("Go to date")
+    end
+  end
+
   describe "with different parameter values" do
     context "with week period" do
       let(:attrs) { base_attrs.merge(period: "week") }

--- a/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
+++ b/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
@@ -29,6 +29,7 @@ module ExampleTheme
         theme.stylesheet "example_theme/theme"
         theme.homepage_view "ExampleTheme::Views::Home"
         theme.head "ExampleTheme::Components::Head"
+        theme.event_filter_style :day_strip
       end
     end
   end

--- a/spec/requests/extensions/day_strip_filter_spec.rb
+++ b/spec/requests/extensions/day_strip_filter_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# WP 1.3b (#3368, D22): a site whose theme sets `event_filter_style :day_strip`
+# gets the Today / Tomorrow / next five days strip in place of the date picker.
+RSpec.describe "Day strip event filter", type: :request do
+  let(:ward) { create(:riverside_ward) }
+
+  before do
+    site.neighbourhoods << ward
+  end
+
+  context "with a theme that asks for the day strip" do
+    let(:site) do
+      create(:site, slug: "exampled", theme: "example_theme", url: "https://exampled.lvh.me")
+    end
+
+    it "renders the day strip instead of the date picker" do
+      get "http://exampled.lvh.me/events"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("day-strip")
+      expect(response.body).to include("All upcoming")
+      expect(response.body).to include("Tomorrow")
+      expect(response.body).not_to include("Go to date")
+    end
+
+    it "links days to the existing dated event URLs" do
+      get "http://exampled.lvh.me/events"
+
+      today = Time.zone.today
+      expect(response.body).to include("/events/#{today.year}/#{today.month}/#{today.day}?period=day#paginator")
+      expect(response.body).to include("/events?period=future#paginator")
+    end
+  end
+
+  context "with a core theme" do
+    let(:site) do
+      create(:site, slug: "corely", theme: "pink", url: "https://corely.lvh.me")
+    end
+
+    it "keeps the date picker" do
+      get "http://corely.lvh.me/events"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Go to date")
+      expect(response.body).not_to include("day-strip")
+    end
+  end
+end


### PR DESCRIPTION
WP 1.3b of #3368 (D22), implemented by Opus, reviewed by the coordinator (screenshots at 450 and 1250 checked).

`Components::EventFilter` renders a Today / Tomorrow / next five days / All upcoming strip when the site's theme registers `event_filter_style :day_strip`; date picker themes unchanged. Links reuse the existing `/events/YYYY/M/D?period=day` URLs and hidden sort/repeating params. Fixture theme now uses the day strip.

Gate (pasted from implementer):
```
rubocop: 12 files inspected, no offenses detected
rspec i18n_keys, components/event_filter, requests/extensions, requests/public/events: 94 examples, 0 failures
screenshots: tmp/screenshots/{day_strip,date_picker}_{450,1250}.png (coordinator viewed day_strip_450)
```