### PR TITLE
WP 1.15: hero section name and event page date format (#3368)

### DIFF
--- a/app/components/event.rb
+++ b/app/components/event.rb
@@ -20,7 +20,7 @@ class Components::Event < Components::Base
   private
 
   def render_page_layout
-    Hero(summary, @site_tagline)
+    Hero(summary, @site_tagline, section: t('events.show.section'))
     a(class: 'p-name u-url', href: event_path(id), hidden: true) { summary }
     div(class: 'container-public') { render_event_details }
   end
@@ -137,12 +137,13 @@ class Components::Event < Components::Base
 
   # Formats come from locale keys so a theme can change them (for example a
   # zero-padded day for a big numeral treatment) through theme_overrides.
+  # Formats come from locale keys so a theme can change them (for example a
+  # zero-padded day for a big numeral treatment) through theme_overrides.
+  # The page layout has its own keys. `%o` stands for the ordinal day (2nd).
   def formatted_date(date)
-    if date.year == Time.zone.now.year
-      date.strftime(t('events.card.date_format'))
-    else
-      date.strftime(t('events.card.date_format_with_year'))
-    end
+    scope = page? ? 'events.page' : 'events.card'
+    key = date.year == Time.zone.now.year ? 'date_format' : 'date_format_with_year'
+    date.strftime(t("#{scope}.#{key}").gsub('%o', date.day.ordinalize))
   end
 
   def date

--- a/app/components/hero.rb
+++ b/app/components/hero.rb
@@ -8,6 +8,8 @@ class Components::Hero < Components::Base
   prop :standfirst, _Nilable(String), default: nil
   # Optional second, smaller paragraph after the standfirst.
   prop :standfirst_detail, _Nilable(String), default: nil
+  # Optional section name shown above the hero (e.g. "Events" on an event page).
+  prop :section, _Nilable(String), default: nil
 
   def after_initialize
     @title = clean_title(@title)
@@ -16,6 +18,7 @@ class Components::Hero < Components::Base
   def view_template
     div(class: 'hero') do
       div(class: 'container-public') do
+        p(class: 'hero__section') { @section } if @section.present?
         if @subtitle
           h4(class: 'allcaps') { @subtitle }
           div(role: 'presentation', class: 'hero__divider')

--- a/app/views/news/show.rb
+++ b/app/views/news/show.rb
@@ -10,7 +10,7 @@ class Views::News::Show < Views::Base
     content_for(:title) { article.title }
 
     div(vocab: 'http://schema.org/', typeof: 'Article') do
-      Hero(article.title, site.tagline, 'name')
+      Hero(article.title, site.tagline, 'name', section: t('news.show.section'))
       div(class: 'container-public mb-32') do
         Breadcrumb(
           trail: [['News', news_index_path], [article.title, news_path(article)]],

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -75,7 +75,7 @@ class Views::Partners::Show < Views::Base
 
   def render_local_layout
     div do
-      Hero(partner.name, site.tagline)
+      Hero(partner.name, site.tagline, section: t('partners.show.section'))
 
       div(class: 'container-public mb-32') do
         Breadcrumb(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -353,12 +353,16 @@ en:
   # ===========================================================================
 
   partners:
+    show:
+      section: ""
     index:
       page_title: "Partners"
       title: "Our Partners"
       standfirst: ""
       standfirst_detail: ""
   news:
+    show:
+      section: ""
     index:
       page_title: "News from your area"
       title: "News from your area"
@@ -404,6 +408,13 @@ en:
       date_format_with_year: "%e %b %Y"
       # Text before the organiser link in the event list, blank in core
       organiser_prefix: ""
+    page:
+      # strftime patterns for the event page date; %o is the ordinal day
+      date_format: "%e %b"
+      date_format_with_year: "%e %b %Y"
+    show:
+      # Section name above the event page title, blank in core
+      section: ""
     csv_export:
       link: "Download events as CSV"
       # Column headers for the events CSV (app/services/events_csv.rb).

--- a/spec/fixtures/extensions/example_theme/config/locales/en.yml
+++ b/spec/fixtures/extensions/example_theme/config/locales/en.yml
@@ -9,6 +9,10 @@ en:
       region_filter:
         all: Anywhere
       events:
+        show:
+          section: Fixture events section
+        page:
+          date_format: "%o %B %Y"
         card:
           date_format: "%d %b"
           organiser_prefix: "by "

--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -65,3 +65,28 @@ RSpec.describe "Theme-overridable event card and day strip formats", type: :requ
     expect(response.body).not_to include("event__organiser-prefix")
   end
 end
+
+RSpec.describe "Show page section name and page date format", type: :request do
+  let(:ward) { create(:riverside_ward) }
+
+  it "renders the theme's section name and ordinal page date on an event page" do
+    site = create(:site, slug: "themed", theme: "example_theme", url: "https://themed.lvh.me")
+    site.neighbourhoods << ward
+    organiser = create(:riverside_partner, address: create(:riverside_address, neighbourhood: ward))
+    event = create(:event, organiser: organiser, address: nil, dtstart: Time.zone.local(2022, 11, 2, 10), dtend: Time.zone.local(2022, 11, 2, 11))
+    get "http://themed.lvh.me/events/#{event.id}"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('hero__section">Fixture events section</p>')
+    expect(response.body).to include("2nd November 2022")
+  end
+
+  it "renders no section name on other themes" do
+    site = create(:site, slug: "plain", theme: "pink", url: "https://plain.lvh.me")
+    site.neighbourhoods << ward
+    organiser = create(:riverside_partner, address: create(:riverside_address, neighbourhood: ward))
+    event = create(:event, organiser: organiser, address: nil, dtstart: Time.zone.local(2022, 11, 2, 10), dtend: Time.zone.local(2022, 11, 2, 11))
+    get "http://plain.lvh.me/events/#{event.id}"
+    expect(response.body).not_to include("hero__section")
+    expect(response.body).to include(" 2 Nov")
+  end
+end


### PR DESCRIPTION
Coordinator WP 1.15 of #3368, from the visual diff. `Components::Hero` gains `section:` (rendered as `p.hero__section` above the kicker) used by the event, partner and article pages with `<ns>.show.section` keys (blank in core); the event page date reads `events.page.date_format` (with `%o` for the ordinal day) so a theme can show "2nd September 2026". Fixture and request specs cover themed and plain sites. Gate: rubocop clean; rspec i18n_keys, requests/extensions, components/event, requests/public/{events,partners,articles}: 159 examples, 0 failures.