### PR TITLE
WP 3.6: translation shim fixes, cached news count, sitemap and route tidy-ups, homepage region filter

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -111,8 +111,25 @@ class SitemapsController < ApplicationController
   end
 
   # terms-of-use is directory-only; privacy and get-in-touch resolve on both.
+  # A site that takes no enquiries has no Join link (SiteNavigation#join_navigation),
+  # so /get-in-touch should not be advertised for it either. A slug the site
+  # publishes as its own page is dropped here and emitted once, with a lastmod,
+  # by #site_page_entries.
   def static_page_slugs
-    current_site ? %w[privacy get-in-touch] : %w[privacy terms-of-use get-in-touch]
+    slugs = current_site ? %w[privacy get-in-touch] : %w[privacy terms-of-use get-in-touch]
+    slugs -= %w[get-in-touch] if current_site && current_site.contact_email.blank?
+    slugs - site_page_slugs
+  end
+
+  # @return [Array<String>] slugs of the current site's published pages
+  def site_page_slugs
+    site_pages.map(&:first)
+  end
+
+  def site_pages
+    return [] unless current_site
+
+    @site_pages ||= current_site.pages.published.pluck(:slug, :updated_at)
   end
 
   def articles_scope
@@ -136,14 +153,12 @@ class SitemapsController < ApplicationController
 
     urls.concat(site_page_entries)
 
-    wrap_urlset(urls)
+    wrap_urlset(urls.uniq)
   end
 
   # Editable per-site pages (WP 1.1).
   def site_page_entries
-    return [] unless current_site
-
-    current_site.pages.published.pluck(:slug, :updated_at).map do |slug, updated_at|
+    site_pages.map do |slug, updated_at|
       url_entry("#{base_url}/#{slug}", updated_at)
     end
   end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -27,11 +27,18 @@ class SitesController < ApplicationController
 
   private
 
+  # The homepage help cards honour the region control above them (#3368 D7):
+  # a selected region is a Partnership tag, the same filter the partner index
+  # applies (PartnersController#render_local_index).
   def set_places_to_get_computer_access
-    @places_to_get_computer_access = PartnersQuery.new(site: current_site).call(tag_slug: 'computers')
+    @places_to_get_computer_access = homepage_partners('computers')
   end
 
   def set_places_with_free_wifi
-    @places_with_free_wifi = PartnersQuery.new(site: current_site).call(tag_slug: 'wifi')
+    @places_with_free_wifi = homepage_partners('wifi')
+  end
+
+  def homepage_partners(tag_slug)
+    PartnersQuery.new(site: current_site).call(tag_slug: tag_slug, partnership_id: current_region&.id)
   end
 end

--- a/app/mailers/join_mailer.rb
+++ b/app/mailers/join_mailer.rb
@@ -3,8 +3,10 @@
 class JoinMailer < ApplicationMailer
   def join_us(join)
     site = join.site
+    # A newline in the interpolated name would let it inject extra mail
+    # headers, so it never reaches the Subject header intact.
     subject = if site
-                t('join_mailer.join_us.subject_with_site', site: site.name)
+                t('join_mailer.join_us.subject_with_site', site: site.name.to_s.delete("\r\n"))
               else
                 t('join_mailer.join_us.subject')
               end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -186,14 +186,21 @@ class Site < ApplicationRecord
   end
 
   # Whether a site shows News in its nav is derived from this count (#3368 D6),
-  # so it is asked once per request; memoised per instance.
+  # so every page of every site runs it. Memoised per instance for the request
+  # and cached across requests for ten minutes.
+  #
+  # There is no cheap invalidation hook: an Article belongs to a site only
+  # indirectly, through its partners and tags (Article.for_site), so saving one
+  # article can change the count for any number of sites. Rather than sweep
+  # every site on every article save, the count goes stale for at most the TTL,
+  # which only ever means a News link appearing or leaving the nav a few
+  # minutes late.
   #
   # @return [Integer] published articles count for this site
   def news_article_count
-    @news_article_count ||= Article
-                            .for_site(self)
-                            .published
-                            .count
+    @news_article_count ||= Rails.cache.fetch(['site', id, 'news_article_count'], expires_in: 10.minutes) do
+      Article.for_site(self).published.count
+    end
   end
 
   # @return [Boolean] whether neighbourhood badges should be shown

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -8,7 +8,8 @@
 # Each built-in stylesheet is app/assets/stylesheets/themes/<name>.scss,
 # built by dartsass (config/initializers/dartsass.rb), with a matching
 # public/map-styles/<name>.json.
-THEME_COLORS = {
+# A local, not a top-level constant: nothing outside this file needs it.
+theme_colors = {
   pink: '#f19089',
   orange: '#fe9263',
   green: '#afcf5a',
@@ -19,7 +20,7 @@ THEME_COLORS = {
   PlaceCal::Extensions.register_theme(name, core: true) do |theme|
     theme.stylesheet "themes/#{name}"
     theme.map_style name
-    theme.theme_color THEME_COLORS[name.to_sym]
+    theme.theme_color theme_colors[name.to_sym]
   end
 end
 

--- a/config/initializers/site_page_routes.rb
+++ b/config/initializers/site_page_routes.rb
@@ -10,5 +10,10 @@
 # the route name twice. Page validates its slug against the reserved first
 # path segments derived from the finished route set.
 Rails.application.routes.append do
-  get '/:slug', to: 'pages#show', as: :site_page, constraints: { slug: /[a-z0-9-]+/ }
+  # HTML only: without the constraint /about.json served the HTML page under a
+  # JSON content type. The default fills the format in for the extensionless
+  # /about so it still matches.
+  get '/:slug(.:format)', to: 'pages#show', as: :site_page,
+                          constraints: { slug: /[a-z0-9-]+/, format: 'html' },
+                          defaults: { format: :html }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,8 @@ Rails.application.routes.draw do
         delete :clear_address
       end
     end
-    resources :pages
+    # No admin show action: pages are edited, and previewed on the public site.
+    resources :pages, except: [:show]
     resources :partnerships
     resources :sites
     resources :supporters

--- a/lib/placecal/extensions.rb
+++ b/lib/placecal/extensions.rb
@@ -24,9 +24,24 @@ module PlaceCal
     def register_theme(name, core: false)
       theme = Theme.new(name, core: core)
       yield theme if block_given?
+      warn_on_reregistration(theme.name)
       registry[theme.name] = theme
       theme
     end
+
+    # Two extensions claiming the same theme name is a silent hijack: the last
+    # one to boot wins and the other extension's sites change appearance. Say
+    # so in the log. Specs replace registrations deliberately, so stay quiet
+    # there.
+    def warn_on_reregistration(name)
+      return if Rails.env.test?
+      return unless registry.key?(name)
+
+      Rails.logger.warn(
+        "PlaceCal::Extensions: theme #{name.inspect} was already registered; the previous definition has been replaced"
+      )
+    end
+    private_class_method :warn_on_reregistration
 
     # @return [Array<PlaceCal::Theme>] core themes first, then extension
     #   themes, each group in registration order
@@ -60,9 +75,11 @@ module PlaceCal
       registry.clear
     end
 
-    # @return [Hash] a copy of the registry state, for #restore
+    # @return [Hash] a copy of the registry state, for #restore. Each theme is
+    #   duplicated too, so a spec that reconfigures a registered theme in place
+    #   cannot leak that change into later examples.
     def snapshot
-      registry.dup
+      registry.transform_values(&:dup)
     end
 
     # @param state [Hash] a value from #snapshot

--- a/lib/placecal/theme_translation.rb
+++ b/lib/placecal/theme_translation.rb
@@ -15,11 +15,55 @@ module PlaceCal
   module ThemeTranslation
     OVERRIDE_SCOPE = 'theme_overrides'
 
-    def t(key, **)
-      theme = Current.site&.theme_definition
-      return I18n.t(key, **) unless theme && key.is_a?(String) && !key.start_with?('.')
+    # Interpolation keys I18n itself owns; every other option is caller data
+    # and gets escaped for an `_html` key, as ActionView's `t` does.
+    RESERVED_INTERPOLATIONS = %i[count default scope locale raise throw separator].freeze
 
-      I18n.t("#{OVERRIDE_SCOPE}.#{theme.name}.#{key}", **, default: key.to_sym)
+    def t(key, **options)
+      theme = Current.site&.theme_definition
+      options = escape_html_interpolations(key, options)
+
+      value =
+        if theme && key.is_a?(String) && !key.start_with?('.')
+          theme_scoped_translation(theme, key, **options)
+        elsif defined?(super)
+          # A lazy ('.foo') key only means anything to the including class's
+          # own `t` (controllers, ActionView), which knows the current scope.
+          super
+        else
+          I18n.t(key, **options)
+        end
+
+      html_key?(key) && value.is_a?(String) ? value.html_safe : value # rubocop:disable Rails/OutputSafety
+    end
+
+    private
+
+    # Try the theme's override first, then the key the caller asked for, then
+    # whatever defaults the caller supplied.
+    def theme_scoped_translation(theme, key, **options)
+      scoped = "#{OVERRIDE_SCOPE}.#{theme.name}.#{key}"
+      # The scoped key is absolute, so there is nothing the including class's
+      # own `t` would add here; go straight to I18n.
+      I18n.t(scoped, **options, default: [key.to_sym, *Array(options[:default])])
+    rescue I18n::MissingTranslationData => e
+      # Report the key the caller wrote, not the theme_overrides path they
+      # have never heard of.
+      raise I18n::MissingTranslationData.new(e.locale, key, e.options)
+    end
+
+    def escape_html_interpolations(key, options)
+      return options unless html_key?(key)
+
+      options.to_h do |name, value|
+        next [name, value] if RESERVED_INTERPOLATIONS.include?(name) || value.is_a?(ActiveSupport::SafeBuffer)
+
+        [name, ERB::Util.html_escape(value)]
+      end
+    end
+
+    def html_key?(key)
+      key.to_s.end_with?('_html')
     end
   end
 end

--- a/spec/fixtures/extensions/example_theme/config/locales/en.yml
+++ b/spec/fixtures/extensions/example_theme/config/locales/en.yml
@@ -24,3 +24,7 @@ en:
         index:
           standfirst: Fixture standfirst for events
           standfirst_detail: Fixture detail for events
+          list_heading: Fixture events list heading
+      partners:
+        index:
+          list_heading: Fixture partners list heading

--- a/spec/lib/placecal/extensions_spec.rb
+++ b/spec/lib/placecal/extensions_spec.rb
@@ -66,6 +66,34 @@ RSpec.describe PlaceCal::Extensions do
       expect { described_class.fetch_theme(:nope) }.to raise_error(PlaceCal::Extensions::UnknownTheme, /nope/)
     end
 
+    it "warns when a name is re-registered outside the test environment" do
+      described_class.register_theme(:sample)
+      allow(Rails.env).to receive(:test?).and_return(false)
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.register_theme(:sample)
+
+      expect(Rails.logger).to have_received(:warn).with(/"sample" was already registered/)
+    end
+
+    it "stays quiet for a first registration, and in the test environment" do
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.env).to receive(:test?).and_return(false)
+      described_class.register_theme(:brand_new)
+      allow(Rails.env).to receive(:test?).and_return(true)
+      described_class.register_theme(:brand_new)
+
+      expect(Rails.logger).not_to have_received(:warn)
+    end
+
+    it "snapshots each theme so reconfiguring a registered one cannot leak" do
+      state = described_class.snapshot
+      described_class.find_theme(:pink).map_style "hijacked"
+      described_class.restore(state)
+
+      expect(described_class.find_theme(:pink).map_style).to eq("pink")
+    end
+
     it "reset! empties the registry" do
       described_class.reset!
       expect(described_class.theme_names).to be_empty

--- a/spec/mailers/join_mailer_spec.rb
+++ b/spec/mailers/join_mailer_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe JoinMailer, type: :mailer do
       expect(mail.subject).to eq(I18n.t("join_mailer.join_us.subject_with_site", site: "Millbrook"))
     end
 
+    it "keeps newlines in the site name out of the subject header" do
+      site = build(:site, name: "Millbrook\r\nBcc: sneaky@example.com", contact_email: "hello@example.org")
+      mail = described_class.join_us(Join.new(site: site, **join_attrs))
+
+      expect(mail.subject).not_to include("\r")
+      expect(mail.subject).not_to include("\n")
+      expect(mail.subject).to include("MillbrookBcc: sneaky@example.com")
+      expect(mail.bcc).to be_nil
+    end
+
     it "falls back to the default recipient when the site has no contact_email" do
       site = build(:site, contact_email: nil)
       mail = described_class.join_us(Join.new(site: site, **join_attrs))

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -356,4 +356,44 @@ RSpec.describe Site, type: :model do
       end
     end
   end
+
+  # Derived nav asks for this on every request of every site (#3368 D6).
+  describe "#news_article_count" do
+    let(:site) { create(:site) }
+    let(:cache_key) { ["site", site.id, "news_article_count"] }
+
+    around do |example|
+      original = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+    ensure
+      Rails.cache = original
+    end
+
+    it "stores the computed count" do
+      expect(site.news_article_count).to eq(0)
+      expect(Rails.cache.read(cache_key)).to eq(0)
+    end
+
+    it "serves a later instance from the cache instead of counting again" do
+      Rails.cache.write(cache_key, 7)
+
+      expect(described_class.find(site.id).news_article_count).to eq(7)
+    end
+
+    it "caches for ten minutes rather than forever" do
+      allow(Rails.cache).to receive(:fetch).and_call_original
+
+      site.news_article_count
+
+      expect(Rails.cache).to have_received(:fetch).with(cache_key, expires_in: 10.minutes)
+    end
+
+    it "keys the cache per site" do
+      other = create(:site)
+      Rails.cache.write(cache_key, 7)
+
+      expect(other.news_article_count).to eq(0)
+    end
+  end
 end

--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -12,6 +12,27 @@ RSpec.describe "Admin::Pages", type: :request do
   let!(:page_record) { create(:page, site: site, slug: "about", title: "About Hulme") }
   let!(:other_page) { create(:page, site: other_site, slug: "about", title: "About Other") }
 
+  # There is no show action: a page is edited in admin and viewed on the public
+  # site, so the route should not exist rather than 500 on a missing template.
+  describe "GET /admin/pages/:id" do
+    before { sign_in root_user }
+
+    it "defines no GET route to the admin show action" do
+      actions = Rails.application.routes.routes
+                     .select { |route| route.defaults[:controller] == "admin/pages" }
+                     .map { |route| route.defaults[:action] }
+
+      expect(actions).not_to include("show")
+    end
+
+    it "does not reach a missing show template" do
+      get "http://#{admin_host}/pages/#{page_record.id}"
+
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).not_to have_http_status(:internal_server_error)
+    end
+  end
+
   describe "GET /admin/pages" do
     context "as a root user" do
       before { sign_in root_user }

--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -120,3 +120,77 @@ RSpec.describe "Theme nav call to action, menu label and map style", type: :requ
     expect(helper.send(:style_url_for_site, plain)).to eq("/map-styles/pink.json")
   end
 end
+
+# Core ships events.index.list_heading and partners.index.list_heading empty,
+# so the heading is a slot only a theme fills (#3368 D19).
+RSpec.describe "Theme list heading slot", type: :request do
+  let(:ward) { create(:riverside_ward) }
+
+  def site_on(theme, slug)
+    site = create(:site, slug: slug, theme: theme, url: "https://#{slug}.lvh.me")
+    site.neighbourhoods << ward
+    site
+  end
+
+  it "renders the theme's list headings on a themed site" do
+    site_on("example_theme", "themed")
+
+    get "http://themed.lvh.me/events"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('class="list-heading">Fixture events list heading</h2>')
+
+    get "http://themed.lvh.me/partners"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('class="list-heading">Fixture partners list heading</h2>')
+  end
+
+  it "renders no list heading on a core theme" do
+    site_on("pink", "plain")
+
+    get "http://plain.lvh.me/events"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("list-heading")
+
+    get "http://plain.lvh.me/partners"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("list-heading")
+  end
+end
+
+# A theme whose own footer carries the Join link turns the nav one off
+# (PlaceCal::Theme#nav_join, SiteNavigation#join_navigation).
+RSpec.describe "Theme nav_join", :theme_registry, type: :request do
+  let(:ward) { create(:riverside_ward) }
+
+  def site_on(theme, slug)
+    site = create(:site, slug: slug, theme: theme, url: "https://#{slug}.lvh.me",
+                         contact_email: "hello@example.org")
+    site.neighbourhoods << ward
+    site
+  end
+
+  def header_of(body)
+    body[%r{<header.*?</header>}m].to_s
+  end
+
+  it "renders no Join link in the header nav for a theme that opts out" do
+    PlaceCal::Extensions.register_theme(:no_join_theme) { |theme| theme.nav_join false }
+    site_on("no_join_theme", "nojoin")
+
+    get "http://nojoin.lvh.me/events"
+
+    expect(response).to have_http_status(:ok)
+    expect(header_of(response.body)).not_to include(I18n.t("navigation.site.join"))
+    expect(header_of(response.body)).not_to include('href="/get-in-touch"')
+  end
+
+  it "renders it for a core theme on a site that takes enquiries" do
+    site_on("pink", "plain")
+
+    get "http://plain.lvh.me/events"
+
+    expect(response).to have_http_status(:ok)
+    expect(header_of(response.body)).to include(I18n.t("navigation.site.join"))
+    expect(header_of(response.body)).to include('href="/get-in-touch"')
+  end
+end

--- a/spec/requests/extensions/theme_translation_spec.rb
+++ b/spec/requests/extensions/theme_translation_spec.rb
@@ -37,3 +37,96 @@ RSpec.describe "Theme-scoped translations", type: :request do
     expect(response.body).to include(I18n.t("navigation.site.events"))
   end
 end
+
+# The `t` shim itself: it must behave like the `t` it replaces, not just find
+# theme overrides (#3368 D19).
+RSpec.describe PlaceCal::ThemeTranslation do
+  let(:ward) { create(:riverside_ward) }
+  let(:themed_site) do
+    site = create(:site, slug: "themed", theme: "example_theme", url: "https://themed.lvh.me")
+    site.neighbourhoods << ward
+    site
+  end
+
+  # Stands in for a Phlex component: no `t` further up the ancestor chain.
+  let(:component) { Class.new { include PlaceCal::ThemeTranslation }.new }
+
+  # Stands in for a controller or ActionView, where `t` has a super that knows
+  # how to expand a lazy ('.foo') key.
+  let(:with_super) do
+    base = Module.new do
+      def t(key, **_options)
+        "super:#{key}"
+      end
+    end
+    Class.new do
+      include base
+      include PlaceCal::ThemeTranslation
+    end.new
+  end
+
+  before do
+    Current.site = themed_site
+    I18n.backend.store_translations(
+      :en,
+      theme_overrides: { example_theme: { spec_shim: { greeting_html: "<b>Hello %{name}</b>" } } } # rubocop:disable Style/FormatStringToken
+    )
+  end
+
+  after { Current.site = nil }
+
+  describe "caller-supplied defaults" do
+    it "prefers the unscoped core string over the caller's default" do
+      expect(component.t("navigation.site.events", default: "Caller default"))
+        .to eq(I18n.t("navigation.site.events"))
+    end
+
+    it "falls back to the caller's default when neither the override nor the core key exists" do
+      expect(component.t("no.such.key.anywhere", default: "Caller default")).to eq("Caller default")
+    end
+
+    it "still prefers the theme's override over both" do
+      expect(component.t("region_filter.all", default: "Caller default")).to eq("Anywhere")
+    end
+  end
+
+  describe "lazy keys" do
+    it "hands a leading-dot key to the including class's own t" do
+      expect(with_super.t(".some_key")).to eq("super:.some_key")
+    end
+
+    it "does not hand an absolute key to it on a themed site" do
+      expect(with_super.t("region_filter.all")).to eq("Anywhere")
+    end
+  end
+
+  describe "_html keys" do
+    it "returns an html_safe string and escapes interpolations" do
+      result = component.t("spec_shim.greeting_html", name: "<script>")
+
+      expect(result).to be_html_safe
+      expect(result).to eq("<b>Hello &lt;script&gt;</b>")
+    end
+
+    it "leaves plain keys unmarked" do
+      expect(component.t("navigation.site.events")).not_to be_html_safe
+    end
+  end
+
+  describe "missing translations" do
+    it "reports the key the caller wrote, not the theme_overrides path" do
+      expect { component.t("definitely.missing.key", raise: true) }
+        .to raise_error(I18n::MissingTranslationData) { |error|
+          expect(error.message).to include("definitely.missing.key")
+          expect(error.message).not_to include("theme_overrides")
+        }
+    end
+
+    it "reports the same key on a site with no theme override scope" do
+      Current.site = nil
+
+      expect { component.t("definitely.missing.key", raise: true) }
+        .to raise_error(I18n::MissingTranslationData, /definitely\.missing\.key/)
+    end
+  end
+end

--- a/spec/requests/public/pages_spec.rb
+++ b/spec/requests/public/pages_spec.rb
@@ -202,6 +202,16 @@ RSpec.describe "Public Pages", type: :request do
         expect(response).to have_http_status(:not_found)
       end
 
+      it "serves the page as HTML only, not as JSON" do
+        create(:page, site: site, slug: "about", title: "About Hulme")
+
+        get "http://hulme.lvh.me/about"
+        expect(response).to have_http_status(:ok)
+
+        expect { get "http://hulme.lvh.me/about.json" }
+          .to raise_error(ActionController::RoutingError)
+      end
+
       it "404s for an unknown slug" do
         get "http://hulme.lvh.me/nothing-here"
 

--- a/spec/requests/public/sitemaps_spec.rb
+++ b/spec/requests/public/sitemaps_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "Public Sitemaps", type: :request do
-  let!(:local_site) { create(:site, slug: "mossley", is_published: true, url: "https://mossley.placecal.org/") }
+  let!(:local_site) do
+    create(:site, slug: "mossley", is_published: true, url: "https://mossley.placecal.org/",
+                  contact_email: "hello@mossley.example.org")
+  end
 
   describe "on the apex (directory)" do
     let(:host) { "lvh.me" }
@@ -176,6 +179,30 @@ RSpec.describe "Public Sitemaps", type: :request do
       it "does not link to the directory" do
         get "/sitemap/pages.xml", headers: { "Host" => host }
         expect(response.body).not_to include("https://placecal.org/")
+      end
+
+      # The site's own privacy page and core's /privacy are the same URL.
+      it "lists /privacy once when the site publishes its own privacy page" do
+        create(:page, site: local_site, slug: "privacy", title: "Privacy")
+
+        get "/sitemap/pages.xml", headers: { "Host" => host }
+
+        expect(response.body.scan("<loc>https://mossley.placecal.org/privacy</loc>").size).to eq(1)
+      end
+
+      it "lists /privacy once when the site has no page of its own" do
+        get "/sitemap/pages.xml", headers: { "Host" => host }
+
+        expect(response.body.scan("<loc>https://mossley.placecal.org/privacy</loc>").size).to eq(1)
+      end
+
+      # Mirrors SiteNavigation#join_navigation: no enquiries address, no Join.
+      it "omits /get-in-touch for a site that takes no enquiries" do
+        local_site.update!(contact_email: nil)
+
+        get "/sitemap/pages.xml", headers: { "Host" => host }
+
+        expect(response.body).not_to include("https://mossley.placecal.org/get-in-touch")
       end
     end
 

--- a/spec/requests/public/sites_spec.rb
+++ b/spec/requests/public/sites_spec.rb
@@ -140,6 +140,43 @@ RSpec.describe "Public Sites", type: :request do
         expect(response.body).to include("region-filter")
       end
 
+      # The control is only worth having if the lists below it obey it (D7).
+      context "when the homepage help cards list partners" do
+        let(:computers) { create(:tag, name: "Computers", slug: "computers", type: "Facility") }
+
+        def partner_in(region_tag, name)
+          partner = create(:partner, name: name, address: create(:address, neighbourhood: region_ward))
+          partner.tags << [region_tag, computers]
+          partner
+        end
+
+        before do
+          partner_in(north_tag, "Northern Library")
+          partner_in(south_tag, "Southern Library")
+        end
+
+        it "lists every region's partners with no region selected" do
+          get "http://regions.lvh.me"
+
+          expect(response.body).to include("Northern Library")
+          expect(response.body).to include("Southern Library")
+        end
+
+        it "lists only the selected region's partners" do
+          get "http://regions.lvh.me?region=#{north_tag.slug}"
+
+          expect(response.body).to include("Northern Library")
+          expect(response.body).not_to include("Southern Library")
+        end
+
+        it "ignores an unknown region slug and lists everything" do
+          get "http://regions.lvh.me?region=nowhere"
+
+          expect(response.body).to include("Northern Library")
+          expect(response.body).to include("Southern Library")
+        end
+      end
+
       it "carries the region on the site navigation links" do
         get "http://regions.lvh.me?region=#{north_tag.slug}"
 


### PR DESCRIPTION
Minor items from the Opus review of #3436.

- Theme-aware t keeps caller defaults, hands lazy keys to the including class, returns html_safe for _html keys with escaped interpolations, and reports missing keys under the caller's key.
- Re-registering a theme name logs a warning outside test.
- News nav count cached for ten minutes per site (no cheap invalidation across the partner, tag and neighbourhood derivation, documented).
- Admin pages resource has no show route; sitemap lists a site-owned static page once and omits /get-in-touch without a contact email; join mail subject strips line breaks.
- Homepage partner lists honour the selected region (D7).
- Specs for the list heading slot on a themed site and nav_join false; catch-all site page route is html only; THEME_COLORS no longer a top-level constant; registry snapshot dups themes.

Specs: lib, site model, mailers, public, extension and admin requests green (781 examples); components 309; i18n keys, queries, helpers 185.