### PR TITLE
WP 3.1: theme asset guards, blank theme backfill, cheaper news fallback

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -37,8 +37,8 @@ class NewsController < ApplicationController
   def set_article
     @article = Article.published.friendly.find(params[:id])
   rescue ActiveRecord::RecordNotFound
-    article = published_article_by_title_slug or raise
-    redirect_to news_path(article), status: :moved_permanently
+    slug = published_slug_by_title_slug or raise
+    redirect_to news_path(slug), status: :moved_permanently
   end
 
   # Sites that consumed PlaceCal news through the API built their own URLs
@@ -47,9 +47,18 @@ class NewsController < ApplicationController
   # title-derived slug, send the visitor to the canonical URL instead of a
   # 404. Generic: keyed on nothing site-specific.
   #
-  # @return [Article, nil]
-  def published_article_by_title_slug
+  # Only slugs and titles are read, and only from the articles this site
+  # publishes, so a 404 never loads every article body (#3368 WP 3.1).
+  #
+  # @return [String, nil] canonical slug of the matching article
+  def published_slug_by_title_slug
     wanted = params[:id].to_s
-    Article.published.find { |a| a.title.to_s.parameterize == wanted }
+    return nil if wanted.blank?
+
+    scope = current_site ? Article.for_site(current_site) : Article.all
+    row = scope.published.pluck(:id, :title, :slug).find do |(_id, title, _slug)|
+      title.to_s.parameterize == wanted
+    end
+    row && (row[2].presence || row[0].to_s)
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -22,7 +22,7 @@
 #  place_name        :string
 #  slug              :string           not null
 #  tagline           :string
-#  theme             :string
+#  theme             :string           default("pink")
 #  url               :string           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
@@ -131,7 +131,9 @@ class Site < ApplicationRecord
   validates :contact_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
   # Themes come from the extension registry, not a static list, so an
   # extension can add one without touching this model (#3368, D2).
-  validates :theme, inclusion: { in: ->(_site) { PlaceCal::Extensions.theme_names } }
+  # allow_blank keeps the enumerize-era behaviour where a site could carry no
+  # theme at all and render core's default styling (#3368 WP 3.1).
+  validates :theme, inclusion: { in: ->(_site) { PlaceCal::Extensions.theme_names } }, allow_blank: true
 
   # ==== Scopes ====
   scope :published, -> { where(is_published: true) }
@@ -253,10 +255,10 @@ class Site < ApplicationRecord
   end
 
   # @return [String, nil] asset pipeline stylesheet path for this site's theme,
-  #   or nil when no stylesheet should be linked. The legacy :custom theme
-  #   resolves the per-site asset (themes/custom/<slug>.css) and returns nil
-  #   when it is missing from the pipeline, so the page renders with the
-  #   default styling instead of raising Propshaft::MissingAssetError (#2936).
+  #   or nil when no stylesheet should be linked. Any theme whose stylesheet is
+  #   missing from the pipeline resolves to nil, so the page renders with the
+  #   default styling instead of raising Propshaft::MissingAssetError
+  #   (#2936, #3368 WP 3.1).
   def stylesheet_link
     theme_definition&.stylesheet_for(self)
   end

--- a/db/migrate/20260903170000_backfill_site_theme_default.rb
+++ b/db/migrate/20260903170000_backfill_site_theme_default.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Sites carried a nil theme from the enumerize era. The theme registry
+# (#3368) treats a blank theme as "no theme", which renders unstyled, so
+# backfill the historic default and let the database supply it from now on.
+class BackfillSiteThemeDefault < ActiveRecord::Migration[8.0]
+  def up
+    change_column_default :sites, :theme, 'pink'
+    # sites holds a handful of rows, so a single UPDATE is safe here.
+    safety_assured do
+      execute "UPDATE sites SET theme = 'pink' WHERE theme IS NULL OR theme = ''"
+    end
+  end
+
+  def down
+    change_column_default :sites, :theme, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_03_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -310,7 +310,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_160000) do
     t.bigint "site_admin_id"
     t.string "slug", null: false
     t.string "tagline"
-    t.string "theme"
+    t.string "theme", default: "pink"
     t.datetime "updated_at", precision: nil, null: false
     t.string "url", null: false
     t.index ["events_count"], name: "index_sites_on_events_count"

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -125,10 +125,19 @@ module PlaceCal
 
     # ---- Resolution
 
+    # A theme's stylesheet is only linked when the asset pipeline can resolve
+    # it. A renamed or unbuilt engine CSS file would otherwise raise
+    # Propshaft::MissingAssetError on every page of the site (#3368 WP 3.1).
+    #
     # @param site [Site]
     # @return [String, nil] stylesheet logical path for this site, or nil
     def stylesheet_for(site)
-      resolve(@stylesheet, site)
+      path = resolve(@stylesheet, site)
+      return nil if path.nil?
+      return path if asset_resolves?("#{path}.css")
+
+      Rails.logger.error("PlaceCal theme #{name}: stylesheet #{path}.css does not resolve in the asset pipeline; rendering without it")
+      nil
     end
 
     # @param site [Site]
@@ -140,17 +149,17 @@ module PlaceCal
     # @return [Class, nil] the homepage Phlex view class, or nil when the
     #   theme uses core's default homepage
     def homepage_view_class
-      @homepage_view&.constantize
+      constant_for(@homepage_view, 'homepage_view')
     end
 
     # @return [Class, nil] the head Phlex component class, or nil
     def head_class
-      @head&.constantize
+      constant_for(@head, 'head')
     end
 
     # @return [Class, nil] the footer Phlex component class, or nil
     def footer_class
-      @footer&.constantize
+      constant_for(@footer, 'footer')
     end
 
     # Human label for admin selects. Themes may translate `themes.<name>.label`.
@@ -167,6 +176,28 @@ module PlaceCal
     def resolve(setting, site)
       value = setting.respond_to?(:call) ? setting.call(site) : setting
       value&.to_s.presence
+    end
+
+    # @param logical_path [String] asset path including extension
+    # @return [Boolean] whether Propshaft can serve the asset
+    def asset_resolves?(logical_path)
+      Rails.application.assets&.load_path&.find(logical_path).present?
+    end
+
+    # A theme names its classes as strings so registration can happen before
+    # autoloading is ready. A renamed or removed class must not take the site
+    # down: log it and let core's default render instead (#3368 WP 3.1).
+    #
+    # @param class_name [String, nil]
+    # @param setting [String] which DSL setting is being resolved, for the log
+    # @return [Class, nil]
+    def constant_for(class_name, setting)
+      return nil if class_name.nil?
+
+      class_name.constantize
+    rescue NameError
+      Rails.logger.error("PlaceCal theme #{name}: #{setting} class #{class_name} could not be resolved; falling back to core")
+      nil
     end
   end
 end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -22,7 +22,7 @@
 #  place_name        :string
 #  slug              :string           not null
 #  tagline           :string
-#  theme             :string
+#  theme             :string           default("pink")
 #  url               :string           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null

--- a/spec/lib/placecal/theme_spec.rb
+++ b/spec/lib/placecal/theme_spec.rb
@@ -59,10 +59,27 @@ RSpec.describe PlaceCal::Theme do
     end
 
     it "calls a block with the site when one was given" do
+      mossley = build(:site, slug: "mossley")
       theme.stylesheet { |s| "themes/custom/#{s.slug}" }
       theme.map_style(&:slug)
-      expect(theme.stylesheet_for(site)).to eq("themes/custom/hulme")
+      expect(theme.stylesheet_for(mossley)).to eq("themes/custom/mossley")
       expect(theme.map_style_for(site)).to eq("hulme")
+    end
+
+    it "returns nil and logs when the stylesheet is missing from the pipeline" do
+      allow(Rails.logger).to receive(:error)
+      theme.stylesheet "themes/no-such-theme"
+
+      expect(theme.stylesheet_for(site)).to be_nil
+      expect(Rails.logger).to have_received(:error).with(%r{themes/no-such-theme\.css})
+    end
+
+    it "returns nil and logs when a block resolves to a missing stylesheet" do
+      allow(Rails.logger).to receive(:error)
+      theme.stylesheet { |s| "themes/custom/#{s.slug}" }
+
+      expect(theme.stylesheet_for(site)).to be_nil
+      expect(Rails.logger).to have_received(:error).with(%r{themes/custom/hulme\.css})
     end
 
     it "returns nil when nothing is set or the block returns nil" do
@@ -78,6 +95,22 @@ RSpec.describe PlaceCal::Theme do
       theme.head "Components::Footer"
       expect(theme.homepage_view_class).to eq(Views::Sites::Default)
       expect(theme.head_class).to eq(Components::Footer)
+    end
+
+    it "returns nil and logs when a class name no longer resolves" do
+      theme.homepage_view "Nope::Views::Home"
+      theme.head "Nope::Components::Head"
+      theme.footer "Nope::Components::Footer"
+
+      allow(Rails.logger).to receive(:error)
+
+      expect(theme.homepage_view_class).to be_nil
+      expect(theme.head_class).to be_nil
+      expect(theme.footer_class).to be_nil
+
+      expect(Rails.logger).to have_received(:error).with(/homepage_view class Nope::Views::Home/)
+      expect(Rails.logger).to have_received(:error).with(/head class Nope::Components::Head/)
+      expect(Rails.logger).to have_received(:error).with(/footer class Nope::Components::Footer/)
     end
   end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -22,7 +22,7 @@
 #  place_name        :string
 #  slug              :string           not null
 #  tagline           :string
-#  theme             :string
+#  theme             :string           default("pink")
 #  url               :string           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
@@ -205,6 +205,18 @@ RSpec.describe Site, type: :model do
       expect(build(:site, theme: "late_arrival")).to be_valid
     end
 
+    it "allows a blank theme, as the enumerize-era column did" do
+      site = create(:site, theme: nil)
+      expect(site).to be_valid
+      expect(site.reload.theme).to be_nil
+      expect(site.theme_definition).to be_nil
+      expect(site.stylesheet_link).to be_nil
+    end
+
+    it "allows an empty string theme" do
+      expect(build(:site, theme: "")).to be_valid
+    end
+
     describe "#theme_definition" do
       it "returns the registered theme" do
         site = build(:site, theme: "orange")
@@ -233,6 +245,14 @@ RSpec.describe Site, type: :model do
 
       it "returns nil when the theme is not registered" do
         expect(build(:site, theme: "nope").stylesheet_link).to be_nil
+      end
+
+      it "returns nil and logs when the theme's stylesheet is missing from the pipeline", :theme_registry do
+        PlaceCal::Extensions.register_theme(:ghost) { |theme| theme.stylesheet "ghost/theme" }
+        allow(Rails.logger).to receive(:error)
+
+        expect(build(:site, theme: "ghost").stylesheet_link).to be_nil
+        expect(Rails.logger).to have_received(:error).with(%r{ghost/theme\.css})
       end
     end
   end

--- a/spec/requests/extensions/theme_asset_fallback_spec.rb
+++ b/spec/requests/extensions/theme_asset_fallback_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# WP 3.1 (#3368): a theme whose stylesheet was renamed or never built, and
+# whose view classes no longer exist, must not take its site down. The site
+# renders core's default chrome and the failures are logged.
+RSpec.describe "Theme asset and class fallbacks", :theme_registry, type: :request do
+  let(:ward) { create(:riverside_ward) }
+  let(:site) do
+    create(:site, slug: "brokenly", theme: "brokenly", url: "https://brokenly.lvh.me").tap do |s|
+      s.neighbourhoods << ward
+    end
+  end
+
+  before do
+    PlaceCal::Extensions.register_theme(:brokenly) do |theme|
+      theme.stylesheet "brokenly/theme"
+      theme.homepage_view "Brokenly::Views::Home"
+      theme.head "Brokenly::Components::Head"
+      theme.footer "Brokenly::Components::Footer"
+    end
+    allow(Rails.logger).to receive(:error)
+    # The theme must be registered before the site is validated.
+    site
+  end
+
+  it "renders the site homepage without the missing stylesheet" do
+    get "http://brokenly.lvh.me"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("brokenly/theme")
+    expect(response.body).to include(site.description)
+    expect(Rails.logger).to have_received(:error).with(%r{brokenly/theme\.css})
+  end
+
+  it "renders an inner page without the missing head and footer components" do
+    get "http://brokenly.lvh.me/news"
+
+    expect(response).to have_http_status(:ok)
+    expect(Rails.logger).to have_received(:error).with(/head class Brokenly::Components::Head/)
+  end
+end

--- a/spec/requests/public/redirects_spec.rb
+++ b/spec/requests/public/redirects_spec.rb
@@ -21,9 +21,12 @@ RSpec.describe "Public Redirects", type: :request do
   end
 
   describe "GET /news/:title-derived-slug" do
-    let(:site) { create(:site) }
+    let(:tag) { create(:category) }
+    let(:site) { create(:site).tap { |s| s.tags << tag } }
     let!(:article) do
-      create(:article, title: "Introducting G(END)ER SWAP", slug: "gender-swap-2023", is_draft: false, published_at: 1.day.ago)
+      create(:article, title: "Introducting G(END)ER SWAP", slug: "gender-swap-2023", is_draft: false, published_at: 1.day.ago).tap do |a|
+        a.tags << tag
+      end
     end
 
     it "301s a title-derived slug to the article's canonical slug" do
@@ -35,6 +38,35 @@ RSpec.describe "Public Redirects", type: :request do
     it "still 404s for unknown slugs" do
       get "/news/no-such-article", headers: { "Host" => "#{site.slug}.lvh.me" }
       expect(response).to have_http_status(404)
+    end
+
+    it "does not find an article that belongs to another site" do
+      other_site = create(:site).tap { |s| s.tags << create(:category) }
+
+      get "/news/introducting-g-end-er-swap", headers: { "Host" => "#{other_site.slug}.lvh.me" }
+      expect(response).to have_http_status(404)
+    end
+
+    it "reads only the columns it needs, never article bodies" do
+      queries = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        queries << ActiveSupport::Notifications::Event.new(*args).payload[:sql]
+      end
+
+      begin
+        get "/news/introducting-g-end-er-swap", headers: { "Host" => "#{site.slug}.lvh.me" }
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(response).to have_http_status(301)
+
+      # The fallback plucks the three columns it needs.
+      expect(queries).to include(a_string_matching(/SELECT.*"articles"\."id".*"articles"\."title".*"articles"\."slug".*FROM "articles"/m))
+      # The only whole-row article query is the canonical slug lookup that 404ed;
+      # the fallback never loads article bodies (#3368 WP 3.1).
+      whole_row = queries.select { |sql| sql.include?('SELECT "articles".*') }
+      expect(whole_row.size).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Review fixes from the Opus pass on #3436.

- A theme stylesheet that does not resolve in the asset pipeline is skipped with a logged error instead of raising on every page; homepage, head and footer classes fall back to core when they cannot be constantized.
- Blank site themes validate again, with a migration backfilling pink and setting the column default.
- The news title-slug 404 fallback reads id, title and slug only, scoped to the current site.

Specs: theme, site, redirects, extensions and public requests green (394 examples).