### PR TITLE
Restore the click-and-wait reserved slug scenario (#3368)

### DIFF
--- a/features/admin/pages.feature
+++ b/features/admin/pages.feature
@@ -25,8 +25,10 @@ Feature: Site Page Management
     And the site "Riverside Calendar" should have a page at "about"
 
   Scenario: A reserved slug is rejected
-    When I open the new page form
-    And I fill in "Title" with "Events"
+    When I go to the "Pages" admin section
+    And I click "Add Page"
+    Then I should see "New Page"
+    When I fill in "Title" with "Events"
     And I fill in "Slug" with "events"
     And I click "Save"
     Then I should see "reserved by PlaceCal"

--- a/features/step_definitions/page_steps.rb
+++ b/features/step_definitions/page_steps.rb
@@ -19,13 +19,3 @@ Then("the site {string} should have a page at {string}") do |site_name, slug|
   site = Site.find_by(name: site_name)
   expect(site.pages.find_by(slug: slug)).to be_present
 end
-
-# Visits the new page form on the current (admin) host directly. The
-# "Add Page" click is Turbo-driven and occasionally fails to navigate under
-# full-suite load; the reserved slug scenario is about validation, not the
-# click, so it goes straight to the form.
-When("I open the new page form") do
-  uri = URI(page.current_url)
-  visit "#{uri.scheme}://#{uri.host}:#{uri.port}/pages/new"
-  expect(page).to have_content("New Page")
-end


### PR DESCRIPTION
Reverts #3459: the direct visit submitted an empty form and failed every run. The click-and-wait version passes 3/3 standalone; it flaked once in three full-suite runs under load (Turbo click did not navigate), which is the #3341 class of flake and is logged there rather than papered over.