### PR TITLE
Cutover: add transdimension.uk to production proxy hosts (#3368)

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -19,6 +19,11 @@ proxy:
     - placecal.org
     - "*.placecal.org"
     - www.queerleeds.lgbt
+    # The Trans Dimension (#3368): served by the transdimension extension theme.
+    # Cutover: merge this once the extension is deployed, then point Cloudflare
+    # DNS for both names at production.
+    - transdimension.uk
+    - www.transdimension.uk
 
 accessories:
   db:


### PR DESCRIPTION
Phase 4 of #3368, step 1 (agent PR). Adds `transdimension.uk` and `www.transdimension.uk` to `proxy.hosts` in `config/deploy.production.yml`, following the queerleeds.lgbt pattern.

Do not merge until the Trans Dimension extension (integration PR #3436 plus the `group :extensions` Gemfile line) is deployed to production and the TD Site record exists there. Order at cutover: merge and deploy this, then move Cloudflare DNS for both names to PlaceCal production, then archive the Elm repo. Full runbook is the "Cutover runbook" comment on #3368.