### PR TITLE
WP 2.16: section-aware nav, list heading slot, nav_join switch

### DIFF
--- a/app/components/list_heading.rb
+++ b/app/components/list_heading.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Optional heading between a listing page's hero and its filters, for example
+# "All partners" (#3368). Core ships the locale key empty, so nothing renders
+# unless a theme overrides `<ns>.index.list_heading`.
+class Components::ListHeading < Components::Base
+  prop :text, _Nilable(String), :positional, default: nil
+
+  def view_template
+    return if @text.blank?
+
+    h2(class: 'list-heading') { @text }
+  end
+end

--- a/app/controllers/concerns/site_navigation.rb
+++ b/app/controllers/concerns/site_navigation.rb
@@ -52,6 +52,7 @@ module SiteNavigation
 
   def join_navigation
     return [] if current_site&.contact_email.blank?
+    return [] if current_site.theme_definition&.nav_join? == false
 
     [[t('navigation.site.join'), get_in_touch_path]]
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -77,7 +77,7 @@ module ApplicationHelper
   def active_link_to(title, url, data: Hash, base_css_class: '', active_css_class: 'active')
     current_path = request.original_fullpath
     link_path = Addressable::URI.parse(url).path
-    is_current_path = current_path.match(%r{^#{Regexp.escape(link_path)}/?(\?.*)?$}).present?
+    is_current_path = current_section?(current_path, link_path)
 
     options = {}
     options[:data] = data if data.present?
@@ -85,6 +85,15 @@ module ApplicationHelper
     options['aria-current'] = 'page' if is_current_path
 
     link_to(title, url, options).html_safe
+  end
+
+  # A nav link is current on its own page and on every page beneath it, so
+  # "Events" stays underlined on an event page. The root link only matches
+  # itself, otherwise it would be current everywhere.
+  def current_section?(current_path, link_path)
+    return current_path.match(%r{^/?(\?.*)?$}).present? if link_path == '/'
+
+    current_path.match(%r{^#{Regexp.escape(link_path)}(/.*)?(\?.*)?$}).present?
   end
 
   # Convenience wrapper for humanized model names

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -22,6 +22,7 @@ class Views::Events::Index < Views::Base
                                                 standfirst_detail: t('events.index.standfirst_detail'))
 
     div(class: 'container-public mb-32') do
+      ListHeading(t('events.index.list_heading'))
       turbo_frame_tag 'events-browser', data: { turbo_action: 'advance' } do
         render_paginator
         hr

--- a/app/views/partners/index.rb
+++ b/app/views/partners/index.rb
@@ -17,6 +17,7 @@ class Views::Partners::Index < Views::Base
                                                   standfirst_detail: t('partners.index.standfirst_detail'))
     turbo_frame_tag 'partner_previews' do
       div(class: 'container-public mb-32') do
+        ListHeading(t('partners.index.list_heading'))
         Breadcrumb(trail: [['Partners', partners_path]], site_name: site.name) do
           PartnerFilter(
             site: site,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -361,6 +361,7 @@ en:
       title: "Our Partners"
       standfirst: ""
       standfirst_detail: ""
+      list_heading: ""
   news:
     show:
       section: ""
@@ -397,6 +398,7 @@ en:
       title: "Events & activities"
       standfirst: ""
       standfirst_detail: ""
+      list_heading: ""
     # Day strip event filter (D22): the Today / Tomorrow / next five days
     # navigation rendered for themes with event_filter_style :day_strip.
     filter:

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -33,6 +33,7 @@ module PlaceCal
       @head = nil
       @theme_color = nil
       @event_filter_style = :date_picker
+      @nav_join = true
     end
 
     def core?
@@ -95,6 +96,21 @@ module PlaceCal
       return @nav_cta if label_key.nil?
 
       @nav_cta = { label_key: label_key.to_s, url: url.to_s }
+    end
+
+    # Whether the derived site nav (SiteNavigation) includes the Join link
+    # when the site takes enquiries. A theme whose footer carries the link
+    # instead sets this to false. Defaults to true.
+    #
+    # @param value [Boolean, nil]
+    def nav_join(value = nil)
+      return @nav_join if value.nil?
+
+      @nav_join = value ? true : false
+    end
+
+    def nav_join?
+      @nav_join
     end
 
     # @param value [Symbol, nil] one of EVENT_FILTER_STYLES

--- a/spec/components/list_heading_component_spec.rb
+++ b/spec/components/list_heading_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::ListHeading, type: :component do
+  it "renders the heading when given text" do
+    render_inline(described_class.new("All partners"))
+
+    expect(page).to have_css("h2.list-heading", text: "All partners")
+  end
+
+  it "renders nothing for blank text, so core pages stay unchanged" do
+    render_inline(described_class.new(""))
+
+    expect(page).not_to have_css("h2")
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#current_section?" do
+    it "is current on the link's own page" do
+      expect(helper.current_section?("/events", "/events")).to be(true)
+      expect(helper.current_section?("/events?period=week", "/events")).to be(true)
+    end
+
+    it "stays current on pages beneath the link" do
+      expect(helper.current_section?("/events/123", "/events")).to be(true)
+      expect(helper.current_section?("/partners/some-partner", "/partners")).to be(true)
+    end
+
+    it "does not match a link that is only a prefix of the path" do
+      expect(helper.current_section?("/eventsy", "/events")).to be(false)
+      expect(helper.current_section?("/news", "/events")).to be(false)
+    end
+
+    it "only matches the root link on the root page" do
+      expect(helper.current_section?("/", "/")).to be(true)
+      expect(helper.current_section?("/?region=london", "/")).to be(true)
+      expect(helper.current_section?("/events", "/")).to be(false)
+    end
+  end
+end

--- a/spec/lib/placecal/theme_spec.rb
+++ b/spec/lib/placecal/theme_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe PlaceCal::Theme do
     expect(theme.head).to be_nil
     expect(theme.theme_color).to be_nil
     expect(theme.event_filter_style).to eq(:date_picker)
+    expect(theme).to be_nav_join
+  end
+
+  it "lets a theme drop the Join link from the main nav" do
+    theme.nav_join false
+
+    expect(theme.nav_join).to be(false)
+    expect(theme).not_to be_nav_join
   end
 
   it "sets and reads values through the DSL" do


### PR DESCRIPTION
Three small core changes from Kim's review of the Trans Dimension theme.

- A nav link counts as current for its whole section, so Events stays underlined on an event page.
- Listing pages get an optional heading between the hero and the filters. Core ships it empty; a theme fills `events.index.list_heading` and `partners.index.list_heading`.
- Theme DSL gains `nav_join false` so a theme whose footer carries the Join link can keep it out of the main nav.

Specs: theme DSL, ListHeading component, current_section? helper. Requests and i18n key specs green locally.