### PR TITLE
WP 3.2: tag-only partner set in SQL, sticky region on the day strip, partners frame advances

### DIFF
--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -122,10 +122,13 @@ class Components::EventFilter < Components::Base
     "#{path}#paginator"
   end
 
+  # The selected region is sticky across the day strip, so it rides along on
+  # every day link and on "All upcoming" (#3368 D20).
   def day_strip_params
     params = {}
     params[:sort] = @sort if @sort.present? && @sort != 'time'
     params[:repeating] = @repeating if @repeating.present? && @repeating != 'on'
+    params[:region] = @selected_region.slug if @selected_region
     params
   end
 

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -212,22 +212,28 @@ class EventsQuery
         .or(base.where(addresses: { neighbourhood_id: site_neighbourhood_ids }))
   end
 
-  # For sites with tags: must load partners for legacy name/postcode address matching
+  # For sites with tags: events organised by, or hosted at, a partner in the
+  # site scope, plus the legacy venue match. The partner set stays in the
+  # database as a subquery, so a tag-only site does not load every partner
+  # row on every events request (#3368).
   def events_for_tagged_site(partners_scope)
-    partner_records = partners_scope.includes(:address).load
-    partner_names = partner_records.map { |p| p.name.downcase }
-    partner_postcodes = partner_records.filter_map(&:address).map { |a| a.postcode.downcase }
+    partner_subquery = partners_scope.select(:id)
+    base = Event.left_joins(:address)
+    base.where(organiser_id: partner_subquery)
+        .or(base.where(place_id: partner_subquery))
+        .or(base.where(legacy_venue_match_sql(partner_subquery)))
+  end
 
-    Event
-      .left_joins(:address)
-      .where(
-        'organiser_id IN (:partner_ids) OR ' \
-        '(lower(addresses.street_address) IN (:partner_names) AND ' \
-        'lower(addresses.postcode) IN (:partner_postcodes))',
-        partner_ids: partner_records.map(&:id),
-        partner_names: partner_names,
-        partner_postcodes: partner_postcodes
-      )
+  # Legacy venue matching, from 2024 (commit 5b90f19), for events whose place
+  # was never set: an event counts as happening at a partner when its address
+  # street line is the partner's name and the postcodes agree.
+  def legacy_venue_match_sql(partner_subquery)
+    <<~SQL.squish
+      EXISTS (SELECT 1 FROM partners venue_partners
+        INNER JOIN addresses venue_addresses ON venue_addresses.id = venue_partners.address_id
+        WHERE venue_partners.id IN (#{partner_subquery.to_sql})
+        AND lower(venue_partners.name) = lower(addresses.street_address) AND lower(venue_addresses.postcode) = lower(addresses.postcode))
+    SQL
   end
 
   # ===================

--- a/app/views/partners/index.rb
+++ b/app/views/partners/index.rb
@@ -15,7 +15,7 @@ class Views::Partners::Index < Views::Base
 
     Hero(t('partners.index.title'), site.tagline, standfirst: t('partners.index.standfirst'),
                                                   standfirst_detail: t('partners.index.standfirst_detail'))
-    turbo_frame_tag 'partner_previews' do
+    turbo_frame_tag 'partner_previews', data: { turbo_action: 'advance' } do
       div(class: 'container-public mb-32') do
         ListHeading(t('partners.index.list_heading'))
         Breadcrumb(trail: [['Partners', partners_path]], site_name: site.name) do

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -722,4 +722,54 @@ RSpec.describe EventsQuery do
       expect(result.values.flatten.map(&:summary)).to contain_exactly("Northern Social", "Hosted Up North")
     end
   end
+
+  describe "site scoping for a tag-only site" do
+    let(:tag_only_site) { create(:site, slug: "tag-only-site") }
+    let(:ward) { create(:riverside_ward) }
+    let(:tag) { create(:partnership, name: "Tagged") }
+    let(:tagged_partner) { create(:partner, name: "Tagged Partner", address: create(:address, neighbourhood: ward)) }
+    let(:untagged_partner) { create(:partner, name: "Untagged Partner", address: create(:address, neighbourhood: ward)) }
+
+    before do
+      tag_only_site.tags << tag
+      tagged_partner.tags << tag
+      create(:future_event, organiser: tagged_partner, summary: "Tagged Social")
+      create(:future_event, organiser: untagged_partner, summary: "Untagged Social")
+    end
+
+    it "returns only events from partners carrying the site tag" do
+      result = described_class.new(site: tag_only_site, day: today).call(period: "future")
+
+      expect(result.values.flatten.map(&:summary)).to eq(["Tagged Social"])
+    end
+
+    it "includes events hosted at a tagged partner" do
+      create(:future_event, organiser: untagged_partner, place: tagged_partner, summary: "Hosted At Tagged")
+
+      result = described_class.new(site: tag_only_site, day: today).call(period: "future")
+
+      expect(result.values.flatten.map(&:summary)).to contain_exactly("Tagged Social", "Hosted At Tagged")
+    end
+
+    it "keeps the partner set in SQL rather than loading partner rows" do
+      queries = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        queries << payload[:sql]
+      end
+
+      begin
+        described_class.new(site: tag_only_site, day: today).call(period: "future")
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      # Preloading the organiser and place of the events we return fetches
+      # partner rows by primary key, which is fine. What must not happen is a
+      # query that pulls the whole site partner set into memory.
+      partner_set_queries = queries.select { |sql| sql.include?('"partners".*') }
+                                   .grep_v(/"partners"\."id" (?:=|IN \()/)
+
+      expect(partner_set_queries).to be_empty
+    end
+  end
 end

--- a/spec/requests/extensions/day_strip_filter_spec.rb
+++ b/spec/requests/extensions/day_strip_filter_spec.rb
@@ -35,6 +35,30 @@ RSpec.describe "Day strip event filter", type: :request do
     end
   end
 
+  context "with two partnership tags and a selected region" do
+    let(:site) do
+      create(:site, slug: "exampled", theme: "example_theme", url: "https://exampled.lvh.me")
+    end
+    let(:north_tag) { create(:partnership, name: "North") }
+    let(:south_tag) { create(:partnership, name: "South") }
+
+    before do
+      site.tags << north_tag
+      site.tags << south_tag
+    end
+
+    it "keeps the region on the day links and on All upcoming" do
+      get "http://exampled.lvh.me/events?region=#{south_tag.slug}"
+
+      today = Time.zone.today
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(
+        "/events/#{today.year}/#{today.month}/#{today.day}?period=day&amp;region=#{south_tag.slug}#paginator"
+      )
+      expect(response.body).to include("/events?period=future&amp;region=#{south_tag.slug}#paginator")
+    end
+  end
+
   context "with a core theme" do
     let(:site) do
       create(:site, slug: "corely", theme: "pink", url: "https://corely.lvh.me")

--- a/spec/requests/public/partners_spec.rb
+++ b/spec/requests/public/partners_spec.rb
@@ -714,6 +714,15 @@ RSpec.describe "Public Partners", type: :request do
         expect(response.body).to include("South Partner")
       end
 
+      it "advances the URL when the partner list frame is swapped" do
+        get partners_url(host: "regions.lvh.me")
+
+        frame = response.body[/<turbo-frame[^>]*id="partner_previews"[^>]*>/]
+
+        expect(frame).to be_present
+        expect(frame).to include('data-turbo-action="advance"')
+      end
+
       it "carries the region on the site navigation links" do
         get partners_url(host: "regions.lvh.me", region: south_tag.slug)
 


### PR DESCRIPTION
Review fixes from the Opus pass on #3436.

- Tag-only sites no longer load every partner on each events request: organiser, place and the legacy venue match are all subqueries. A spec captures SQL and fails on the old code.
- Day strip links and All upcoming keep the selected region.
- The partner list Turbo frame advances the URL, so a region choice on /partners is shareable and survives reload.

Specs: queries, extensions and public partners and events requests green (262 examples), components green (309).