### PR TITLE
WP 3.5: locale keys for filter and breadcrumb labels, menu label opt-in, footer Home, docs

### DIFF
--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -152,7 +152,7 @@ class Components::EventFilter < Components::Base
           (@selected_region ? view_context.hidden_field_tag(:region, @selected_region.slug) : nil),
           view_context.render(Components::Filter.new(
                                 name: 'neighbourhood',
-                                label: 'Neighbourhood',
+                                label: t('filters.neighbourhood'),
                                 items: neighbourhood_items,
                                 selected_id: @selected_neighbourhood,
                                 controller: 'event-filter',

--- a/app/components/footer.rb
+++ b/app/components/footer.rb
@@ -54,12 +54,13 @@ class Components::Footer < Components::Base
     end
   end
 
-  # The footer mirrors the derived site nav (#3368 D6) minus Home, plus the
-  # legal and log-in links the footer has always carried.
+  # The footer mirrors the derived site nav (#3368 D6), plus the legal and
+  # log-in links the footer has always carried.
   def nav_links
     return directory_nav_links if @site.nil?
 
     links = [
+      [t('navigation.site.home'), root_path],
       [t('navigation.site.events'), events_path],
       [t('navigation.site.partners'), partners_path]
     ]
@@ -76,7 +77,7 @@ class Components::Footer < Components::Base
   # OVERRIDABLE_ROUTE_SLUGS), so listing it here too would duplicate the link.
   def site_page_links
     @site.pages.in_nav.reject { |page| page.slug == 'privacy' }
-         .map { |page| [page.title, "/#{page.slug}"] }
+         .map { |page| [page.title, site_page_path(page.slug)] }
   end
 
   def directory_nav_links

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -100,7 +100,7 @@ class Components::Navigation < Components::Base
   # TODO: Change to join.placecal.org once the join flow is live
   def render_join_button
     li(class: 'text-center max-md:py-3') do
-      link_to('Join us', get_in_touch_path, class: 'inline-flex items-center rounded-full bg-secondary px-4 py-1.5 text-detail font-bold no-underline hover:brightness-110 transition-all', style: 'color: #43392f')
+      link_to(t('navigation.directory.join'), get_in_touch_path, class: 'inline-flex items-center rounded-full bg-secondary px-4 py-1.5 text-detail font-bold no-underline hover:brightness-110 transition-all', style: 'color: #43392f')
     end
   end
 
@@ -172,6 +172,12 @@ class Components::Navigation < Components::Base
     ]
   end
 
+  # The directory always labels its menu toggle; a site does so only when its
+  # theme opts in with `menu_label true` (#3368 D1).
+  def show_menu_label?
+    @site.nil? || @site.theme_definition&.menu_label? || false
+  end
+
   def render_toggle
     button(type: 'button', class: [
              'header__toggle row-start-1 col-start-2 flex gap-2 ms-auto me-1.5 items-center',
@@ -183,7 +189,7 @@ class Components::Navigation < Components::Base
                  ['md:hidden']
                end)
            ], data: { action: 'click->mobile-menu#toggle', turbo: 'false' }) do
-      span(class: 'text-base font-semibold header__toggle-label') { t('navigation.menu') }
+      span(class: 'text-base font-semibold header__toggle-label') { t('navigation.menu') } if show_menu_label?
       raw(view_context.icon(:misc_menu, size: nil, css_class: 'size-8 fill-secondary'))
     end
   end

--- a/app/components/partner_filter.rb
+++ b/app/components/partner_filter.rb
@@ -21,7 +21,7 @@ class Components::PartnerFilter < Components::Base
     form_with(**form_data, class: 'filters__form') do
       hidden_field_tag(:region, @selected_region.slug) if @selected_region
       div(class: 'breadcrumb__element breadcrumb__element--last') do
-        span { 'Filter by:' }
+        span { t('filters.filter_by') }
         render_category_filter if show_category_filter?
         render_neighbourhood_filter if show_neighbourhood_filter?
         render_reset_link if any_filter_active?
@@ -45,7 +45,7 @@ class Components::PartnerFilter < Components::Base
     div(class: 'breadcrumb__filters filters') do
       Filter(
         name: 'category',
-        label: 'Category',
+        label: t('filters.category'),
         items: category_items,
         selected_id: @selected_category,
         controller: 'partner-filter-component',
@@ -60,7 +60,7 @@ class Components::PartnerFilter < Components::Base
     div(class: 'breadcrumb__filters filters') do
       Filter(
         name: 'neighbourhood',
-        label: 'Neighbourhood',
+        label: t('filters.neighbourhood'),
         items: neighbourhood_items,
         selected_id: @selected_neighbourhood,
         controller: 'partner-filter-component',
@@ -73,7 +73,7 @@ class Components::PartnerFilter < Components::Base
 
   def render_reset_link
     div(class: 'breadcrumb__filters') do
-      link_to('Reset filters', partners_path(@selected_region ? { region: @selected_region.slug } : {}), class: 'filters__link', data: { turbo_frame: 'partner_previews' })
+      link_to(t('filters.reset'), partners_path(@selected_region ? { region: @selected_region.slug } : {}), class: 'filters__link', data: { turbo_frame: 'partner_previews' })
     end
   end
 

--- a/app/controllers/concerns/site_navigation.rb
+++ b/app/controllers/concerns/site_navigation.rb
@@ -47,7 +47,7 @@ module SiteNavigation
   def page_navigation
     return [] if current_site.nil?
 
-    current_site.pages.in_nav.map { |page| [page.title, "/#{page.slug}"] }
+    current_site.pages.in_nav.map { |page| [page.title, site_page_path(page.slug)] }
   end
 
   def join_navigation

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,6 +91,7 @@ module ApplicationHelper
   # "Events" stays underlined on an event page. The root link only matches
   # itself, otherwise it would be current everywhere.
   def current_section?(current_path, link_path)
+    return false if link_path.blank?
     return current_path.match(%r{^/?(\?.*)?$}).present? if link_path == '/'
 
     current_path.match(%r{^#{Regexp.escape(link_path)}(/.*)?(\?.*)?$}).present?

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -38,7 +38,7 @@ class Views::Events::Index < Views::Base
   def render_paginator
     div(class: 'paginator', id: 'paginator') do
       div(class: 'paginator__context') do
-        Breadcrumb(trail: [['Events', events_path]], site_name: site.name) do
+        Breadcrumb(trail: [[t('navigation.site.events'), events_path]], site_name: site.name) do
           div(class: 'breadcrumb__actions') do
             today = Time.zone.today
             region_param = selected_region ? "&region=#{selected_region.slug}" : ''

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -11,6 +11,10 @@ class Views::Layouts::Application < Phlex::HTML
   include Phlex::Rails::Helpers::Request
   include Components
 
+  # I18n translate helper, theme-aware (PlaceCal::ThemeTranslation), so a theme
+  # can override page metadata strings for its own sites (#3368 D19).
+  include PlaceCal::ThemeTranslation
+
   def view_template
     doctype
     html(lang: 'en') do
@@ -113,7 +117,7 @@ class Views::Layouts::Application < Phlex::HTML
     elsif site
       # Generated share card for site homepages and other site pages (#2077)
       meta(property: 'og:image', content: og_image_url)
-      meta(property: 'og:image:alt', content: I18n.t('og_image.alt.site', name: site.name))
+      meta(property: 'og:image:alt', content: t('og_image.alt.site', name: site.name))
       meta(property: 'og:image:width', content: '1200')
       meta(property: 'og:image:height', content: '630')
     else
@@ -163,7 +167,7 @@ class Views::Layouts::Application < Phlex::HTML
     if content_for?(:description)
       content_for(:description).to_s
     else
-      I18n.t('meta.description', site: site&.name)
+      t('meta.description', site: site&.name)
     end
   end
 

--- a/app/views/news/show.rb
+++ b/app/views/news/show.rb
@@ -13,7 +13,7 @@ class Views::News::Show < Views::Base
       Hero(article.title, site.tagline, 'name', section: t('news.show.section'))
       div(class: 'container-public mb-32') do
         Breadcrumb(
-          trail: [['News', news_index_path], [article.title, news_path(article)]],
+          trail: [[t('navigation.site.news'), news_index_path], [article.title, news_path(article)]],
           site_name: site.name
         )
         hr

--- a/app/views/partners/index.rb
+++ b/app/views/partners/index.rb
@@ -18,7 +18,7 @@ class Views::Partners::Index < Views::Base
     turbo_frame_tag 'partner_previews', data: { turbo_action: 'advance' } do
       div(class: 'container-public mb-32') do
         ListHeading(t('partners.index.list_heading'))
-        Breadcrumb(trail: [['Partners', partners_path]], site_name: site.name) do
+        Breadcrumb(trail: [[t('navigation.site.partners'), partners_path]], site_name: site.name) do
           PartnerFilter(
             site: site,
             selected_category: selected_category,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
       partners: "Partners"
       partnerships: "Partnerships"
       events: "Events"
+      join: "Join us"
     site:
       home: "Home"
       events: "Events"
@@ -63,6 +64,14 @@ en:
 
   footer:
     site_navigation: "Site Navigation"
+
+  # Labels for the partner and event listing filters on a site (the nationwide
+  # directory has its own set under directory.filters).
+  filters:
+    filter_by: "Filter by:"
+    category: "Category"
+    neighbourhood: "Neighbourhood"
+    reset: "Reset filters"
 
   # Region selector shown on local sites with more than one Partnership tag
   # (#3368 D7). Labels only: the URL param is always ?region=<tag slug>, so a

--- a/db/migrate/20260902120000_create_pages.rb
+++ b/db/migrate/20260902120000_create_pages.rb
@@ -6,7 +6,7 @@
 class CreatePages < ActiveRecord::Migration[8.0]
   def change
     create_table :pages do |t|
-      t.references :site, null: false, foreign_key: true, index: true
+      t.references :site, null: false, foreign_key: true, index: false
       t.string :slug, null: false
       t.string :title, null: false
       t.text :body

--- a/db/migrate/20260903160000_remove_redundant_pages_site_id_index.rb
+++ b/db/migrate/20260903160000_remove_redundant_pages_site_id_index.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# index_pages_on_site_id is covered by the unique [site_id, slug] index.
-class RemoveRedundantPagesSiteIdIndex < ActiveRecord::Migration[8.0]
-  def change
-    remove_index :pages, name: :index_pages_on_site_id, column: :site_id
-  end
-end

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -23,7 +23,7 @@ Extensions are Rails engines generated with `rails plugin new --full` (NOT `--mo
     locales/en.yml        # Locale strings (loaded automatically by Rails)
 ```
 
-The engine's `app/controllers` and `config/routes.rb` exist only in core's fixture engine (for testing); real extensions have neither.
+An extension normally has no controllers: core's controllers serve every page and the extension supplies views, components and copy. An engine _may_ draw routes in its own `config/routes.rb` (they load after core's `config/routes.rb`, so they win over core's `/:slug` site-page catch-all, which is appended last by `config/initializers/site_page_routes.rb`), but a theme that needs new routes is usually a sign the feature belongs in core. Core's fixture engine under `spec/` has both, for testing.
 
 ## Phlex namespaces
 
@@ -65,17 +65,42 @@ The engine registers a theme during initialization (before core's `config/initia
 ```ruby
 initializer "my_ext.register_theme" do
   PlaceCal::Extensions.register_theme(:my_ext) do |theme|
-    theme.stylesheet    "my_ext/theme"           # logical path, see CSS build below
-    theme.homepage_view "MyExt::Views::Home"     # Phlex view class name
-    theme.map_style     "my_ext"                 # name of public/map-styles/<name>.json
-    theme.head          "MyExt::Components::Head" # Phlex component rendered in <head>
-    theme.footer        "MyExt::Components::Footer" # replaces core's site footer; new(site:, navigation:)
-    theme.event_filter_style :day_strip          # :date_picker (default) or :day_strip
+    theme.stylesheet    "my_ext/theme"
+    theme.homepage_view "MyExt::Views::Home"
+    theme.map_style     "my_ext"
+    theme.head          "MyExt::Components::Head"
+    theme.footer        "MyExt::Components::Footer"
+    theme.theme_color   "#f19089"
+    theme.nav_cta       "my_ext.nav.donate", "https://example.org/donate"
+    theme.nav_join      false
+    theme.menu_label    true
+    theme.event_filter_style :day_strip
   end
 end
 ```
 
-All settings are optional. `stylesheet` and `map_style` may receive a block that gets the Site, for lookups that depend on the record (core's legacy `custom` theme resolves by site slug that way).
+Every setting is optional, and the full list is defined in `lib/placecal/theme.rb`:
+
+| Setting              | Value                                                                | Default              | What it does                                                                                                                                             |
+| -------------------- | -------------------------------------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stylesheet`         | asset logical path without the extension, or a block taking the Site | none                 | Linked in `<head>` after core's stylesheets. Skipped with an error in the log if the asset does not resolve, so a stale build cannot take the site down. |
+| `homepage_view`      | Phlex view class name (String)                                       | core's site homepage | Renders the site's homepage.                                                                                                                             |
+| `map_style`          | MapLibre style name, or a block taking the Site                      | `pink`               | See "Map styles" below.                                                                                                                                  |
+| `head`               | Phlex component class name                                           | none                 | Rendered inside `<head>`, for fonts, meta tags and the like.                                                                                             |
+| `footer`             | Phlex component class name                                           | core's footer        | Replaces core's site footer. Constructed with `new(site:, navigation:)`.                                                                                 |
+| `theme_color`        | hex colour, e.g. `"#f19089"`                                         | none                 | `theme-color` value in the web manifest.                                                                                                                 |
+| `nav_cta`            | locale key and URL                                                   | none                 | A call-to-action link (for example Donate) rendered as the last item in the site nav.                                                                    |
+| `nav_join`           | boolean                                                              | `true`               | Whether the derived nav includes the Join link when the site takes enquiries. Set `false` when the theme's own footer carries it.                        |
+| `event_filter_style` | `:date_picker` or `:day_strip`                                       | `:date_picker`       | Which date control the events filter renders.                                                                                                            |
+| `menu_label`         | boolean                                                              | `false`              | Whether the mobile menu toggle shows a "Menu" text label next to the icon.                                                                               |
+
+Class names are given as strings and resolved lazily, so registration can run before autoloading is ready; a name that no longer resolves is logged and core's default renders instead.
+
+`stylesheet` and `map_style` may receive a block that gets the Site, for lookups that depend on the record (core's legacy `custom` theme resolves by site slug that way).
+
+## Map styles
+
+`map_style` names a MapLibre style JSON. Core's own styles live in `public/map-styles/<name>.json`; an extension ships its style as an engine asset at `app/assets/builds/map-styles/<name>.json`, which Propshaft picks up and serves at the same logical path. `MapHelper#style_url_for_site` checks core's public directory first, then the asset pipeline, and falls back to `pink.json` if neither has it.
 
 ## Locale files
 
@@ -90,6 +115,19 @@ en:
     my_ext:
       region_filter:
         all: Everywhere
+```
+
+Keep the overrides in their own file (`config/locales/overrides.en.yml` by convention) so it is obvious which strings the theme rewrites and which are its own.
+
+Some core strings exist only as override slots: core ships them empty so nothing renders, and a theme fills them in. The listing pages carry one such slot, `<ns>.index.list_heading` (`partners.index.list_heading`, `events.index.list_heading`), which `Components::ListHeading` renders as an `h2` between the hero and the filters when it is not blank:
+
+```yaml
+en:
+  theme_overrides:
+    my_ext:
+      partners:
+        index:
+          list_heading: All partners
 ```
 
 ## Stylesheet and CSS build

--- a/features/admin/pages.feature
+++ b/features/admin/pages.feature
@@ -28,6 +28,9 @@ Feature: Site Page Management
     Then I should see a success message
     And the site "Riverside Calendar" should have a page at "about"
 
+  # @wip: the Add Page click is swallowed when this runs after another
+  # scenario in the same browser (CI and local, three runs logged on #3341).
+  # Admin create is covered by spec/requests/admin/pages_spec.rb.
   @wip
   Scenario: A reserved slug is rejected
     When I go to the "Pages" admin section

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -32,8 +32,11 @@ module PlaceCal
       @map_style = nil
       @head = nil
       @theme_color = nil
+      @footer = nil
+      @nav_cta = nil
       @event_filter_style = :date_picker
       @nav_join = true
+      @menu_label = false
     end
 
     def core?
@@ -111,6 +114,21 @@ module PlaceCal
 
     def nav_join?
       @nav_join
+    end
+
+    # Whether the mobile menu toggle shows a "Menu" text label beside the icon.
+    # The nationwide directory always shows it; sites show it only when their
+    # theme opts in. Defaults to false.
+    #
+    # @param value [Boolean, nil]
+    def menu_label(value = nil)
+      return @menu_label if value.nil?
+
+      @menu_label = value ? true : false
+    end
+
+    def menu_label?
+      @menu_label
     end
 
     # @param value [Symbol, nil] one of EVENT_FILTER_STYLES

--- a/spec/components/footer_component_spec.rb
+++ b/spec/components/footer_component_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Components::Footer, type: :component do
       it "renders the derived nav in order" do
         expect(footer_nav_labels).to eq(
           [
+            I18n.t("navigation.site.home"),
             I18n.t("navigation.site.events"),
             I18n.t("navigation.site.partners"),
             I18n.t("navigation.site.news"),
@@ -68,6 +69,7 @@ RSpec.describe Components::Footer, type: :component do
       it "renders only the core links" do
         expect(footer_nav_labels).to eq(
           [
+            I18n.t("navigation.site.home"),
             I18n.t("navigation.site.events"),
             I18n.t("navigation.site.partners"),
             I18n.t("navigation.site.privacy"),

--- a/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
+++ b/spec/fixtures/extensions/example_theme/lib/example_theme/engine.rb
@@ -32,6 +32,7 @@ module ExampleTheme
         theme.footer "ExampleTheme::Components::Footer"
         theme.nav_cta "example_theme.nav.donate", "https://example.org/donate"
         theme.map_style "example_theme"
+        theme.menu_label true
         theme.event_filter_style :day_strip
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,5 +24,10 @@ RSpec.describe ApplicationHelper do
       expect(helper.current_section?("/?region=london", "/")).to be(true)
       expect(helper.current_section?("/events", "/")).to be(false)
     end
+
+    it "is never current when the link has no path" do
+      expect(helper.current_section?("/events", nil)).to be(false)
+      expect(helper.current_section?("/events", "")).to be(false)
+    end
   end
 end

--- a/spec/lib/placecal/theme_spec.rb
+++ b/spec/lib/placecal/theme_spec.rb
@@ -17,8 +17,19 @@ RSpec.describe PlaceCal::Theme do
     expect(theme.map_style).to be_nil
     expect(theme.head).to be_nil
     expect(theme.theme_color).to be_nil
+    expect(theme.footer).to be_nil
+    expect(theme.nav_cta).to be_nil
     expect(theme.event_filter_style).to eq(:date_picker)
     expect(theme).to be_nav_join
+    expect(theme.menu_label).to be(false)
+    expect(theme).not_to be_menu_label
+  end
+
+  it "lets a theme label the mobile menu toggle" do
+    theme.menu_label true
+
+    expect(theme.menu_label).to be(true)
+    expect(theme).to be_menu_label
   end
 
   it "lets a theme drop the Join link from the main nav" do

--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -103,12 +103,12 @@ RSpec.describe "Theme nav call to action, menu label and map style", type: :requ
     expect(response.body).to include('header__toggle-label">Menu<')
   end
 
-  it "renders no call to action on other themes" do
+  it "renders no call to action and no menu label on other themes" do
     site = create(:site, slug: "plain", theme: "pink", url: "https://plain.lvh.me")
     site.neighbourhoods << ward
     get "http://plain.lvh.me/events"
     expect(response.body).not_to include("header__cta")
-    expect(response.body).to include('header__toggle-label">Menu<')
+    expect(response.body).not_to include("header__toggle-label")
   end
 
   it "resolves a theme map style shipped as an engine asset" do


### PR DESCRIPTION
Minor items from the Opus review of #3436.

- Breadcrumb, filter and directory Join labels move to locale keys; the layout uses the theme-aware t.
- Mobile Menu label is now a theme opt-in (menu_label) so existing sites render as before; site footers get their Home link back.
- current_section? ignores blank link paths.
- doc/extensions.md documents every DSL setting, engine map styles, routes and the list heading slot.
- The pages site_id index churn is collapsed into the create migration; schema unchanged.
- Site page links use the named route.

Specs: components, helpers, lib, public and extension requests, i18n keys green (782 examples).