### PR TITLE
WP 1.16: news index strings and date format from locale keys (#3368)

### DIFF
--- a/app/views/news/index.rb
+++ b/app/views/news/index.rb
@@ -21,7 +21,7 @@ class Views::News::Index < Views::Base
     end
 
     p(class: 'articles__pagination') do
-      link_to 'Older news items', "?offset=#{next_offset}" if articles.count == NewsController::ARTICLES_PER_PAGE
+      link_to t('news.index.older'), "?offset=#{next_offset}" if articles.count == NewsController::ARTICLES_PER_PAGE
     end
   end
 
@@ -31,7 +31,7 @@ class Views::News::Index < Views::Base
     div(class: 'articles__article-card g') do
       div(class: 'gi gi__1-5 articles__aside') do
         p(class: 'articles__published', title: article.published_at.to_s) do
-          plain article.published_at.strftime('%B %Y')
+          plain article.published_at.strftime(t('news.index.date_format'))
         end
       end
 
@@ -57,7 +57,7 @@ class Views::News::Index < Views::Base
           end
         end
 
-        p { link_to 'Find out more', news_path(article), class: 'btn btn--alt btn--mt' }
+        p { link_to t('news.index.read_more'), news_path(article), class: 'btn btn--alt btn--mt' }
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,6 +365,10 @@ en:
       section: ""
     index:
       page_title: "News from your area"
+      read_more: "Find out more"
+      older: "Older news items"
+      # strftime pattern for the article card date; themes may override
+      date_format: "%B %Y"
       title: "News from your area"
       standfirst: ""
       standfirst_detail: ""


### PR DESCRIPTION
Coordinator WP 1.16 of #3368, from the visual diff. `Views::News::Index` had hardcoded "Find out more" and "Older news items" and a fixed `%B %Y` date; they now come from `news.index.{read_more,older,date_format}` so a theme can override them. Gate: rubocop clean; rspec i18n_keys, requests/public/articles, requests/extensions: see log.