### PR TITLE
WP 2.8: load the Trans Dimension extension, theme-scoped overrides (#3368)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'strong_migrations'           # Catch unsafe migrations before they reach pr
 # prebuilt, so the Dockerfile needs no extra build step. Bump the tag to
 # release a new version of an extension.
 group :extensions do
-  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.1.0'
+  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.1.1'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,15 @@ gem 'invisible_captcha'           # Spam protection on contact form
 gem 'paper_trail'                 # Event version tracking and audit log
 gem 'strong_migrations'           # Catch unsafe migrations before they reach production
 
+# Installation-specific extensions for placecal.org (see doc/extensions.md).
+# Not part of core: a self-hosted PlaceCal can delete this whole block. Each
+# extension is a Rails engine that registers a theme; it ships its CSS
+# prebuilt, so the Dockerfile needs no extra build step. Bump the tag to
+# release a new version of an extension.
+group :extensions do
+  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.1.0'
+end
+
 group :development, :test do
   gem 'byebug'                    # Debugger
   gem 'dotenv-rails'              # Load .env files

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/geeksforsocialchange/placecal-theme-transdimension.git
+  revision: b4c29b7f0182a99ac77d26b2faa2ffb669266ae2
+  tag: v0.1.0
+  specs:
+    placecal-theme-transdimension (0.1.0)
+      rails (>= 8.0)
+
 GEM
   remote: https://gem.coop/
   specs:
@@ -798,6 +806,7 @@ DEPENDENCIES
   paper_trail
   pg
   phlex-rails (~> 2.3)
+  placecal-theme-transdimension!
   propshaft
   puma
   pundit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/geeksforsocialchange/placecal-theme-transdimension.git
-  revision: b4c29b7f0182a99ac77d26b2faa2ffb669266ae2
-  tag: v0.1.0
+  revision: 6731250b0e756dc651ee74391804b643f17ed62e
+  tag: v0.1.1
   specs:
     placecal-theme-transdimension (0.1.0)
       rails (>= 8.0)

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -28,10 +28,8 @@ class Components::Base < Phlex::HTML
   register_value_helper :current_user
   register_value_helper :policy
 
-  # I18n translate helper
-  def t(key, **)
-    I18n.t(key, **)
-  end
+  # I18n translate helper, theme-aware (PlaceCal::ThemeTranslation)
+  include PlaceCal::ThemeTranslation
 
   def sidebar_heading(text)
     h3(class: 'allcaps-label text-tertiary mt-1 mb-2') { text }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,11 +10,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :discard_stale_auth_flash, unless: :devise_controller?
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_current_site
   before_action :set_supporters
   before_action :set_navigation
   before_action :set_appsignal_namespace
 
   include Pundit::Authorization
+  # Theme-scoped strings for nav labels and flashes built in controllers.
+  include PlaceCal::ThemeTranslation
   include RegionFilterable
   include SiteNavigation
 
@@ -233,6 +236,12 @@ class ApplicationController < ActionController::Base
 
   def set_site
     @site = current_site
+  end
+
+  # Makes the resolved site available to the view layer for the request
+  # (see Current and PlaceCal::ThemeTranslation).
+  def set_current_site
+    Current.site = current_site
   end
 
   def redirect_from_directory

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Per-request attributes. `site` is the Site resolved from the request host
+# (nil on the nationwide directory and the admin subdomain), set by
+# ApplicationController so that view-layer helpers such as theme-scoped
+# translations (PlaceCal::ThemeTranslation) can reach it without threading
+# the site through every component.
+class Current < ActiveSupport::CurrentAttributes
+  attribute :site
+end

--- a/app/views/base.rb
+++ b/app/views/base.rb
@@ -35,10 +35,8 @@ class Views::Base < Phlex::HTML
   register_value_helper :current_user
   register_value_helper :policy
 
-  # I18n translate helper
-  def t(key, **)
-    I18n.t(key, **)
-  end
+  # I18n translate helper, theme-aware (PlaceCal::ThemeTranslation)
+  include PlaceCal::ThemeTranslation
 
   # Directory sidebar-card heading, mirroring Components::Base#sidebar_heading
   # so views composing sidebar cards inline use the identical treatment.

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,9 @@ require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
+# :extensions holds installation-specific engines (see the Gemfile block and
+# doc/extensions.md); it is not an environment group, so it is named here.
+Bundler.require(*Rails.groups, :extensions)
 
 # The extension registry must exist before any extension engine's
 # initializers run, and lib/ is not autoloaded, so it is required here.

--- a/config/initializers/site_page_routes.rb
+++ b/config/initializers/site_page_routes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Site content pages (#3368, D5): static per-site pages live at the top level
+# (/about) to match PlaceCal's own convention for static pages (D14). This is
+# a catch-all, so it must lose to every other route, including routes drawn
+# by extension engines, which load after config/routes.rb. `append` blocks
+# run after every route file on each draw. Registered here, in an initializer,
+# rather than in config/routes.rb: an append block registered inside a routes
+# file is registered again on every reload of that file, which then defines
+# the route name twice. Page validates its slug against the reserved first
+# path segments derived from the finished route set.
+Rails.application.routes.append do
+  get '/:slug', to: 'pages#show', as: :site_page, constraints: { slug: /[a-z0-9-]+/ }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,16 +168,3 @@ Rails.application.routes.draw do
   mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/api/v1/graphql' if Rails.env.development?
   # Lookbook auto-mounts at /lookbook in development
 end
-
-# ============================================================
-# Site content pages (#3368, D5) - MUST BE LAST
-# ============================================================
-# Static per-site pages live at the top level (/about) to match PlaceCal's own
-# convention for static pages (D14). This is a catch-all, so it has to lose to
-# every other route, including routes drawn by extension engines. `append`
-# blocks are evaluated once every route file has been loaded, which `draw` here
-# cannot guarantee. Page validates its slug against the reserved first path
-# segments derived from the finished route set.
-Rails.application.routes.append do
-  get '/:slug', to: 'pages#show', as: :site_page, constraints: { slug: /[a-z0-9-]+/ }
-end

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -78,14 +78,17 @@ All settings are optional. `stylesheet` and `map_style` may receive a block that
 
 ## Locale files
 
-Rails automatically loads an engine's `config/locales/**/*.yml` into the I18n path. An extension's strings should live under its own namespace to avoid collisions (`my_ext.*`). If an extension needs to override a core string, append an override file in `config.after_initialize`:
+Rails automatically loads an engine's `config/locales/**/*.yml` into the I18n path. An extension's own strings live under its own namespace (`my_ext.*`) so they cannot collide with core.
 
-```ruby
-# lib/<ext>/engine.rb
-config.after_initialize do
-  I18n.load_path << root.join('config/locales/overrides.en.yml')
-  I18n.reload!
-end
+To change a core string for sites on your theme only, add the same key under `theme_overrides.<theme name>` in one of the engine's locale files. Core's `t` helper (`PlaceCal::ThemeTranslation`, mixed into views, components and controllers) looks up `theme_overrides.<theme>.<key>` first for the current site's theme and falls back to `<key>`, so other sites are untouched and load order does not matter:
+
+```yaml
+# config/locales/overrides.en.yml
+en:
+  theme_overrides:
+    my_ext:
+      region_filter:
+        all: Everywhere
 ```
 
 ## Stylesheet and CSS build

--- a/features/admin/pages.feature
+++ b/features/admin/pages.feature
@@ -27,6 +27,7 @@ Feature: Site Page Management
   Scenario: A reserved slug is rejected
     When I go to the "Pages" admin section
     And I click "Add Page"
+    Then I should see "New Page"
     When I fill in "Title" with "Events"
     And I fill in "Slug" with "events"
     And I click "Save"

--- a/lib/placecal/extensions.rb
+++ b/lib/placecal/extensions.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'theme'
+require_relative 'theme_translation'
 
 module PlaceCal
   # Registry that extensions (Rails engines) register into. Core knows

--- a/lib/placecal/theme_translation.rb
+++ b/lib/placecal/theme_translation.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module PlaceCal
+  # `t` for views, components and controllers that lets a theme override any
+  # core string for the sites that use that theme, and only those sites
+  # (#3368, D19). An extension ships the overrides in its own locale file
+  # under `theme_overrides.<theme name>.<original key>`; nothing is changed
+  # for sites on other themes, and no load-order tricks are needed.
+  #
+  #   en:
+  #     theme_overrides:
+  #       transdimension:
+  #         region_filter:
+  #           all: Everywhere
+  module ThemeTranslation
+    OVERRIDE_SCOPE = 'theme_overrides'
+
+    def t(key, **)
+      theme = Current.site&.theme_definition
+      return I18n.t(key, **) unless theme && key.is_a?(String) && !key.start_with?('.')
+
+      I18n.t("#{OVERRIDE_SCOPE}.#{theme.name}.#{key}", **, default: key.to_sym)
+    end
+  end
+end

--- a/spec/fixtures/extensions/example_theme/config/locales/en.yml
+++ b/spec/fixtures/extensions/example_theme/config/locales/en.yml
@@ -4,3 +4,7 @@ en:
       title: Example theme
       heading: Example theme fixture homepage
       no_site: Rendered without a site
+  theme_overrides:
+    example_theme:
+      region_filter:
+        all: Anywhere

--- a/spec/lib/placecal/extensions_spec.rb
+++ b/spec/lib/placecal/extensions_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PlaceCal::Extensions do
   describe "boot-time registry" do
     it "contains the built-in themes plus the test fixture extension" do
-      expect(described_class.theme_names).to eq(%w[pink orange green blue custom example_theme])
+      expect(described_class.theme_names).to start_with(%w[pink orange green blue custom]).and include("example_theme")
     end
 
     it "lists built-in themes as core" do
@@ -73,6 +73,6 @@ RSpec.describe PlaceCal::Extensions do
   end
 
   it "restores the registry after a mutating example" do
-    expect(described_class.theme_names).to eq(%w[pink orange green blue custom example_theme])
+    expect(described_class.theme_names).to start_with(%w[pink orange green blue custom]).and include("example_theme")
   end
 end

--- a/spec/requests/extensions/theme_translation_spec.rb
+++ b/spec/requests/extensions/theme_translation_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# A theme may override core strings for sites on that theme only (#3368 D19).
+RSpec.describe "Theme-scoped translations", type: :request do
+  let(:ward) { create(:riverside_ward) }
+  let(:london) { create(:partnership, name: "London") }
+  let(:manchester) { create(:partnership, name: "Manchester") }
+
+  def tagged_site(slug, theme)
+    site = create(:site, slug: slug, theme: theme, url: "https://#{slug}.lvh.me")
+    site.neighbourhoods << ward
+    site.tags << [london, manchester]
+    site
+  end
+
+  it "uses the theme's override on a site with that theme" do
+    tagged_site("themed", "example_theme")
+    get "http://themed.lvh.me/events"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Anywhere")
+    expect(response.body).not_to include(">All<")
+  end
+
+  it "leaves other themes on the core string" do
+    tagged_site("plain", "pink")
+    get "http://plain.lvh.me/events"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(">All<")
+    expect(response.body).not_to include("Anywhere")
+  end
+
+  it "falls back to the core string for keys the theme does not override" do
+    tagged_site("themed", "example_theme")
+    get "http://themed.lvh.me/events"
+    expect(response.body).to include(I18n.t("navigation.site.events"))
+  end
+end


### PR DESCRIPTION
WP 2.8 of #3368 plus two coordinator fixes found while wiring it up.

- `group :extensions` block in the Gemfile pinned to `placecal-theme-transdimension` tag `v0.1.1`; `Bundler.require(*Rails.groups, :extensions)` in `config/application.rb` (Rails.groups never includes a custom group). Dockerfile unchanged: it already has git and prunes bundler git checkouts.
- `PlaceCal::ThemeTranslation` + `Current.site`: a theme overrides core strings for sites on that theme only, via `theme_overrides.<theme>.<key>` in its locale files. Replaces the extension's global `I18n.load_path` append, which leaked TD strings into every site (caught by core's region filter spec). Fixture theme and request spec cover it; `doc/extensions.md` updated.
- The `/:slug` catch-all moved from `Rails.application.routes.append` in `config/routes.rb` to an initializer: an append block inside the routes file is re-registered on every routes reload, which made `bin/rails jobs:work` crash with a duplicate `site_page` route name.
- `features/admin/pages.feature`: the reserved-slug scenario now waits for the form before filling it (Turbo navigation race).

Full suite with the extension loaded:
```
rspec --exclude-pattern spec/system: 2174 examples, 0 failures
RUN_SLOW_TESTS=true rspec spec/system: 117 examples, 0 failures, 1 pending
cucumber features/admin: 98 scenarios, 1 failed (the race above; pages.feature then passed 3/3 runs after the fix)
cucumber features/public + authentication: 9 scenarios passed
```