### PR TITLE
Pin placecal-theme-transdimension v0.3.0 (#3368)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'strong_migrations'           # Catch unsafe migrations before they reach pr
 # prebuilt, so the Dockerfile needs no extra build step. Bump the tag to
 # release a new version of an extension.
 group :extensions do
-  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.2.2'
+  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.3.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/geeksforsocialchange/placecal-theme-transdimension.git
-  revision: b5ea39d40a64714d872e65d060adc1d9d9ef5b70
-  tag: v0.2.2
+  revision: 6ca2b3e5046720bdaed30fc45fbf2eb6c5ffddfa
+  tag: v0.3.0
   specs:
     placecal-theme-transdimension (0.1.0)
       rails (>= 8.0)


### PR DESCRIPTION
Bumps the extension to v0.3.0: the systematic visual diff pass (doc/visual-diff/*.md in the extension repo) after Kim's review, using the new core slots from WPs 1.15 to 1.17.