### PR TITLE
WP 1.4: join form on sites with per-site recipient (#3368)

### DIFF
--- a/app/controllers/joins_controller.rb
+++ b/app/controllers/joins_controller.rb
@@ -5,22 +5,33 @@ class JoinsController < ApplicationController
   invisible_captcha only: %i[create update]
 
   def new
-    @join = Join.new
-    render Views::Directory::Join.new(join: @join)
+    @join = Join.new(site: current_site)
+    render join_view
   end
 
   def create
     @join = Join.new(join_params)
+    @join.site = current_site
 
     if @join.submit
       redirect_to '/', notice: t('directory.join.flash.success')
     else
       flash[:error] = t('directory.join.flash.error')
-      render Views::Directory::Join.new(join: @join)
+      render join_view
     end
   end
 
   private
+
+  # The form is served on every host: local sites get their own themed view
+  # (#3368, D8), the nationwide directory keeps the directory one.
+  def join_view
+    if current_site
+      Views::Sites::Join.new(join: @join, site: current_site)
+    else
+      Views::Directory::Join.new(join: @join)
+    end
+  end
 
   def join_params
     params.require(:join).permit(:name, :email, :phone, :job_title, :job_org, :area, :ringback, :more_info, :why)

--- a/app/mailers/join_mailer.rb
+++ b/app/mailers/join_mailer.rb
@@ -2,7 +2,14 @@
 
 class JoinMailer < ApplicationMailer
   def join_us(join)
-    mail(to: 'support@placecal.org', subject: 'New Join Request') do |format|
+    site = join.site
+    subject = if site
+                t('join_mailer.join_us.subject_with_site', site: site.name)
+              else
+                t('join_mailer.join_us.subject')
+              end
+
+    mail(to: site&.join_recipient || Join::DEFAULT_RECIPIENT, subject: subject) do |format|
       format.html { render Views::Mailers::Join::JoinUs.new(join: join) }
     end
   end

--- a/app/models/join.rb
+++ b/app/models/join.rb
@@ -4,6 +4,10 @@ class Join
   include ActiveModel::Model
   include ActiveModel::Attributes
 
+  # Fallback recipient for enquiries that arrive without a site, or from a
+  # site with no contact_email of its own (#3368, D13).
+  DEFAULT_RECIPIENT = 'support@placecal.org'
+
   attribute :name, :string
   attribute :email, :string
   attribute :phone, :string
@@ -13,6 +17,10 @@ class Join
   attribute :ringback, :boolean
   attribute :more_info, :boolean
   attribute :why, :string
+
+  # The site the enquiry was submitted from, if any. Not a form field: the
+  # controller sets it from current_site, and the directory leaves it nil.
+  attr_accessor :site
 
   validates :name, :email, :why, presence: true
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -6,6 +6,7 @@
 #
 #  id                :bigint           not null, primary key
 #  badge_zoom_level  :string
+#  contact_email     :string
 #  description       :text
 #  description_html  :string
 #  events_count      :integer          default(0), not null
@@ -69,6 +70,7 @@ class Site < ApplicationRecord
 
   # ==== Attributes ====
   # Columns marked (nullable) have no NOT NULL constraint in the DB.
+  attribute :contact_email,     :string                          # nullable
   attribute :description,       :text                            # nullable
   attribute :description_html,  :string                          # nullable, populated by HtmlRenderCache
   attribute :events_count,      :integer, default: 0             # NOT NULL
@@ -123,6 +125,7 @@ class Site < ApplicationRecord
   validates :name, :slug, :url, presence: true
   validates :slug, uniqueness: true
   validates :hero_text, length: { maximum: 120 }
+  validates :contact_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
   # Themes come from the extension registry, not a static list, so an
   # extension can add one without touching this model (#3368, D2).
   validates :theme, inclusion: { in: ->(_site) { PlaceCal::Extensions.theme_names } }
@@ -134,6 +137,14 @@ class Site < ApplicationRecord
 
   def to_s
     "#{id}: #{name}"
+  end
+
+  # Where this site's Join ("get in touch") enquiries are sent. Sites without
+  # their own address fall back to the PlaceCal support inbox (#3368, D13).
+  #
+  # @return [String]
+  def join_recipient
+    contact_email.presence || Join::DEFAULT_RECIPIENT
   end
 
   # The site's public URL, falling back to its conventional placecal.org

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -31,7 +31,8 @@ class SitePolicy < ApplicationPolicy
 
   def permitted_attributes
     attrs = %i[id name place_name logo footer_logo is_published tagline description
-               badge_zoom_level hero_image hero_image_credit hero_alttext hero_text theme ]
+               badge_zoom_level hero_image hero_image_credit hero_alttext hero_text theme
+               contact_email]
             .push(sites_neighbourhoods_attributes: %i[_destroy id neighbourhood_id relation_type],
                   sites_neighbourhood_attributes: %i[_destroy id neighbourhood_id relation_type])
 

--- a/app/views/admin/sites/form_tab_basic.rb
+++ b/app/views/admin/sites/form_tab_basic.rb
@@ -15,6 +15,7 @@ class Views::Admin::Sites::FormTabBasic < Views::Admin::Base
       render_name_field
       render_site_admin_field(site)
       render_place_name_field
+      render_contact_email_field
       render_tagline_field
       render_hero_text_field
       render_description_field
@@ -68,6 +69,14 @@ class Views::Admin::Sites::FormTabBasic < Views::Admin::Base
       raw form.label(:place_name, attr_label(:site, :place_name), class: 'fieldset-legend')
       raw form.input_field(:place_name, class: 'input input-bordered w-full')
       p(class: 'fieldset-label') { t('admin.sites.fields.place_name_hint') }
+    end
+  end
+
+  def render_contact_email_field
+    fieldset(class: 'fieldset') do
+      raw form.label(:contact_email, attr_label(:site, :contact_email), class: 'fieldset-legend')
+      raw form.input_field(:contact_email, as: :email, class: 'input input-bordered w-full')
+      p(class: 'fieldset-label') { t('admin.sites.fields.contact_email_hint') }
     end
   end
 

--- a/app/views/sites/join.rb
+++ b/app/views/sites/join.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# The "get in touch" form as it appears on a local site (#3368, D8).
+#
+# The field set, form markup and validation are identical to the directory
+# form, so this subclasses it rather than duplicating ~100 lines of form
+# rendering; only the page chrome (hero, intro, email CTA) is site-specific.
+# The enquiry is delivered to the site's own contact_email (D13).
+class Views::Sites::Join < Views::Directory::Join
+  prop :site, Site, reader: :private
+
+  def view_template
+    content_for(:title) { t('sites.join.hero.title') }
+    content_for(:description) { site.og_description }
+
+    Hero(t('sites.join.hero.title'), site.tagline)
+
+    div(class: 'container-editorial py-8') do
+      p(class: 'join-note mb-6') { t('sites.join.intro', site: site.name) }
+      render_form
+      render_email_cta
+    end
+  end
+
+  private
+
+  # Only shown when the site has published a contact address of its own: the
+  # fallback support inbox is an internal detail, not a public address.
+  def render_email_cta
+    address = site.contact_email
+    return if address.blank?
+
+    div(class: 'join-email-cta') do
+      div do
+        h2(class: 'join-email-cta__heading') { t('sites.join.email_cta.heading') }
+        p(class: 'join-email-cta__body') { t('sites.join.email_cta.body', site: site.name) }
+      end
+      a(href: "mailto:#{address}", class: 'join-email-link with-no-sass') do
+        icon(:mail, size: '4')
+        plain address
+      end
+    end
+  end
+end

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -563,6 +563,7 @@ en:
         preview_title: "Site Content Preview"
       fields:
         alt_text_hint: "How should a screen reader describe this image?"
+        contact_email_hint: 'Where "get in touch" enquiries from this site are sent. Setting this also adds the Get in touch link to the site navigation. Leave blank to send to PlaceCal support.'
         hero_handbook_link: "See handbook for guidance"
         hero_image_description: "The large image at the top of your site's homepage."
         hero_text_hint: "Large text for the homepage banner"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,11 @@ en:
   contact:
     email: "support@placecal.org"
 
+  join_mailer:
+    join_us:
+      subject: "New Join Request"
+      subject_with_site: "New Join Request (%{site})"
+
   components:
     details:
       open: "Open to read more"
@@ -315,6 +320,19 @@ en:
       gfsc_logo_alt: "Geeks for Social Change"
 
   # ===========================================================================
+  # LOCAL SITES (subdomain sites)
+  # ===========================================================================
+
+  sites:
+    join:
+      hero:
+        title: "Get in touch"
+      intro: "Send a message to the %{site} team. We read every message and will get back to you."
+      email_cta:
+        heading: "Rather just email?"
+        body: "Write to %{site} directly and we'll pick it up from there."
+
+  # ===========================================================================
   # EVENT EXPORTS (shared by local sites and the directory)
   # ===========================================================================
 
@@ -531,6 +549,7 @@ en:
 
       site:
         <<: *default_attrs
+        contact_email: "Contact Email"
         place_name: "Place Name"
         hero_text: "Hero Text"
         hero_image: "Hero Image"

--- a/db/migrate/20260902100000_add_contact_email_to_sites.rb
+++ b/db/migrate/20260902100000_add_contact_email_to_sites.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddContactEmailToSites < ActiveRecord::Migration[8.0]
+  def change
+    add_column :sites, :contact_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_02_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -278,6 +278,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_090000) do
 
   create_table "sites", force: :cascade do |t|
     t.string "badge_zoom_level"
+    t.string "contact_email"
     t.datetime "created_at", precision: nil, null: false
     t.text "description"
     t.string "description_html"

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -6,6 +6,7 @@
 #
 #  id                :bigint           not null, primary key
 #  badge_zoom_level  :string
+#  contact_email     :string
 #  description       :text
 #  description_html  :string
 #  events_count      :integer          default(0), not null

--- a/spec/mailers/join_mailer_spec.rb
+++ b/spec/mailers/join_mailer_spec.rb
@@ -1,3 +1,33 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+
+RSpec.describe JoinMailer, type: :mailer do
+  let(:join_attrs) do
+    { name: "Test User", email: "test@example.com", why: "I want to help my community" }
+  end
+
+  describe "#join_us" do
+    it "sends to the default recipient when there is no site" do
+      mail = described_class.join_us(Join.new(**join_attrs))
+
+      expect(mail.to).to eq([Join::DEFAULT_RECIPIENT])
+      expect(mail.subject).to eq(I18n.t("join_mailer.join_us.subject"))
+    end
+
+    it "sends to the site's contact_email and names the site in the subject" do
+      site = build(:site, name: "Millbrook", contact_email: "hello@example.org")
+      mail = described_class.join_us(Join.new(site: site, **join_attrs))
+
+      expect(mail.to).to eq(["hello@example.org"])
+      expect(mail.subject).to eq(I18n.t("join_mailer.join_us.subject_with_site", site: "Millbrook"))
+    end
+
+    it "falls back to the default recipient when the site has no contact_email" do
+      site = build(:site, contact_email: nil)
+      mail = described_class.join_us(Join.new(site: site, **join_attrs))
+
+      expect(mail.to).to eq([Join::DEFAULT_RECIPIENT])
+    end
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                :bigint           not null, primary key
 #  badge_zoom_level  :string
+#  contact_email     :string
 #  description       :text
 #  description_html  :string
 #  events_count      :integer          default(0), not null
@@ -54,6 +55,23 @@ RSpec.describe Site, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
 
+    describe "contact_email" do
+      it "is valid when blank" do
+        expect(build(:site, contact_email: nil)).to be_valid
+        expect(build(:site, contact_email: "")).to be_valid
+      end
+
+      it "is valid with a well-formed address" do
+        expect(build(:site, contact_email: "hello@example.org")).to be_valid
+      end
+
+      it "is invalid with a malformed address" do
+        site = build(:site, contact_email: "not-an-email")
+        expect(site).not_to be_valid
+        expect(site.errors[:contact_email]).to be_present
+      end
+    end
+
     # NOTE: slug presence is enforced at the model and database level, but a
     # blank slug is auto-generated from the name before validation (see
     # #should_generate_new_friendly_id? and the "FriendlyId" specs below), so
@@ -61,6 +79,18 @@ RSpec.describe Site, type: :model do
 
     # NOTE: FriendlyId handles slug uniqueness at the database level
     # No explicit validates_uniqueness_of on slug in the model
+  end
+
+  describe "#join_recipient" do
+    it "returns the site's own contact email when set" do
+      site = build(:site, contact_email: "hello@example.org")
+      expect(site.join_recipient).to eq("hello@example.org")
+    end
+
+    it "falls back to the default recipient when blank" do
+      expect(build(:site, contact_email: nil).join_recipient).to eq(Join::DEFAULT_RECIPIENT)
+      expect(build(:site, contact_email: "").join_recipient).to eq(Join::DEFAULT_RECIPIENT)
+    end
   end
 
   describe "factories" do

--- a/spec/requests/public/joins_spec.rb
+++ b/spec/requests/public/joins_spec.rb
@@ -3,6 +3,37 @@
 require "rails_helper"
 
 RSpec.describe "Public Joins (Contact Form)", type: :request do
+  # invisible_captcha guards the form with a session timestamp, a spinner token
+  # and honeypot fields, all of which are seeded by rendering the form. A
+  # realistic submission therefore has to GET the page first, carry its session
+  # (hence host! rather than a per-request Host header, so the cookie jar
+  # matches) and echo back the spinner. The suite freezes the clock, so the
+  # "too quick" threshold is dropped to zero rather than moving time forward.
+  def submit_form(host:, params:, honeypot: nil)
+    host! host
+    get "/get-in-touch"
+
+    body = params.deep_dup
+    body[:spinner] = response.body[/name="spinner"[^>]*value="([^"]*)"/, 1]
+    body[honeypot] = "spam" if honeypot
+    post "/get-in-touch", params: body
+  end
+
+  let(:valid_params) do
+    {
+      join: {
+        name: "Test User",
+        email: "test@example.com",
+        why: "I want to help my community"
+      }
+    }
+  end
+
+  before do
+    allow(InvisibleCaptcha).to receive(:timestamp_threshold).and_return(0)
+    ActionMailer::Base.deliveries.clear
+  end
+
   describe "GET /get-in-touch" do
     it "returns successful response" do
       get "/get-in-touch", headers: { "Host" => "lvh.me" }
@@ -13,23 +44,63 @@ RSpec.describe "Public Joins (Contact Form)", type: :request do
       get "/get-in-touch", headers: { "Host" => "lvh.me" }
       expect(response.body).to include("join")
     end
+
+    it "renders the site form on a site host" do
+      site = create(:site, contact_email: "hello@example.org")
+      get "/get-in-touch", headers: { "Host" => "#{site.slug}.lvh.me" }
+      expect(response).to be_successful
+      expect(response.body).to include(site.name)
+    end
   end
 
   describe "POST /get-in-touch" do
     context "with valid params" do
-      let(:valid_params) do
-        {
-          join: {
-            name: "Test User",
-            email: "test@example.com",
-            why: "I want to help my community"
-          }
-        }
-      end
-
       it "redirects on success" do
         post "/get-in-touch", params: valid_params, headers: { "Host" => "lvh.me" }
         expect(response).to be_redirect
+      end
+
+      it "delivers one mail to the default recipient from the directory" do
+        submit_form(host: "lvh.me", params: valid_params)
+
+        expect(ActionMailer::Base.deliveries.size).to eq(1)
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.to).to eq([Join::DEFAULT_RECIPIENT])
+        expect(mail.subject).to eq(I18n.t("join_mailer.join_us.subject"))
+      end
+    end
+
+    context "on a site host" do
+      it "delivers to the site's contact_email with the site name in the subject" do
+        site = create(:site, contact_email: "hello@example.org")
+
+        submit_form(host: "#{site.slug}.lvh.me", params: valid_params)
+
+        expect(ActionMailer::Base.deliveries.size).to eq(1)
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.to).to eq(["hello@example.org"])
+        expect(mail.subject).to include(site.name)
+      end
+
+      it "falls back to the default recipient when contact_email is blank" do
+        site = create(:site, contact_email: nil)
+
+        submit_form(host: "#{site.slug}.lvh.me", params: valid_params)
+
+        expect(ActionMailer::Base.deliveries.size).to eq(1)
+        expect(ActionMailer::Base.deliveries.last.to).to eq([Join::DEFAULT_RECIPIENT])
+      end
+    end
+
+    context "with the invisible captcha honeypot filled" do
+      it "is rejected and sends no mail" do
+        site = create(:site, contact_email: "hello@example.org")
+
+        submit_form(host: "#{site.slug}.lvh.me",
+                    params: valid_params,
+                    honeypot: InvisibleCaptcha.honeypots.first)
+
+        expect(ActionMailer::Base.deliveries).to be_empty
       end
     end
 
@@ -48,6 +119,11 @@ RSpec.describe "Public Joins (Contact Form)", type: :request do
         post "/get-in-touch", params: invalid_params, headers: { "Host" => "lvh.me" }
         # Renders form again or redirects depending on captcha
         expect(response).to be_successful.or be_redirect
+      end
+
+      it "sends no mail" do
+        submit_form(host: "lvh.me", params: invalid_params)
+        expect(ActionMailer::Base.deliveries).to be_empty
       end
     end
   end


### PR DESCRIPTION
WP 1.4 of #3368 (D8, D13), implemented by Opus, reviewed by the coordinator.

- Migration `sites.contact_email` (nullable, email format validated), admin field on the Basic tab for root and site admins, `Site#join_recipient` with the support fallback.
- `JoinMailer` recipient and subject are site-aware; `JoinsController` renders `Views::Sites::Join` (subclass of the directory view: same fields, site chrome) on site hosts. No route change was needed: `get-in-touch` already resolved on sites, but rendered directory copy and mailed support.
- Finding: the pre-existing join request specs passed vacuously (invisible_captcha rejected every POST). New `submit_form` helper in the spec exercises a real submission.

Gate (pasted from implementer):
```
rubocop: 507 files inspected, no offenses detected
rspec i18n_keys, models/site, requests/public/joins, mailers, requests/admin, requests/extensions: 374 examples, 0 failures
cucumber features/admin/sites.feature: 4 scenarios (4 passed), 20 steps (20 passed)
```