### PR TITLE
WP 1.14: theme-overridable event date formats and organiser prefix (#3368)

### DIFF
--- a/app/components/event.rb
+++ b/app/components/event.rb
@@ -101,6 +101,9 @@ class Components::Event < Components::Base
     div(class: 'event__detail event__organiser') do
       raw(view_context.icon(:partner, size: nil))
       plain ' '
+      # Optional prefix such as "by ", blank in core; themes set it.
+      prefix = t('events.card.organiser_prefix')
+      span(class: 'event__organiser-prefix') { prefix } if prefix.present?
       link_to(organiser.name.truncate(25), partner_path(organiser), data: { turbo_frame: '_top' })
     end
   end
@@ -132,11 +135,13 @@ class Components::Event < Components::Base
     end
   end
 
+  # Formats come from locale keys so a theme can change them (for example a
+  # zero-padded day for a big numeral treatment) through theme_overrides.
   def formatted_date(date)
     if date.year == Time.zone.now.year
-      date.strftime('%e %b')
+      date.strftime(t('events.card.date_format'))
     else
-      date.strftime('%e %b %Y')
+      date.strftime(t('events.card.date_format_with_year'))
     end
   end
 

--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -112,7 +112,7 @@ class Components::EventFilter < Components::Base
     case index
     when 0 then t('events.filter.day_strip.today')
     when 1 then t('events.filter.day_strip.tomorrow')
-    else I18n.l(date, format: :day_strip)
+    else date.strftime(t('events.filter.day_strip.date_format'))
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -396,6 +396,14 @@ en:
         today: "Today"
         tomorrow: "Tomorrow"
         all_upcoming: "All upcoming"
+        # strftime pattern for the other day buttons; themes may override
+        date_format: "%a %-d"
+    card:
+      # strftime patterns for the event list date; themes may override
+      date_format: "%e %b"
+      date_format_with_year: "%e %b %Y"
+      # Text before the organiser link in the event list, blank in core
+      organiser_prefix: ""
     csv_export:
       link: "Download events as CSV"
       # Column headers for the events CSV (app/services/events_csv.rb).
@@ -419,7 +427,6 @@ en:
     formats:
       datetime: "%b %-d, %Y %l:%M"
       # Day strip filter buttons, e.g. "Thu 13"
-      day_strip: "%a %-d"
 
   time:
     formats:

--- a/spec/fixtures/extensions/example_theme/config/locales/en.yml
+++ b/spec/fixtures/extensions/example_theme/config/locales/en.yml
@@ -9,6 +9,12 @@ en:
       region_filter:
         all: Anywhere
       events:
+        card:
+          date_format: "%d %b"
+          organiser_prefix: "by "
+        filter:
+          day_strip:
+            date_format: "%a %d %b"
         index:
           standfirst: Fixture standfirst for events
           standfirst_detail: Fixture detail for events

--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -39,3 +39,29 @@ RSpec.describe "Theme footer slot and hero standfirst", type: :request do
     expect(response.body).not_to include("hero__standfirst")
   end
 end
+
+RSpec.describe "Theme-overridable event card and day strip formats", type: :request do
+  let(:ward) { create(:riverside_ward) }
+
+  it "applies the theme's date formats and organiser prefix on a themed site" do
+    site = create(:site, slug: "themed", theme: "example_theme", url: "https://themed.lvh.me")
+    site.neighbourhoods << ward
+    organiser = create(:riverside_partner, address: create(:riverside_address, neighbourhood: ward))
+    create(:event, organiser: organiser, address: nil, dtstart: Time.zone.local(2022, 11, 9, 10), dtend: Time.zone.local(2022, 11, 9, 11))
+    get "http://themed.lvh.me/events?period=future"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("09 Nov")
+    expect(response.body).to include('event__organiser-prefix">by </span>')
+    expect(response.body).to include("Thu 10 Nov")
+  end
+
+  it "keeps core's formats on other themes" do
+    site = create(:site, slug: "plain", theme: "pink", url: "https://plain.lvh.me")
+    site.neighbourhoods << ward
+    organiser = create(:riverside_partner, address: create(:riverside_address, neighbourhood: ward))
+    create(:event, organiser: organiser, address: nil, dtstart: Time.zone.local(2022, 11, 9, 10), dtend: Time.zone.local(2022, 11, 9, 11))
+    get "http://plain.lvh.me/events?period=future"
+    expect(response.body).to include(" 9 Nov")
+    expect(response.body).not_to include("event__organiser-prefix")
+  end
+end


### PR DESCRIPTION
Coordinator WP 1.14 of #3368, from Kim's detail review. Event list date formats, the day strip date format and an optional organiser prefix ("by ") come from locale keys (events.card.*, events.filter.day_strip.date_format) so a theme can set them through theme_overrides. Fixture theme and request specs cover both themed and plain sites. Gate: rubocop clean; rspec i18n_keys, requests/extensions, components/{event,event_filter}, requests/public/{events,partners}: 199 examples, 0 failures.