### PR TITLE
WP 1.18: theme nav call to action, menu label, engine map styles (#3368)

### DIFF
--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -78,7 +78,22 @@ class Components::Navigation < Components::Base
           li(class: menu_li_classes) { active_link_to(link_text, link_path, data: { turbolinks: false }, base_css_class: menu_link_classes, active_css_class: menu_active_classes) }
         end
         render_join_button if @site.nil?
+        render_theme_cta if theme_cta
       end
+    end
+  end
+
+  # Theme call-to-action (#3368 D1): a theme may register `nav_cta`, for
+  # example a Donate link; core renders it as the last nav item.
+  def theme_cta
+    @theme_cta ||= @site&.theme_definition&.nav_cta
+  end
+
+  def render_theme_cta
+    li(class: 'text-center max-md:py-3 header__cta') do
+      link_to(t(theme_cta[:label_key]), theme_cta[:url],
+              class: 'header__cta-link inline-flex items-center rounded-sm bg-background px-4 py-1.5 text-detail font-bold no-underline',
+              target: '_blank', rel: 'noopener')
     end
   end
 
@@ -168,7 +183,7 @@ class Components::Navigation < Components::Base
                  ['md:hidden']
                end)
            ], data: { action: 'click->mobile-menu#toggle', turbo: 'false' }) do
-      span(class: 'text-base font-semibold') { 'Menu' } if @site.nil?
+      span(class: 'text-base font-semibold header__toggle-label') { t('navigation.menu') }
       raw(view_context.icon(:misc_menu, size: nil, css_class: 'size-8 fill-secondary'))
     end
   end

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -69,10 +69,12 @@ module MapHelper
     # record or an unregistered theme fall back to pink.
     style_name = site_record&.theme_definition&.map_style_for(site_record) || 'pink'
 
-    # Fall back to pink if style file doesn't exist
-    style_path = Rails.public_path.join('map-styles', "#{style_name}.json")
-    style_name = 'pink' unless File.exist?(style_path)
+    # A style ships either in core's public/map-styles or, for extensions, as
+    # an asset at map-styles/<name>.json (e.g. app/assets/builds/map-styles/).
+    # Fall back to pink if neither exists.
+    return "/map-styles/#{style_name}.json" if Rails.public_path.join('map-styles', "#{style_name}.json").exist?
 
-    "/map-styles/#{style_name}.json"
+    asset = Rails.application.assets&.resolver&.resolve("map-styles/#{style_name}.json")
+    asset || '/map-styles/pink.json'
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
   # (#3368 D6), so these are the only fixed items; Pages contribute their own
   # titles.
   navigation:
+    menu: "Menu"
     directory:
       home: "Home"
       partners: "Partners"

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -85,6 +85,18 @@ module PlaceCal
       @footer = value.to_s
     end
 
+    # Optional call-to-action button at the end of the site nav (for example
+    # a Donate link). Rendered as a link to `url` labelled by the locale key.
+    #
+    # @param label_key [String, nil] locale key for the label
+    # @param url [String, nil]
+    # @return [Hash, nil] { label_key:, url: }
+    def nav_cta(label_key = nil, url = nil)
+      return @nav_cta if label_key.nil?
+
+      @nav_cta = { label_key: label_key.to_s, url: url.to_s }
+    end
+
     # @param value [Symbol, nil] one of EVENT_FILTER_STYLES
     def event_filter_style(value = nil)
       return @event_filter_style if value.nil?

--- a/spec/fixtures/extensions/example_theme/app/assets/builds/map-styles/example_theme.json
+++ b/spec/fixtures/extensions/example_theme/app/assets/builds/map-styles/example_theme.json
@@ -1,0 +1,1 @@
+{ "version": 8, "name": "example_theme", "sources": {}, "layers": [] }

--- a/spec/fixtures/extensions/example_theme/config/locales/en.yml
+++ b/spec/fixtures/extensions/example_theme/config/locales/en.yml
@@ -1,5 +1,7 @@
 en:
   example_theme:
+    nav:
+      donate: Donate to the fixture
     home:
       title: Example theme
       heading: Example theme fixture homepage

--- a/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
+++ b/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
@@ -30,6 +30,8 @@ module ExampleTheme
         theme.homepage_view "ExampleTheme::Views::Home"
         theme.head "ExampleTheme::Components::Head"
         theme.footer "ExampleTheme::Components::Footer"
+        theme.nav_cta "example_theme.nav.donate", "https://example.org/donate"
+        theme.map_style "example_theme"
         theme.event_filter_style :day_strip
       end
     end

--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -90,3 +90,33 @@ RSpec.describe "Show page section name and page date format", type: :request do
     expect(response.body).to include(" 2 Nov")
   end
 end
+
+RSpec.describe "Theme nav call to action, menu label and map style", type: :request do
+  let(:ward) { create(:riverside_ward) }
+
+  it "renders the theme's nav call to action and the menu label on a themed site" do
+    site = create(:site, slug: "themed", theme: "example_theme", url: "https://themed.lvh.me")
+    site.neighbourhoods << ward
+    get "http://themed.lvh.me/events"
+    expect(response.body).to include('href="https://example.org/donate"')
+    expect(response.body).to include("Donate to the fixture")
+    expect(response.body).to include('header__toggle-label">Menu<')
+  end
+
+  it "renders no call to action on other themes" do
+    site = create(:site, slug: "plain", theme: "pink", url: "https://plain.lvh.me")
+    site.neighbourhoods << ward
+    get "http://plain.lvh.me/events"
+    expect(response.body).not_to include("header__cta")
+    expect(response.body).to include('header__toggle-label">Menu<')
+  end
+
+  it "resolves a theme map style shipped as an engine asset" do
+    site = create(:site, slug: "themed", theme: "example_theme", url: "https://themed.lvh.me")
+    helper = Class.new { include MapHelper }.new
+    expect(helper.send(:style_url_for_site, site))
+      .to match(%r{\A/assets/map-styles/example_theme-[0-9a-f]+\.json\z})
+    plain = create(:site, slug: "plain", theme: "pink", url: "https://plain.lvh.me")
+    expect(helper.send(:style_url_for_site, plain)).to eq("/map-styles/pink.json")
+  end
+end


### PR DESCRIPTION
From Kim's review. `theme.nav_cta(label_key, url)` renders a call-to-action link as the last nav item (TD's Donate button); the mobile menu toggle always carries its "Menu" label (locale key `navigation.menu`); `MapHelper#style_url_for_site` resolves a theme map style from engine assets (`map-styles/<name>.json`) when core's public dir has none. Fixture and request specs cover themed and plain sites. Gate: rubocop clean; rspec i18n_keys, requests/extensions, lib/placecal, helpers/map_helper, components/navigation, requests/public/sites: see log.