### PR TITLE
Pin placecal-theme-transdimension v0.2.0 (#3368)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'strong_migrations'           # Catch unsafe migrations before they reach pr
 # prebuilt, so the Dockerfile needs no extra build step. Bump the tag to
 # release a new version of an extension.
 group :extensions do
-  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.1.1'
+  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.2.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/geeksforsocialchange/placecal-theme-transdimension.git
-  revision: 6731250b0e756dc651ee74391804b643f17ed62e
-  tag: v0.1.1
+  revision: 927db9431155e0563b5d2e6817f7e76c729997f0
+  tag: v0.2.0
   specs:
     placecal-theme-transdimension (0.1.0)
       rails (>= 8.0)


### PR DESCRIPTION
Bumps the extension to v0.2.0 (TD footer component via the new footer slot, listing intro panels via the hero standfirst, site record corrections). Gate: rspec requests/extensions, lib/placecal, components, requests/public/{sites,events,navigation}, i18n_keys: see output in #3436 log.