### PR TITLE
WP 1.13: second standfirst paragraph on listing heroes (#3368)

### DIFF
--- a/app/components/hero.rb
+++ b/app/components/hero.rb
@@ -6,6 +6,8 @@ class Components::Hero < Components::Base
   prop :schema, _Nilable(String), :positional, default: nil
   # Optional lead paragraph under the title; themes fill it via locale keys.
   prop :standfirst, _Nilable(String), default: nil
+  # Optional second, smaller paragraph after the standfirst.
+  prop :standfirst_detail, _Nilable(String), default: nil
 
   def after_initialize
     @title = clean_title(@title)
@@ -24,6 +26,7 @@ class Components::Hero < Components::Base
           h1 { safe(@title) }
         end
         p(class: 'hero__standfirst') { @standfirst } if @standfirst.present?
+        p(class: 'hero__standfirst-detail') { @standfirst_detail } if @standfirst_detail.present?
       end
     end
   end

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -18,7 +18,8 @@ class Views::Events::Index < Views::Base
     content_for(:title) { t('events.index.page_title') }
     content_for(:description) { site.og_description }
 
-    Hero(t('events.index.title'), site.tagline, standfirst: t('events.index.standfirst'))
+    Hero(t('events.index.title'), site.tagline, standfirst: t('events.index.standfirst'),
+                                                standfirst_detail: t('events.index.standfirst_detail'))
 
     div(class: 'container-public mb-32') do
       turbo_frame_tag 'events-browser', data: { turbo_action: 'advance' } do

--- a/app/views/news/index.rb
+++ b/app/views/news/index.rb
@@ -11,7 +11,8 @@ class Views::News::Index < Views::Base
   def view_template
     content_for(:title) { t('news.index.page_title') }
 
-    Hero(t('news.index.title'), site.tagline, standfirst: t('news.index.standfirst'))
+    Hero(t('news.index.title'), site.tagline, standfirst: t('news.index.standfirst'),
+                                              standfirst_detail: t('news.index.standfirst_detail'))
 
     div(class: 'articles') do
       articles.each do |article|

--- a/app/views/partners/index.rb
+++ b/app/views/partners/index.rb
@@ -13,7 +13,8 @@ class Views::Partners::Index < Views::Base
     content_for(:title) { t('partners.index.page_title') }
     content_for(:description) { site.og_description }
 
-    Hero(t('partners.index.title'), site.tagline, standfirst: t('partners.index.standfirst'))
+    Hero(t('partners.index.title'), site.tagline, standfirst: t('partners.index.standfirst'),
+                                                  standfirst_detail: t('partners.index.standfirst_detail'))
     turbo_frame_tag 'partner_previews' do
       div(class: 'container-public mb-32') do
         Breadcrumb(trail: [['Partners', partners_path]], site_name: site.name) do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,11 +357,13 @@ en:
       page_title: "Partners"
       title: "Our Partners"
       standfirst: ""
+      standfirst_detail: ""
   news:
     index:
       page_title: "News from your area"
       title: "News from your area"
       standfirst: ""
+      standfirst_detail: ""
 
   # ===========================================================================
   # LOCAL SITES (subdomain sites)
@@ -385,6 +387,7 @@ en:
       page_title: "Events"
       title: "Events & activities"
       standfirst: ""
+      standfirst_detail: ""
     # Day strip event filter (D22): the Today / Tomorrow / next five days
     # navigation rendered for themes with event_filter_style :day_strip.
     filter:

--- a/spec/fixtures/extensions/example_theme/config/locales/en.yml
+++ b/spec/fixtures/extensions/example_theme/config/locales/en.yml
@@ -11,3 +11,4 @@ en:
       events:
         index:
           standfirst: Fixture standfirst for events
+          standfirst_detail: Fixture detail for events

--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "Theme footer slot and hero standfirst", type: :request do
     site_on("example_theme", "themed")
     get "http://themed.lvh.me/events"
     expect(response.body).to include("Fixture standfirst for events")
+    expect(response.body).to include('hero__standfirst-detail">Fixture detail for events')
     site_on("pink", "plain")
     get "http://plain.lvh.me/events"
     expect(response.body).not_to include("hero__standfirst")


### PR DESCRIPTION
Coordinator WP 1.13 of #3368. `Components::Hero` gains `standfirst_detail:`; events, partners and news listing heroes read `<ns>.index.standfirst_detail` (blank in core, filled by themes). Fixture and spec updated. Gate: rubocop clean; rspec i18n_keys, requests/extensions, requests/public/{events,partners,articles}, components: 440 examples, 0 failures.