### PR TITLE
WP 1.12: theme footer slot, hero standfirst, listing hero locale keys (#3368)

### DIFF
--- a/app/components/hero.rb
+++ b/app/components/hero.rb
@@ -4,6 +4,8 @@ class Components::Hero < Components::Base
   prop :title, String, :positional
   prop :subtitle, _Nilable(String), :positional, default: ''
   prop :schema, _Nilable(String), :positional, default: nil
+  # Optional lead paragraph under the title; themes fill it via locale keys.
+  prop :standfirst, _Nilable(String), default: nil
 
   def after_initialize
     @title = clean_title(@title)
@@ -21,6 +23,7 @@ class Components::Hero < Components::Base
         else
           h1 { safe(@title) }
         end
+        p(class: 'hero__standfirst') { @standfirst } if @standfirst.present?
       end
     end
   end

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -15,10 +15,10 @@ class Views::Events::Index < Views::Base
   prop :selected_region, _Nilable(::Tag), reader: :private, default: nil
 
   def view_template
-    content_for(:title) { 'Events' }
+    content_for(:title) { t('events.index.page_title') }
     content_for(:description) { site.og_description }
 
-    Hero('Events & activities', site.tagline)
+    Hero(t('events.index.title'), site.tagline, standfirst: t('events.index.standfirst'))
 
     div(class: 'container-public mb-32') do
       turbo_frame_tag 'events-browser', data: { turbo_action: 'advance' } do

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -62,6 +62,9 @@ class Views::Layouts::Application < Phlex::HTML
           end
           if site.nil?
             Directory::Footer()
+          elsif (footer_class = site.theme_definition&.footer_class)
+            # Theme footer slot (#3368 D1): the theme owns the whole footer.
+            render footer_class.new(site: site, navigation: navigation)
           else
             Footer(site)
           end

--- a/app/views/news/index.rb
+++ b/app/views/news/index.rb
@@ -9,9 +9,9 @@ class Views::News::Index < Views::Base
   prop :next_offset, _Nilable(Integer), reader: :private
 
   def view_template
-    content_for(:title) { 'News from your area' }
+    content_for(:title) { t('news.index.page_title') }
 
-    Hero('News from your area', site.tagline)
+    Hero(t('news.index.title'), site.tagline, standfirst: t('news.index.standfirst'))
 
     div(class: 'articles') do
       articles.each do |article|

--- a/app/views/partners/index.rb
+++ b/app/views/partners/index.rb
@@ -10,10 +10,10 @@ class Views::Partners::Index < Views::Base
   prop :selected_region, _Nilable(::Tag), reader: :private, default: nil
 
   def view_template
-    content_for(:title) { 'Partners' }
+    content_for(:title) { t('partners.index.page_title') }
     content_for(:description) { site.og_description }
 
-    Hero('Our Partners', site.tagline)
+    Hero(t('partners.index.title'), site.tagline, standfirst: t('partners.index.standfirst'))
     turbo_frame_tag 'partner_previews' do
       div(class: 'container-public mb-32') do
         Breadcrumb(trail: [['Partners', partners_path]], site_name: site.name) do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -349,6 +349,21 @@ en:
       gfsc_logo_alt: "Geeks for Social Change"
 
   # ===========================================================================
+  # LOCAL SITE LISTING PAGES (heroes; themes override via theme_overrides.*)
+  # ===========================================================================
+
+  partners:
+    index:
+      page_title: "Partners"
+      title: "Our Partners"
+      standfirst: ""
+  news:
+    index:
+      page_title: "News from your area"
+      title: "News from your area"
+      standfirst: ""
+
+  # ===========================================================================
   # LOCAL SITES (subdomain sites)
   # ===========================================================================
 
@@ -366,6 +381,10 @@ en:
   # ===========================================================================
 
   events:
+    index:
+      page_title: "Events"
+      title: "Events & activities"
+      standfirst: ""
     # Day strip event filter (D22): the Today / Tomorrow / next five days
     # navigation rendered for themes with event_filter_style :day_strip.
     filter:

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -69,6 +69,7 @@ initializer "my_ext.register_theme" do
     theme.homepage_view "MyExt::Views::Home"     # Phlex view class name
     theme.map_style     "my_ext"                 # name of public/map-styles/<name>.json
     theme.head          "MyExt::Components::Head" # Phlex component rendered in <head>
+    theme.footer        "MyExt::Components::Footer" # replaces core's site footer; new(site:, navigation:)
     theme.event_filter_style :day_strip          # :date_picker (default) or :day_strip
   end
 end

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -77,6 +77,14 @@ module PlaceCal
       @theme_color = value.to_s
     end
 
+    # @param value [String, nil] Phlex component class name rendered in place
+    #   of core's site footer; constructed with `new(site:, navigation:)`
+    def footer(value = nil)
+      return @footer if value.nil?
+
+      @footer = value.to_s
+    end
+
     # @param value [Symbol, nil] one of EVENT_FILTER_STYLES
     def event_filter_style(value = nil)
       return @event_filter_style if value.nil?
@@ -110,6 +118,11 @@ module PlaceCal
     # @return [Class, nil] the head Phlex component class, or nil
     def head_class
       @head&.constantize
+    end
+
+    # @return [Class, nil] the footer Phlex component class, or nil
+    def footer_class
+      @footer&.constantize
     end
 
     # Human label for admin selects. Themes may translate `themes.<name>.label`.

--- a/spec/fixtures/extensions/example_theme/app/components/example_theme/footer.rb
+++ b/spec/fixtures/extensions/example_theme/app/components/example_theme/footer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Fixture theme footer: rendered by the layout in place of core's Footer for
+# sites on this theme (theme footer slot). Receives the site and the derived
+# navigation tuples.
+class ExampleTheme::Components::Footer < Components::Base
+  prop :site, ::Site
+  prop :navigation, Array, default: -> { [] }
+
+  def view_template
+    footer(class: "example-theme-footer", "data-example-theme": "footer") do
+      p { @site.name }
+      ul { @navigation.each { |label, path| li { a(href: path) { label } } } }
+    end
+  end
+end

--- a/spec/fixtures/extensions/example_theme/config/locales/en.yml
+++ b/spec/fixtures/extensions/example_theme/config/locales/en.yml
@@ -8,3 +8,6 @@ en:
     example_theme:
       region_filter:
         all: Anywhere
+      events:
+        index:
+          standfirst: Fixture standfirst for events

--- a/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
+++ b/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
@@ -29,6 +29,7 @@ module ExampleTheme
         theme.stylesheet "example_theme/theme"
         theme.homepage_view "ExampleTheme::Views::Home"
         theme.head "ExampleTheme::Components::Head"
+        theme.footer "ExampleTheme::Components::Footer"
         theme.event_filter_style :day_strip
       end
     end

--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Theme footer slot and hero standfirst (#3368 D1, D19).
+RSpec.describe "Theme footer slot and hero standfirst", type: :request do
+  let(:ward) { create(:riverside_ward) }
+
+  def site_on(theme, slug)
+    site = create(:site, slug: slug, theme: theme, url: "https://#{slug}.lvh.me")
+    site.neighbourhoods << ward
+    site
+  end
+
+  it "renders the theme footer instead of core's for a themed site" do
+    site = site_on("example_theme", "themed")
+    get "http://themed.lvh.me/events"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('data-example-theme="footer"')
+    expect(response.body).to include(site.name)
+    expect(response.body).not_to include('class="footer__inner')
+    expect(response.body).to include('href="/events"')
+  end
+
+  it "keeps core's footer for other themes" do
+    site_on("pink", "plain")
+    get "http://plain.lvh.me/events"
+    expect(response.body).to include('class="footer__inner')
+    expect(response.body).not_to include('data-example-theme="footer"')
+  end
+
+  it "shows a hero standfirst only when the theme provides one" do
+    site_on("example_theme", "themed")
+    get "http://themed.lvh.me/events"
+    expect(response.body).to include("Fixture standfirst for events")
+    site_on("pink", "plain")
+    get "http://plain.lvh.me/events"
+    expect(response.body).not_to include("hero__standfirst")
+  end
+end


### PR DESCRIPTION
Coordinator WP 1.12 of #3368, from the core-slots list. Theme footer slot (`theme.footer`, rendered by the layout with `new(site:, navigation:)`), `Components::Hero` standfirst, and locale keys for the three listing heroes (previously hardcoded English). Fixture theme exercises both. Gate: rubocop clean; rspec i18n_keys, requests/extensions, lib/placecal, requests/public/{events,partners,articles,sites}, components: 475 examples, 0 failures.