### PR TITLE
Pin placecal-theme-transdimension v0.2.1 (#3368)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'strong_migrations'           # Catch unsafe migrations before they reach pr
 # prebuilt, so the Dockerfile needs no extra build step. Bump the tag to
 # release a new version of an extension.
 group :extensions do
-  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.2.0'
+  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.2.1'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/geeksforsocialchange/placecal-theme-transdimension.git
-  revision: 927db9431155e0563b5d2e6817f7e76c729997f0
-  tag: v0.2.0
+  revision: 9589bfe07650cd5b7ab2b7e6b81f6d2f758a2308
+  tag: v0.2.1
   specs:
     placecal-theme-transdimension (0.1.0)
       rails (>= 8.0)


### PR DESCRIPTION
Bumps the extension to v0.2.1 (inner-page illustration bands, date numerals, strapline wordmark, partners intro split using the standfirst_detail slot).