### PR TITLE
WP 1.10: tag-only site scoping (#3368)

### DIFF
--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -253,16 +253,19 @@ class PartnersQuery
     @base_scope ||= build_base_scope
   end
 
+  # A site scopes its partners by its neighbourhoods, by its tags, or by both
+  # (tag AND neighbourhood). A tagged site with no neighbourhoods is tag-only:
+  # partnership sites such as The Trans Dimension span cities and pick their
+  # partners by Partnership tag alone (#3368 D7, D24). A site with neither
+  # has no partners.
   def build_base_scope
     return Partner.visible if @site.nil?
-    return Partner.none if site_neighbourhood_ids.empty?
+    return Partner.none if site_neighbourhood_ids.empty? && site_tag_ids.empty?
 
     scope = Partner.visible
     scope = scope.joins(:tags).where(tags: { id: site_tag_ids }) if site_tag_ids.any?
-    scope
-      .left_joins(:address, :service_areas)
-      .where(in_site_neighbourhoods_sql)
-      .distinct
+    scope = scope.left_joins(:address, :service_areas).where(in_site_neighbourhoods_sql) if site_neighbourhood_ids.any?
+    scope.distinct
   end
 
   # ===================

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -143,6 +143,33 @@ RSpec.describe PartnersQuery do
         expect(results).to be_empty
       end
     end
+
+    context "with a tag-only site (partnership tags, no neighbourhoods)" do
+      let(:tag_only_site) { create(:site) }
+      let(:partnership) { create(:partnership) }
+      let!(:tagged_partner) { create(:partner, name: "Tagged") }
+      let!(:tagged_elsewhere) { create(:partner, name: "Tagged elsewhere") }
+      let!(:untagged_partner) { create(:partner, name: "Untagged") }
+
+      before do
+        tag_only_site.tags << partnership
+        tagged_partner.tags << partnership
+        tagged_elsewhere.tags << partnership
+      end
+
+      it "scopes by tag alone, wherever the partner is" do
+        results = described_class.new(site: tag_only_site).call
+
+        expect(results).to contain_exactly(tagged_partner, tagged_elsewhere)
+      end
+
+      it "still requires the neighbourhood when the site has both" do
+        tag_only_site.neighbourhoods << create(:neighbourhood)
+        results = described_class.new(site: tag_only_site).call
+
+        expect(results).to be_empty
+      end
+    end
   end
 
   describe "#neighbourhoods_with_counts" do


### PR DESCRIPTION
Coordinator WP 1.10 of #3368, found while creating the dev TD site.

`PartnersQuery#build_base_scope` returned `Partner.none` for any site without neighbourhoods, so a partnership site that picks partners by Partnership tag alone (the way transdimension.uk queries PlaceCal today) would have shown nothing. D24 assumed neighbourhoods were optional config. Now: tags only, neighbourhoods only, or both (both still required when both are set). `EventsQuery` goes through `PartnersQuery`, so events follow.

Gate:
```
rubocop app/queries/partners_query.rb spec/queries/partners_query_spec.rb: no offenses
rspec queries, requests/public/{partners,events,sites,sitemaps}: 232 examples, 0 failures
```