### PR TITLE
WP 3.3: page site move on edit, single-escaped excerpts, fresh URL audit

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -106,7 +106,15 @@ module Admin
     def update
       authorize @page
 
-      if @page.update(permitted_attributes(@page))
+      attributes = attributes_with_submitted_site(permitted_attributes(@page))
+
+      if attributes.nil?
+        flash.now[:danger] = t('admin.pages.flash.site_not_permitted')
+        return render Views::Admin::Pages::Edit.new(page: @page, sites: sites_for_select),
+                      status: :forbidden
+      end
+
+      if @page.update(attributes)
         flash[:success] = t('admin.pages.flash.updated')
         redirect_to edit_admin_page_path(@page)
       else
@@ -153,6 +161,23 @@ module Admin
       return nil if site_id.blank?
 
       sites_for_select.find_by(id: site_id)
+    end
+
+    # A site admin who administers several sites sees an editable Site select,
+    # but site_id is not a permitted attribute for them, so their choice has to
+    # be resolved here against the sites they administer. Returns nil when they
+    # asked for a site they do not administer, so #update can refuse the change
+    # instead of quietly saving the rest and flashing success.
+    def attributes_with_submitted_site(attributes)
+      return attributes if policy(@page).permitted_attributes.include?(:site_id)
+
+      requested_id = params.dig(:page, :site_id)
+      return attributes if requested_id.blank? || requested_id.to_s == @page.site_id.to_s
+
+      site = sites_for_select.find_by(id: requested_id)
+      return nil if site.nil?
+
+      attributes.merge(site_id: site.id)
     end
 
     def require_root_user

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -14,9 +14,16 @@ module ArticlesHelper
 
   # Plain-text excerpt: the body is markdown, so render it and strip the tags
   # rather than showing raw syntax in listings.
+  #
+  # Take the text through Nokogiri rather than strip_tags: strip_tags returns
+  # entity-encoded text, which truncate then escapes a second time, so an "&"
+  # in the body reached the page as a literal "&amp;". Nokogiri decodes the
+  # entities once and lets us drop script and style content entirely. truncate
+  # does the single escape, so no markup from the body reaches the page as HTML.
   def article_summary_text(article)
     html = Kramdown::Document.new(article.body.to_s).to_html
-    text = ActionController::Base.helpers.strip_tags(html).squish
-    truncate text, length: 200, separator: ' '
+    fragment = Nokogiri::HTML5.fragment(html)
+    fragment.css('script, style').each(&:remove)
+    truncate fragment.text.squish, length: 200, separator: ' '
   end
 end

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -475,6 +475,7 @@ en:
         updated: "Page was saved successfully"
         not_updated: "Page was not saved"
         deleted: "Page was deleted"
+        site_not_permitted: "Page was not saved because you do not administer that site"
 
     # -------------------------------------------------------------------------
     # Partners

--- a/doc/audits/td-url-audit-2026-09-02.md
+++ b/doc/audits/td-url-audit-2026-09-02.md
@@ -1,5 +1,7 @@
 # TransDimension URL Audit
 
+Superseded: this is the pre-fix run. See [td-url-audit-2026-09-03.md](td-url-audit-2026-09-03.md) for the post-fix audit.
+
 Date: 2026-09-02
 
 ## Summary

--- a/doc/audits/td-url-audit-2026-09-03.md
+++ b/doc/audits/td-url-audit-2026-09-03.md
@@ -1,0 +1,146 @@
+# TransDimension URL Audit
+
+Date: 2026-09-03
+
+TD: https://transdimension.uk
+
+PlaceCal (production): https://placecal.org
+
+Dev (this branch): http://transdimension.lvh.me:3030
+
+## How to read this run
+
+The **Dev Status** column is the one that matters: it is this branch running locally at `http://transdimension.lvh.me:3030`, so it shows the routing and redirect work in place. The **PC Status** column is live `placecal.org`, which has not had this branch deployed to it yet, so a 404 there is expected for anything fixed on the branch.
+
+`NO DEV DATA` means the path works on production PlaceCal but 404s locally because the local database does not hold the production event, partner and article records. It is an absence of seed data, not a routing problem.
+
+The three remaining `MISSING` rows are legacy news slugs. A PlaceCal article URL is derived from the article title, so reproducing these slugs needs the real production articles, which the dev database does not have. They 404 on production too, so they are unresolved rather than verified: they cannot be confirmed either way from a local run, and should be rechecked against production once this work is deployed.
+
+## Summary
+
+| Verdict      | Count |
+| ------------ | ----- |
+| OK           | 7     |
+| NO DEV DATA  | 104   |
+| MISSING      | 3     |
+| NO ROUTE     | 0     |
+| CHECK FAILED | 0     |
+
+## Details
+
+| Path                                              | TD Status | Route          | PC Status | Dev Status | Verdict     |
+| ------------------------------------------------- | --------- | -------------- | --------- | ---------- | ----------- |
+| `/`                                               | 200       | pages#home     | 200       | 200        | OK          |
+| `/about`                                          | 308       | pages#show     | 404       | 200        | OK          |
+| `/privacy`                                        | 308       | pages#privacy  | 200       | 200        | OK          |
+| `/events`                                         | 308       | events#index   | 200       | 200        | OK          |
+| `/news`                                           | 308       | news#index     | 302       | 200        | OK          |
+| `/partners`                                       | 308       | partners#index | 200       | 200        | OK          |
+| `/join-us`                                        | 308       | pages#show     | 404       | 301        | OK          |
+| `/events/397406`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/397407`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/397408`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/397409`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/397410`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/397411`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/403955`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/403958`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405345`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405346`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405347`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405348`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405349`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405350`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405351`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405352`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405353`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405356`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405357`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405358`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405359`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405360`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405362`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405363`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405364`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405365`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405366`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405367`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405368`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405369`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405370`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405371`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405372`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405378`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405379`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405380`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405381`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405382`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405383`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405384`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405385`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405386`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405387`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405388`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405389`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405390`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405391`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405392`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405393`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/events/405394`                                  | 308       | events#show    | 200       | 404        | NO DEV DATA |
+| `/partners/123`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/124`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/125`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/128`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/129`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/130`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/131`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/132`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/133`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/134`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/135`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/136`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/137`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/138`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/140`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/141`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/142`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/143`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/144`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/146`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/147`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/148`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/149`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/150`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/151`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/152`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/153`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/154`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/156`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/163`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/167`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/169`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/170`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/172`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/173`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/174`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/175`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/176`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/177`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/179`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/188`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/190`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/191`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/192`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/193`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/194`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/195`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/198`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/208`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/partners/209`                                   | 308       | partners#show  | 200       | 404        | NO DEV DATA |
+| `/news/can-you-help-out-with-the-trans-dimension` | 308       | news#show      | 302       | 404        | NO DEV DATA |
+| `/news/greater-manchester-trans-organisers-fund`  | 308       | news#show      | 302       | 404        | NO DEV DATA |
+| `/news/introducting-g-end-er-swap`                | 308       | news#show      | 404       | 404        | MISSING     |
+| `/news/the-outside-project-joins`                 | 308       | news#show      | 404       | 404        | MISSING     |
+| `/news/the-trans-dimension-is-now-in-manchester`  | 308       | news#show      | 302       | 404        | NO DEV DATA |
+| `/news/the-trans-dimension-launches`              | 308       | news#show      | 302       | 404        | NO DEV DATA |
+| `/news/welcoming-velociposse`                     | 308       | news#show      | 404       | 404        | MISSING     |

--- a/lib/tasks/td_url_audit.rake
+++ b/lib/tasks/td_url_audit.rake
@@ -2,6 +2,15 @@
 
 namespace :td do
   desc 'Audit TransDimension URLs for compatibility with PlaceCal'
+  # Checks every legacy TransDimension path three ways: the live TD site, the
+  # live PlaceCal deployment, and a local dev server running this branch. The
+  # dev column is what tells you whether a routing fix on the branch works,
+  # since the fix is not on placecal.org until it deploys.
+  #
+  # Bases can be overridden:
+  #   TD_BASE_URL   default https://transdimension.uk
+  #   PC_BASE_URL   default https://placecal.org
+  #   DEV_BASE_URL  default http://transdimension.lvh.me:3030 (set to '' to skip)
   task 'url_audit', [:urls_file] => :environment do |_t, args|
     urls_file = args[:urls_file] || 'doc/audits/td-url-audit-urls.txt'
 
@@ -13,6 +22,32 @@ namespace :td do
     require 'net/http'
     require 'uri'
 
+    td_base = ENV.fetch('TD_BASE_URL', 'https://transdimension.uk')
+    pc_base = ENV.fetch('PC_BASE_URL', 'https://placecal.org')
+    dev_base = ENV.fetch('DEV_BASE_URL', 'http://transdimension.lvh.me:3030')
+    dev_base = nil if dev_base.blank?
+
+    request_status = lambda do |base, path|
+      uri = URI("#{base}#{path}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
+      http.open_timeout = 5
+      http.read_timeout = 5
+      http.request(Net::HTTP::Head.new(uri.request_uri)).code.to_i
+    rescue StandardError
+      'ERROR'
+    end
+
+    # A single dropped connection or a dev server reloading mid-run should not
+    # be reported as a broken URL, so retry anything that is not a real answer.
+    head_status = lambda do |base, path|
+      status = request_status.call(base, path)
+      return status unless status == 'ERROR' || (status.is_a?(Integer) && status >= 500)
+
+      sleep 1
+      request_status.call(base, path)
+    end
+
     # Read URLs
     paths = File.readlines(urls_file).map(&:strip).reject(&:empty?)
 
@@ -23,6 +58,9 @@ namespace :td do
     Rails.application.routes.default_url_options = { host: 'transdimension.lvh.me' }
 
     puts "Auditing #{paths.length} URLs..."
+    puts "  TD:  #{td_base}"
+    puts "  PC:  #{pc_base}"
+    puts "  DEV: #{dev_base || '(skipped)'}"
     puts ''
 
     paths.each_with_index do |path, idx|
@@ -36,45 +74,27 @@ namespace :td do
         route_result = 'NO ROUTE'
       end
 
-      # Check TD status
-      uri = URI("https://transdimension.uk#{path}")
-      td_status = begin
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        http.open_timeout = 5
-        http.read_timeout = 5
-        request = Net::HTTP::Head.new(uri.request_uri)
-        response = http.request(request)
-        response.code.to_i
-      rescue StandardError
-        'ERROR'
-      end
+      td_status = head_status.call(td_base, path)
+      pc_status = head_status.call(pc_base, path)
+      dev_status = dev_base ? head_status.call(dev_base, path) : nil
 
-      # Check PlaceCal status
-      uri = URI("https://placecal.org#{path}")
-      pc_status = begin
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        http.open_timeout = 5
-        http.read_timeout = 5
-        request = Net::HTTP::Head.new(uri.request_uri)
-        response = http.request(request)
-        response.code.to_i
-      rescue StandardError
-        'ERROR'
-      end
+      # The dev server runs this branch, so it decides the verdict when it is
+      # available. A path that 404s in dev but works in production is missing
+      # local seed data, not a missing route.
+      subject_status = dev_status || pc_status
 
-      # Determine verdict
       verdict = if route_result == 'NO ROUTE'
                   'NO ROUTE'
-                elsif td_status == 'ERROR' || pc_status == 'ERROR'
+                elsif subject_status == 'ERROR'
                   'CHECK FAILED'
-                elsif [200, 301].include?(pc_status)
+                elsif [200, 301, 302, 308].include?(subject_status)
                   'OK'
-                elsif pc_status == 404
+                elsif subject_status == 404 && dev_status == 404 && [200, 301, 302, 308].include?(pc_status)
+                  'NO DEV DATA'
+                elsif subject_status == 404
                   'MISSING'
                 else
-                  "UNKNOWN (#{pc_status})"
+                  "UNKNOWN (#{subject_status})"
                 end
 
       results << {
@@ -82,6 +102,7 @@ namespace :td do
         td_status: td_status,
         route: route_result,
         pc_status: pc_status,
+        dev_status: dev_status,
         verdict: verdict
       }
 
@@ -98,19 +119,20 @@ namespace :td do
 
     # Group by verdict
     by_verdict = results.group_by { |r| r[:verdict] }
+    counts = ->(key) { by_verdict[key]&.length || 0 }
 
     puts ''
     puts 'Summary:'
-    puts "  OK: #{by_verdict['OK']&.length || 0}"
-    puts "  MISSING: #{by_verdict['MISSING']&.length || 0}"
-    puts "  NO ROUTE: #{by_verdict['NO ROUTE']&.length || 0}"
-    puts "  CHECK FAILED: #{by_verdict['CHECK FAILED']&.length || 0}"
-    puts "  UNKNOWN: #{by_verdict['UNKNOWN']&.length || 0}"
+    puts "  OK: #{counts.call('OK')}"
+    puts "  NO DEV DATA: #{counts.call('NO DEV DATA')}"
+    puts "  MISSING: #{counts.call('MISSING')}"
+    puts "  NO ROUTE: #{counts.call('NO ROUTE')}"
+    puts "  CHECK FAILED: #{counts.call('CHECK FAILED')}"
 
     puts ''
     puts 'Issues found:'
     (by_verdict['MISSING'] || []).each do |r|
-      puts "  MISSING: #{r[:path]} (route: #{r[:route]}, TD: #{r[:td_status]}, PC: #{r[:pc_status]})"
+      puts "  MISSING: #{r[:path]} (route: #{r[:route]}, TD: #{r[:td_status]}, PC: #{r[:pc_status]}, DEV: #{r[:dev_status]})"
     end
 
     (by_verdict['NO ROUTE'] || []).each do |r|
@@ -122,29 +144,37 @@ namespace :td do
     end
 
     # Write markdown table
-    output_file = "doc/audits/td-url-audit-#{Time.zone.today.to_s}.md"
+    output_file = "doc/audits/td-url-audit-#{Time.zone.today}.md"
 
     File.open(output_file, 'w') do |f|
       f.puts '# TransDimension URL Audit'
       f.puts ''
       f.puts "Date: #{Time.zone.today}"
       f.puts ''
+      f.puts "TD: #{td_base}"
+      f.puts ''
+      f.puts "PlaceCal (production): #{pc_base}"
+      f.puts ''
+      f.puts "Dev (this branch): #{dev_base || '(skipped)'}"
+      f.puts ''
       f.puts '## Summary'
       f.puts ''
       f.puts '| Verdict | Count |'
       f.puts '|---------|-------|'
-      f.puts "| OK | #{by_verdict['OK']&.length || 0} |"
-      f.puts "| MISSING | #{by_verdict['MISSING']&.length || 0} |"
-      f.puts "| NO ROUTE | #{by_verdict['NO ROUTE']&.length || 0} |"
-      f.puts '| REDIRECT NEEDED | 0 |'
+      f.puts "| OK | #{counts.call('OK')} |"
+      f.puts "| NO DEV DATA | #{counts.call('NO DEV DATA')} |"
+      f.puts "| MISSING | #{counts.call('MISSING')} |"
+      f.puts "| NO ROUTE | #{counts.call('NO ROUTE')} |"
+      f.puts "| CHECK FAILED | #{counts.call('CHECK FAILED')} |"
       f.puts ''
       f.puts '## Details'
       f.puts ''
-      f.puts '| Path | TD Status | Route | PC Status | Verdict |'
-      f.puts '|------|-----------|-------|-----------|---------|'
+      f.puts '| Path | TD Status | Route | PC Status | Dev Status | Verdict |'
+      f.puts '|------|-----------|-------|-----------|------------|---------|'
 
       results.each do |r|
-        f.puts "| `#{r[:path]}` | #{r[:td_status]} | #{r[:route]} | #{r[:pc_status]} | #{r[:verdict]} |"
+        f.puts "| `#{r[:path]}` | #{r[:td_status]} | #{r[:route]} | #{r[:pc_status]} | " \
+               "#{r[:dev_status] || 'n/a'} | #{r[:verdict]} |"
       end
     end
 

--- a/spec/helpers/articles_helper_spec.rb
+++ b/spec/helpers/articles_helper_spec.rb
@@ -24,5 +24,33 @@ RSpec.describe ArticlesHelper, type: :helper do
       output = helper.article_summary_text(article)
       expect(output.length).to eq(200)
     end
+
+    # strip_tags re-encodes entities, so without a decode step "&" arrives at
+    # the browser as the literal "&amp;". The excerpt is escaped exactly once.
+    it "escapes an ampersand exactly once" do
+      article = build(:article, body: "Cats & dogs")
+
+      output = helper.article_summary_text(article)
+      expect(output).to eq("Cats &amp; dogs")
+      expect(CGI.unescapeHTML(output)).to eq("Cats & dogs")
+    end
+
+    it "escapes a quoted phrase exactly once" do
+      article = build(:article, body: 'She said "hello" loudly')
+
+      output = helper.article_summary_text(article)
+      expect(output).not_to include("&amp;")
+      # Kramdown turns straight quotes into typographic ones.
+      expect(CGI.unescapeHTML(output)).to eq("She said \u201Chello\u201D loudly")
+    end
+
+    it "strips a script tag from the body" do
+      article = build(:article, body: "Hello <script>alert('xss')</script> world")
+
+      output = helper.article_summary_text(article)
+      expect(output).not_to include("<script>")
+      expect(output).not_to include("alert")
+      expect(CGI.unescapeHTML(output)).to eq("Hello world")
+    end
   end
 end

--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -134,12 +134,44 @@ RSpec.describe "Admin::Pages", type: :request do
         expect(page_record.reload.title).to eq("About us")
       end
 
+      it "moves a page to another site they administer" do
+        second_site = create(:site, name: "Moss Side", site_admin: site_admin_user)
+
+        patch admin_page_url(page_record, host: admin_host),
+              params: { page: { title: "About us", slug: "about", body: "Updated", site_id: second_site.id } }
+
+        expect(response).to redirect_to(edit_admin_page_path(page_record))
+        expect(page_record.reload.site).to eq(second_site)
+      end
+
+      it "cannot move a page to a site they do not administer" do
+        patch admin_page_url(page_record, host: admin_host),
+              params: { page: { title: "About us", slug: "about", body: "Updated", site_id: other_site.id } }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to include("you do not administer that site")
+        expect(page_record.reload.site).to eq(site)
+        expect(page_record.title).to eq("About Hulme")
+      end
+
       it "cannot update another site's page" do
         patch admin_page_url(other_page, host: admin_host),
               params: { page: { title: "Hacked" } }
 
         expect(response).to redirect_to(admin_root_path)
         expect(other_page.reload.title).to eq("About Other")
+      end
+    end
+
+    context "as a root user" do
+      before { sign_in root_user }
+
+      it "moves a page to any site" do
+        patch admin_page_url(page_record, host: admin_host),
+              params: { page: { title: "About us", slug: "about-us", body: "Updated", site_id: other_site.id } }
+
+        expect(response).to redirect_to(edit_admin_page_path(page_record))
+        expect(page_record.reload.site).to eq(other_site)
       end
     end
   end


### PR DESCRIPTION
Review fixes from the Opus pass on #3436.

- A site admin can move a page between the sites they administer from the edit form; a site they do not administer is refused with a 403 and an error, not a success flash.
- News excerpts decode entities once (Nokogiri text) and drop script and style content, so ampersands and quotes render correctly and nothing from the body reaches the page as HTML.
- The URL audit is re-run against the dev server and committed as doc/audits/td-url-audit-2026-09-03.md: /about and /join-us now resolve; the three legacy news slugs need real production articles and are listed as unverified rather than passed.

Specs: admin pages, helpers, policies green (230 examples); articles and redirects green.