### PR TITLE
WP 1.11: expose region helpers to views (#3368)

### DIFF
--- a/app/controllers/concerns/region_filterable.rb
+++ b/app/controllers/concerns/region_filterable.rb
@@ -9,6 +9,12 @@
 module RegionFilterable
   extend ActiveSupport::Concern
 
+  # Exposed to views so theme homepage views (rendered with only `site:`)
+  # can render the region filter without re-deriving the selection.
+  included do
+    helper_method :region_tags, :current_region, :region_filter?
+  end
+
   private
 
   # @return [Array<Tag>] the site's Partnership tags in name order; empty for

--- a/spec/requests/extensions/theme_homepage_spec.rb
+++ b/spec/requests/extensions/theme_homepage_spec.rb
@@ -49,3 +49,9 @@ RSpec.describe "Extension theme homepage", type: :request do
     end
   end
 end
+
+RSpec.describe "Region helpers for theme homepage views", type: :request do
+  it "exposes region_tags, current_region and region_filter? as helper methods" do
+    expect(SitesController.helpers).to respond_to(:region_tags, :current_region, :region_filter?)
+  end
+end


### PR DESCRIPTION
Coordinator WP 1.11 of #3368. `region_tags`, `current_region` and `region_filter?` become helper methods so a theme homepage view (constructed with only `site:`) can render `RegionFilter` via `view_context`. Gate: rubocop clean; rspec requests/extensions, requests/public/{sites,events}: see run output in the log.