### PR TITLE
Tag-only site scoping and SQL-side partner sets in the queries

### DIFF
--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -55,18 +55,21 @@ class EventsQuery
   # @param place [Partner] filter to events at this place
   # @param organiser_or_place [Partner] filter to events by OR at this organiser
   # @param neighbourhood_id [Integer] filter to events in this neighbourhood
+  # @param tag_id [Integer] filter to events whose organiser or place carries
+  #   this tag (used by the public region filter, see #3368 D7)
   # @param limit [Integer] max number of events to return
   #
   # @return [Hash] events grouped by date { Date => [Event, ...] }
   # rubocop:disable Metrics/ParameterLists
   def call(period:, sort: 'time', repeating: 'on', organiser: nil, place: nil,
-           organiser_or_place: nil, neighbourhood_id: nil, limit: nil)
+           organiser_or_place: nil, neighbourhood_id: nil, tag_id: nil, limit: nil)
     # rubocop:enable Metrics/ParameterLists
     events = build_filtered_scope(
       organiser: organiser,
       place: place,
       organiser_or_place: organiser_or_place,
       neighbourhood_id: neighbourhood_id,
+      tag_id: tag_id,
       repeating: repeating
     )
     events = apply_period(events, period)
@@ -88,7 +91,7 @@ class EventsQuery
   def flat_call(period:)
     events = build_filtered_scope(
       organiser: nil, place: nil,
-      organiser_or_place: nil, neighbourhood_id: nil, repeating: 'on'
+      organiser_or_place: nil, neighbourhood_id: nil, tag_id: nil, repeating: 'on'
     )
     apply_period(events, period).distinct.sort_by_time
   end
@@ -134,14 +137,16 @@ class EventsQuery
   # at every level. Each neighbourhood's count includes events in its subtree.
   #
   # @param period [String] 'day', 'week', or 'future'
+  # @param tag_id [Integer] optionally restrict to a tag, so the counts agree
+  #   with a region-filtered listing
   # @return [Array<Hash>] array of { neighbourhood: Neighbourhood, count: Integer }
-  def neighbourhoods_with_counts(period: 'future')
+  def neighbourhoods_with_counts(period: 'future', tag_id: nil)
     return [] unless @site
 
     all_descendants = @site.neighbourhoods.flat_map { |n| n.descendants.to_a }
     return [] if all_descendants.empty?
 
-    events = apply_period(base_scope, period)
+    events = apply_period(tag_id.present? ? filter_by_tag(base_scope, tag_id) : base_scope, period)
 
     # Count events per leaf neighbourhood (single query)
     raw_counts = events
@@ -207,35 +212,52 @@ class EventsQuery
         .or(base.where(addresses: { neighbourhood_id: site_neighbourhood_ids }))
   end
 
-  # For sites with tags: must load partners for legacy name/postcode address matching
+  # For sites with tags: events organised by, or hosted at, a partner in the
+  # site scope, plus the legacy venue match. The partner set stays in the
+  # database as a subquery, so a tag-only site does not load every partner
+  # row on every events request (#3368).
   def events_for_tagged_site(partners_scope)
-    partner_records = partners_scope.includes(:address).load
-    partner_names = partner_records.map { |p| p.name.downcase }
-    partner_postcodes = partner_records.filter_map(&:address).map { |a| a.postcode.downcase }
+    partner_subquery = partners_scope.select(:id)
+    base = Event.left_joins(:address)
+    base.where(organiser_id: partner_subquery)
+        .or(base.where(place_id: partner_subquery))
+        .or(base.where(legacy_venue_match_sql(partner_subquery)))
+  end
 
-    Event
-      .left_joins(:address)
-      .where(
-        'organiser_id IN (:partner_ids) OR ' \
-        '(lower(addresses.street_address) IN (:partner_names) AND ' \
-        'lower(addresses.postcode) IN (:partner_postcodes))',
-        partner_ids: partner_records.map(&:id),
-        partner_names: partner_names,
-        partner_postcodes: partner_postcodes
-      )
+  # Legacy venue matching, from 2024 (commit 5b90f19), for events whose place
+  # was never set: an event counts as happening at a partner when its address
+  # street line is the partner's name and the postcodes agree.
+  def legacy_venue_match_sql(partner_subquery)
+    <<~SQL.squish
+      EXISTS (SELECT 1 FROM partners venue_partners
+        INNER JOIN addresses venue_addresses ON venue_addresses.id = venue_partners.address_id
+        WHERE venue_partners.id IN (#{partner_subquery.to_sql})
+        AND lower(venue_partners.name) = lower(addresses.street_address) AND lower(venue_addresses.postcode) = lower(addresses.postcode))
+    SQL
   end
 
   # ===================
   # Filtering
   # ===================
 
-  def build_filtered_scope(organiser:, place:, organiser_or_place:, neighbourhood_id:, repeating:)
+  # rubocop:disable Metrics/ParameterLists
+  def build_filtered_scope(organiser:, place:, organiser_or_place:, neighbourhood_id:, tag_id:, repeating:)
+    # rubocop:enable Metrics/ParameterLists
     events = base_scope
+    events = filter_by_tag(events, tag_id) if tag_id.present?
     events = events.by_organiser(organiser) if organiser
     events = events.in_place(place) if place
     events = events.by_organiser_or_place(organiser_or_place) if organiser_or_place
     events = filter_by_neighbourhood(events, neighbourhood_id) if neighbourhood_id.present?
     apply_repeating_filter(events, repeating)
+  end
+
+  # Restrict to events whose organiser or place carries the tag. Mirrors
+  # PartnersQuery#filter_by_tag: the region filter is a partnership-tag filter,
+  # and an event belongs to a region when the partner behind it does.
+  def filter_by_tag(events, tag_id)
+    partner_ids = PartnerTag.where(tag_id: tag_id).select(:partner_id)
+    events.where(organiser_id: partner_ids).or(events.where(place_id: partner_ids))
   end
 
   # Filter by physical location of event (event address, or partner address if no event address)

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -253,16 +253,19 @@ class PartnersQuery
     @base_scope ||= build_base_scope
   end
 
+  # A site scopes its partners by its neighbourhoods, by its tags, or by both
+  # (tag AND neighbourhood). A tagged site with no neighbourhoods is tag-only:
+  # partnership sites such as The Trans Dimension span cities and pick their
+  # partners by Partnership tag alone (#3368 D7, D24). A site with neither
+  # has no partners.
   def build_base_scope
     return Partner.visible if @site.nil?
-    return Partner.none if site_neighbourhood_ids.empty?
+    return Partner.none if site_neighbourhood_ids.empty? && site_tag_ids.empty?
 
     scope = Partner.visible
     scope = scope.joins(:tags).where(tags: { id: site_tag_ids }) if site_tag_ids.any?
-    scope
-      .left_joins(:address, :service_areas)
-      .where(in_site_neighbourhoods_sql)
-      .distinct
+    scope = scope.left_joins(:address, :service_areas).where(in_site_neighbourhoods_sql) if site_neighbourhood_ids.any?
+    scope.distinct
   end
 
   # ===================

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -683,4 +683,93 @@ RSpec.describe EventsQuery do
       expect(described_class.upcoming_counts_by_partner([partner.id])).to eq({})
     end
   end
+
+  describe "#call with tag_id (region filter)" do
+    let(:region_site) { create(:site, slug: "two-region-site") }
+    let(:ward) { create(:riverside_ward) }
+    let(:north_tag) { create(:partnership, name: "North") }
+    let(:south_tag) { create(:partnership, name: "South") }
+    let(:north_partner) { create(:partner, name: "North Partner", address: create(:address, neighbourhood: ward)) }
+    let(:south_partner) { create(:partner, name: "South Partner", address: create(:address, neighbourhood: ward)) }
+
+    before do
+      region_site.neighbourhoods << ward
+      region_site.tags << north_tag
+      region_site.tags << south_tag
+      north_partner.tags << north_tag
+      south_partner.tags << south_tag
+      create(:future_event, organiser: north_partner, summary: "Northern Social")
+      create(:future_event, organiser: south_partner, summary: "Southern Social")
+    end
+
+    it "returns every event when no tag is given" do
+      result = described_class.new(site: region_site, day: today).call(period: "future")
+
+      expect(result.values.flatten.map(&:summary)).to contain_exactly("Northern Social", "Southern Social")
+    end
+
+    it "restricts events to partners carrying the tag" do
+      result = described_class.new(site: region_site, day: today).call(period: "future", tag_id: north_tag.id)
+
+      expect(result.values.flatten.map(&:summary)).to eq(["Northern Social"])
+    end
+
+    it "matches events hosted at a tagged partner as well as organised by one" do
+      create(:future_event, organiser: south_partner, place: north_partner, summary: "Hosted Up North")
+
+      result = described_class.new(site: region_site, day: today).call(period: "future", tag_id: north_tag.id)
+
+      expect(result.values.flatten.map(&:summary)).to contain_exactly("Northern Social", "Hosted Up North")
+    end
+  end
+
+  describe "site scoping for a tag-only site" do
+    let(:tag_only_site) { create(:site, slug: "tag-only-site") }
+    let(:ward) { create(:riverside_ward) }
+    let(:tag) { create(:partnership, name: "Tagged") }
+    let(:tagged_partner) { create(:partner, name: "Tagged Partner", address: create(:address, neighbourhood: ward)) }
+    let(:untagged_partner) { create(:partner, name: "Untagged Partner", address: create(:address, neighbourhood: ward)) }
+
+    before do
+      tag_only_site.tags << tag
+      tagged_partner.tags << tag
+      create(:future_event, organiser: tagged_partner, summary: "Tagged Social")
+      create(:future_event, organiser: untagged_partner, summary: "Untagged Social")
+    end
+
+    it "returns only events from partners carrying the site tag" do
+      result = described_class.new(site: tag_only_site, day: today).call(period: "future")
+
+      expect(result.values.flatten.map(&:summary)).to eq(["Tagged Social"])
+    end
+
+    it "includes events hosted at a tagged partner" do
+      create(:future_event, organiser: untagged_partner, place: tagged_partner, summary: "Hosted At Tagged")
+
+      result = described_class.new(site: tag_only_site, day: today).call(period: "future")
+
+      expect(result.values.flatten.map(&:summary)).to contain_exactly("Tagged Social", "Hosted At Tagged")
+    end
+
+    it "keeps the partner set in SQL rather than loading partner rows" do
+      queries = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        queries << payload[:sql]
+      end
+
+      begin
+        described_class.new(site: tag_only_site, day: today).call(period: "future")
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      # Preloading the organiser and place of the events we return fetches
+      # partner rows by primary key, which is fine. What must not happen is a
+      # query that pulls the whole site partner set into memory.
+      partner_set_queries = queries.select { |sql| sql.include?('"partners".*') }
+                                   .grep_v(/"partners"\."id" (?:=|IN \()/)
+
+      expect(partner_set_queries).to be_empty
+    end
+  end
 end

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -143,6 +143,33 @@ RSpec.describe PartnersQuery do
         expect(results).to be_empty
       end
     end
+
+    context "with a tag-only site (partnership tags, no neighbourhoods)" do
+      let(:tag_only_site) { create(:site) }
+      let(:partnership) { create(:partnership) }
+      let!(:tagged_partner) { create(:partner, name: "Tagged") }
+      let!(:tagged_elsewhere) { create(:partner, name: "Tagged elsewhere") }
+      let!(:untagged_partner) { create(:partner, name: "Untagged") }
+
+      before do
+        tag_only_site.tags << partnership
+        tagged_partner.tags << partnership
+        tagged_elsewhere.tags << partnership
+      end
+
+      it "scopes by tag alone, wherever the partner is" do
+        results = described_class.new(site: tag_only_site).call
+
+        expect(results).to contain_exactly(tagged_partner, tagged_elsewhere)
+      end
+
+      it "still requires the neighbourhood when the site has both" do
+        tag_only_site.neighbourhoods << create(:neighbourhood)
+        results = described_class.new(site: tag_only_site).call
+
+        expect(results).to be_empty
+      end
+    end
   end
 
   describe "#neighbourhoods_with_counts" do


### PR DESCRIPTION
Extracted from #3436 so the SQL change every site runs can be reviewed on its own (#3368 D7 and D24).

- A site defined only by partnership tags, with no neighbourhoods, used to resolve to no partners and no events. PartnersQuery now scopes by tags alone in that case; sites with neighbourhoods keep the tag-and-neighbourhood behaviour.
- EventsQuery keeps the tagged-site partner set in SQL (organiser, place, and the 2024 legacy venue match as subqueries) instead of loading every partner with its address on each events request. A spec captures SQL and fails on the old code.
- EventsQuery gains an optional tag_id filter, unused until the region filter lands.

Specs: queries plus the public events and partners request specs, 190 examples, 0 failures.

Worth timing against production-sized data before deploy: the venue match is an EXISTS over partners joined to addresses.