### PR TITLE
WP 1.17: page slug class on site pages; markdown-free article excerpts (#3368)

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -12,7 +12,11 @@ module ArticlesHelper
     end.join(' | ').html_safe
   end
 
+  # Plain-text excerpt: the body is markdown, so render it and strip the tags
+  # rather than showing raw syntax in listings.
   def article_summary_text(article)
-    truncate article.body.to_s.strip, length: 200, separator: ' '
+    html = Kramdown::Document.new(article.body.to_s).to_html
+    text = ActionController::Base.helpers.strip_tags(html).squish
+    truncate text, length: 200, separator: ' '
   end
 end

--- a/app/views/sites/pages/show.rb
+++ b/app/views/sites/pages/show.rb
@@ -10,7 +10,9 @@ class Views::Sites::Pages::Show < Views::Base
     content_for(:title) { page.title }
     content_for(:description) { page.summary }
 
-    div(class: 'container-public py-8') do
+    # The slug class lets a theme style one page (e.g. its own header art)
+    # without core knowing the page exists.
+    div(class: "container-public py-8 page page--#{page.slug}", data: { page_slug: page.slug }) do
       h1(class: 'h1') { page.title }
 
       div(class: 'markdown-content max-w-(--width-prose-lg) text-base leading-relaxed') do

--- a/spec/requests/public/pages_spec.rb
+++ b/spec/requests/public/pages_spec.rb
@@ -277,3 +277,16 @@ RSpec.describe "Public Pages", type: :request do
     end
   end
 end
+
+RSpec.describe "Site page wrapper", type: :request do
+  it "carries the page slug as a class and data attribute for themes" do
+    ward = create(:riverside_ward)
+    site = create(:site, slug: "wrap", url: "https://wrap.lvh.me")
+    site.neighbourhoods << ward
+    create(:page, site: site, slug: "about", title: "About", body: "Hello", is_published: true)
+    get "http://wrap.lvh.me/about"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("page page--about")
+    expect(response.body).to include('data-page-slug="about"')
+  end
+end


### PR DESCRIPTION
Coordinator WP 1.17 of #3368, from the visual diff. `Views::Sites::Pages::Show` wraps the page in `page page--<slug>` with `data-page-slug` so a theme can style one page (TD's About header art); `article_summary_text` renders the markdown and strips tags so listings no longer show `##` and `**`. Gate: rubocop clean; rspec requests/public/{pages,articles}, helpers, i18n_keys: see log.