### PR TITLE
Site pages: per-site static content at /:slug with admin CRUD

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 module Admin
+  # Serves both the admin dashboard (#home, the admin root) and CRUD for a
+  # Site's static content pages (#3368, WP 1.1). The dashboard actions predate
+  # the Page model and are exempt from Pundit's verification callbacks.
   class PagesController < Admin::ApplicationController
-    skip_after_action :verify_authorized
-    skip_after_action :verify_policy_scoped
+    DASHBOARD_ACTIONS = %i[home icons].freeze
+
+    skip_after_action :verify_authorized, only: DASHBOARD_ACTIONS
+    skip_after_action :verify_policy_scoped, only: DASHBOARD_ACTIONS
     before_action :require_root_user, only: [:icons]
+    before_action :set_page, only: %i[edit update destroy]
 
     def home
       @user = current_user
@@ -65,7 +71,114 @@ module Admin
       render Views::Admin::Pages::Icons.new(icons: @icons)
     end
 
+    def index
+      @pages = policy_scope(Page).includes(:site).order('sites.name': :asc, position: :asc, title: :asc)
+      authorize @pages
+      render Views::Admin::Pages::Index.new(pages: @pages)
+    end
+
+    def new
+      @page = Page.new(site: default_site)
+      authorize @page
+      render Views::Admin::Pages::New.new(page: @page, sites: sites_for_select)
+    end
+
+    def edit
+      authorize @page
+      render Views::Admin::Pages::Edit.new(page: @page, sites: sites_for_select)
+    end
+
+    def create
+      @page = Page.new(permitted_attributes(Page))
+      @page.site ||= submitted_site || default_site
+      authorize @page
+
+      if @page.save
+        flash[:success] = t('admin.pages.flash.created')
+        redirect_to edit_admin_page_path(@page)
+      else
+        flash.now[:danger] = t('admin.pages.flash.not_created')
+        render Views::Admin::Pages::New.new(page: @page, sites: sites_for_select),
+               status: :unprocessable_content
+      end
+    end
+
+    def update
+      authorize @page
+
+      attributes = attributes_with_submitted_site(permitted_attributes(@page))
+
+      if attributes.nil?
+        flash.now[:danger] = t('admin.pages.flash.site_not_permitted')
+        return render Views::Admin::Pages::Edit.new(page: @page, sites: sites_for_select),
+                      status: :forbidden
+      end
+
+      if @page.update(attributes)
+        flash[:success] = t('admin.pages.flash.updated')
+        redirect_to edit_admin_page_path(@page)
+      else
+        flash.now[:danger] = t('admin.pages.flash.not_updated')
+        render Views::Admin::Pages::Edit.new(page: @page, sites: sites_for_select),
+               status: :unprocessable_content
+      end
+    end
+
+    def destroy
+      authorize @page
+      @page.destroy
+      flash[:success] = t('admin.pages.flash.deleted')
+      redirect_to admin_pages_url
+    end
+
     private
+
+    def set_page
+      @page = Page.find(params[:id])
+    end
+
+    # Sites the current user may attach a page to. Root and editors see them
+    # all; a site admin only their own (SitePolicy::Scope excludes editors, who
+    # may still manage every page).
+    def sites_for_select
+      @sites_for_select ||=
+        if current_user.root? || current_user.editor?
+          Site.order(:name)
+        else
+          Site.where(site_admin: current_user).order(:name)
+        end
+    end
+
+    # Site admins usually only have one site, so preselect it.
+    def default_site
+      sites_for_select.one? ? sites_for_select.first : nil
+    end
+
+    # site_id is not a permitted attribute for site admins, so resolve their
+    # submitted choice against the sites they actually administer.
+    def submitted_site
+      site_id = params.dig(:page, :site_id)
+      return nil if site_id.blank?
+
+      sites_for_select.find_by(id: site_id)
+    end
+
+    # A site admin who administers several sites sees an editable Site select,
+    # but site_id is not a permitted attribute for them, so their choice has to
+    # be resolved here against the sites they administer. Returns nil when they
+    # asked for a site they do not administer, so #update can refuse the change
+    # instead of quietly saving the rest and flashing success.
+    def attributes_with_submitted_site(attributes)
+      return attributes if policy(@page).permitted_attributes.include?(:site_id)
+
+      requested_id = params.dig(:page, :site_id)
+      return attributes if requested_id.blank? || requested_id.to_s == @page.site_id.to_s
+
+      site = sites_for_select.find_by(id: requested_id)
+      return nil if site.nil?
+
+      attributes.merge(site_id: site.id)
+    end
 
     def require_root_user
       return if current_user&.root?

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -35,12 +35,27 @@ class PagesController < ApplicationController
   end
 
   def privacy
+    # A site may publish its own privacy copy at the conventional URL (#3368,
+    # D14). `privacy` is therefore the one core route a Page may shadow; see
+    # Page::OVERRIDABLE_ROUTE_SLUGS.
+    site_page = site_page_for('privacy')
+    return render_site_page(site_page) if site_page
+
     render Views::Directory::MarkdownPage.new(
       slug: 'privacy',
       title: t('directory.pages.privacy.title'),
       breadcrumb_label: t('directory.pages.privacy.breadcrumb'),
       document_title: t('directory.pages.privacy.document_title')
     )
+  end
+
+  # Static per-site content page at /:slug (#3368, D5). The catch-all route is
+  # matched last, so anything core routes never reaches here.
+  def show
+    site_page = site_page_for(params[:slug])
+    raise ActiveRecord::RecordNotFound unless site_page
+
+    render_site_page(site_page)
   end
 
   def our_story
@@ -96,6 +111,18 @@ class PagesController < ApplicationController
   ].freeze
 
   private
+
+  # @return [Page, nil] the current site's published page with this slug.
+  #   The nationwide directory has no Site, so it never has pages.
+  def site_page_for(slug)
+    return nil if current_site.nil?
+
+    current_site.pages.published.find_by(slug: slug)
+  end
+
+  def render_site_page(site_page)
+    render Views::Sites::Pages::Show.new(page: site_page)
+  end
 
   def render_directory_home
     @stats = Rails.cache.fetch('directory/stats', expires_in: DIRECTORY_CACHE_TTL) do

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# A static content page belonging to a Site (#3368, D5).
+#
+# Partnerships need their own About/Privacy style copy. Rather than shipping
+# site-specific views, the content lives in the database and is edited in admin
+# by the site's own admin. Pages are served at the top level (`/about`) to match
+# PlaceCal's existing URL convention for static pages (D14).
+# == Schema Information
+#
+# Table name: pages
+#
+#  id           :bigint           not null, primary key
+#  body         :text
+#  body_html    :text
+#  is_published :boolean          default(FALSE), not null
+#  position     :integer          default(0), not null
+#  show_in_nav  :boolean          default(FALSE), not null
+#  slug         :string           not null
+#  title        :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  site_id      :bigint           not null
+#
+# Indexes
+#
+#  index_pages_on_site_id_and_slug  (site_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (site_id => sites.id)
+#
+class Page < ApplicationRecord
+  # ==== Includes / Extends ====
+  include HtmlRenderCache
+
+  # ==== Constants ====
+
+  # Path prefixes that are served outside the Rails router (Propshaft/Sprockets
+  # and friends), so they never appear in `Rails.application.routes` but would
+  # still shadow a page.
+  NON_ROUTED_RESERVED_SLUGS = %w[assets packs manifest].freeze
+
+  # `privacy` is deliberately allowed even though core routes `/privacy`.
+  # PagesController#privacy prefers a site's own published `privacy` page and
+  # only falls back to the directory markdown, so a partnership can supply its
+  # own privacy copy at the conventional URL (D14). No other core route is
+  # overridable this way.
+  OVERRIDABLE_ROUTE_SLUGS = %w[privacy].freeze
+
+  # ==== Attributes ====
+  attribute :body,         :text
+  attribute :body_html,    :text # populated by HtmlRenderCache
+  attribute :is_published, :boolean, default: false
+  attribute :position,     :integer, default: 0
+  attribute :show_in_nav,  :boolean, default: false
+  attribute :slug,         :string
+  attribute :title,        :string
+
+  html_render_cache :body
+
+  # ==== Associations ====
+  belongs_to :site
+
+  # ==== Validations ====
+  validates :title, presence: true
+  validates :slug, presence: true,
+                   format: { with: /\A[a-z0-9-]+\z/, message: :invalid_page_slug },
+                   uniqueness: { scope: :site_id }
+  validate :slug_is_not_reserved
+
+  # ==== Scopes ====
+  scope :published, -> { where(is_published: true) }
+  scope :in_nav, -> { published.where(show_in_nav: true).order(:position, :title) }
+
+  class << self
+    # Slugs a page may not claim, because a core route already owns that first
+    # path segment. Derived from the router so new core routes are covered
+    # automatically. Memoised: the route set does not change at runtime.
+    #
+    # @return [Array<String>]
+    def reserved_slugs
+      @reserved_slugs ||= begin
+        routed = Rails.application.routes.routes.filter_map do |route|
+          next if route.constraints[:subdomain] == Site::ADMIN_SUBDOMAIN
+
+          segment = route.path.spec.to_s.split('/')[1].to_s.sub(/\(.*/, '')
+          next if segment.blank? || segment.start_with?('*', ':')
+
+          segment.downcase
+        end
+
+        (routed + NON_ROUTED_RESERVED_SLUGS - OVERRIDABLE_ROUTE_SLUGS).uniq.sort.freeze
+      end
+    end
+
+    # Clears the memoised reserved slug list (tests that redraw routes).
+    def reset_reserved_slugs!
+      @reserved_slugs = nil
+    end
+  end
+
+  # ==== Instance methods ====
+
+  # @return [String] plain-text lead-in used for meta descriptions
+  def summary(limit = 160)
+    body.to_s.gsub(/[#*_>`\[\]()]/, ' ').squish.truncate(limit)
+  end
+
+  private
+
+  # ==== Private methods ====
+  def slug_is_not_reserved
+    return if slug.blank?
+    return unless self.class.reserved_slugs.include?(slug.downcase)
+
+    errors.add(:slug, :reserved_page_slug)
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -98,6 +98,8 @@ class Site < ApplicationRecord
                                     where(sites_neighbourhoods: { relation_type: 'Primary' })
                                   }, source: :neighbourhood, through: :sites_neighbourhood
 
+  # Static content pages served at /:slug on this site (#3368, D5)
+  has_many :pages, dependent: :destroy
   has_many :sites_neighbourhoods, dependent: :destroy
   has_many :secondary_neighbourhoods, lambda {
                                         where(sites_neighbourhoods: { relation_type: 'Secondary' })

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Who may manage a Site's static content pages (#3368, D5).
+#
+# Root and editor users manage every page. A site admin manages the pages of
+# the sites they administer, and nothing else.
+class PagePolicy < ApplicationPolicy
+  def index?
+    user.root? || user.editor? || user.site_admin?
+  end
+
+  def show?
+    index?
+  end
+
+  def new?
+    create?
+  end
+
+  def create?
+    return true if user.root? || user.editor?
+
+    # A new Page may not have a site yet (the form assigns one); allow any
+    # site admin to reach the form, and check ownership on the saved record.
+    user.site_admin? && (record_site.nil? || administers_record_site?)
+  end
+
+  def update?
+    return true if user.root? || user.editor?
+
+    administers_record_site?
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    update?
+  end
+
+  # Site admins pick from their own sites in the form, so site_id is only
+  # writable by root/editor.
+  #
+  # @return [Array<Symbol>] URL parameters the user may submit
+  def permitted_attributes
+    attrs = %i[title slug body position show_in_nav is_published]
+    return attrs + %i[site_id] if user.root? || user.editor?
+
+    attrs
+  end
+
+  class Scope < Scope
+    # @return [ActiveRecord::Relation<Page>]
+    def resolve
+      return scope.all if user.root? || user.editor?
+      return scope.where(site: Site.where(site_admin: user)) if user.site_admin?
+
+      scope.none
+    end
+  end
+
+  private
+
+  # The record can be a Page, a relation (index) or the Page class itself.
+  def record_site
+    record.respond_to?(:site) ? record.site : nil
+  end
+
+  def administers_record_site?
+    site = record_site
+    site.present? && site.site_admin == user
+  end
+end

--- a/app/views/admin/pages/edit.rb
+++ b/app/views/admin/pages/edit.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Views::Admin::Pages::Edit < Views::Admin::Base
+  prop :page, Page, reader: :private
+  prop :sites, _Interface(:each), reader: :private
+
+  def view_template
+    PageHeader(model_name: Page.model_name.human, title: page.title, id: page.id)
+    render Views::Admin::Pages::Form.new(page: page, sites: sites)
+  end
+end

--- a/app/views/admin/pages/form.rb
+++ b/app/views/admin/pages/form.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+class Views::Admin::Pages::Form < Views::Admin::Base
+  prop :page, Page, reader: :private
+  prop :sites, _Interface(:each), reader: :private
+
+  def view_template
+    simple_form_for([:admin, page], html: { class: 'space-y-6' }) do |form|
+      Error(page)
+
+      div(class: 'card bg-base-100 border border-base-300 shadow-sm') do
+        div(class: 'card-body p-6 space-y-4') do
+          SectionHeader(
+            title: t('admin.pages.sections.content'),
+            description: t('admin.pages.sections.content_description'),
+            margin: 4
+          )
+          render_site_field(form)
+          render_title_field(form)
+          render_slug_field(form)
+          render_body_field(form)
+        end
+      end
+
+      div(class: 'card bg-base-100 border border-base-300 shadow-sm') do
+        div(class: 'card-body p-6 space-y-4') do
+          SectionHeader(
+            title: t('admin.sections.publishing'),
+            description: t('admin.pages.sections.publishing_description'),
+            margin: 4
+          )
+          render_publishing_fields(form)
+        end
+      end
+
+      render_danger_zone
+
+      SaveBar() do
+        raw form.submit(t('admin.actions.save'),
+                        class: 'btn bg-placecal-orange hover:bg-orange-600 text-white border-placecal-orange')
+      end
+    end
+  end
+
+  private
+
+  # Root and editors pick from every site. A site admin cannot submit site_id
+  # (PagePolicy#permitted_attributes), so their page keeps a hidden field when
+  # they only administer one site; with more than one they still choose, and
+  # the controller resolves the choice against the sites they administer.
+  def render_site_field(form)
+    unless sites.many? || policy(page).permitted_attributes.include?(:site_id)
+      raw form.hidden_field(:site_id)
+      return
+    end
+
+    fieldset(class: 'fieldset') do
+      raw form.label(:site_id, Site.model_name.human, class: 'fieldset-legend')
+      raw form.select(
+        :site_id,
+        sites.map { |site| [site.name, site.id] },
+        { include_blank: t('admin.placeholders.select_model', model: Site.model_name.human.downcase) },
+        { class: 'select select-bordered w-full' }
+      )
+    end
+  end
+
+  def render_title_field(form)
+    fieldset(class: 'fieldset') do
+      raw form.label(:title, attr_label(:page, :title), class: 'fieldset-legend')
+      raw form.input_field(:title, as: :string, class: 'input input-bordered w-full')
+    end
+  end
+
+  def render_slug_field(form)
+    fieldset(class: 'fieldset') do
+      raw form.label(:slug, attr_label(:page, :slug), class: 'fieldset-legend')
+      raw form.input_field(:slug, as: :string, class: 'input input-bordered w-full')
+      p(class: 'label text-xs text-gray-600') { t('admin.pages.hints.slug') }
+    end
+  end
+
+  def render_body_field(form)
+    fieldset(class: 'fieldset') do
+      raw form.label(:body, attr_label(:page, :body), class: 'fieldset-legend')
+      raw form.text_area(:body, rows: 18, class: 'textarea textarea-bordered w-full font-mono')
+      p(class: 'label text-xs text-gray-600') { t('admin.pages.hints.body') }
+    end
+  end
+
+  def render_publishing_fields(form)
+    fieldset(class: 'fieldset') do
+      raw form.input(:is_published, wrapper: :tw_boolean, as: :boolean,
+                                    label: t('admin.pages.fields.is_published'))
+      raw form.input(:show_in_nav, wrapper: :tw_boolean, as: :boolean,
+                                   label: t('admin.pages.fields.show_in_nav'))
+    end
+
+    fieldset(class: 'fieldset') do
+      raw form.label(:position, attr_label(:page, :position), class: 'fieldset-legend')
+      raw form.number_field(:position, class: 'input input-bordered w-full max-w-xs')
+      p(class: 'label text-xs text-gray-600') { t('admin.pages.hints.position') }
+    end
+  end
+
+  def render_danger_zone
+    return if page.new_record?
+    return unless policy(page).destroy?
+
+    DangerZone(
+      title: t('admin.actions.delete_model', model: Page.model_name.human),
+      description: t('admin.danger_zone.delete_description', model: Page.model_name.human.downcase),
+      button_text: t('admin.actions.delete_model', model: Page.model_name.human),
+      button_path: admin_page_path(page),
+      confirm: t('admin.confirm.delete_permanent', model: Page.model_name.human.downcase)
+    )
+  end
+end

--- a/app/views/admin/pages/index.rb
+++ b/app/views/admin/pages/index.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class Views::Admin::Pages::Index < Views::Admin::Base
+  prop :pages, _Interface(:each), reader: :private
+
+  def view_template
+    heading = Page.model_name.human(count: 2)
+    content_for(:title) { heading }
+
+    div(class: 'flex items-center justify-between mb-6') do
+      h1(class: 'text-2xl font-semibold') { heading }
+      render_add_button
+    end
+
+    if pages.any?
+      render_table
+    else
+      EmptyState(
+        icon: :clipboard,
+        message: t('admin.empty.no_items', items: Page.model_name.human(count: 2).downcase),
+        hint: t('admin.pages.index.empty_hint')
+      )
+    end
+  end
+
+  private
+
+  def render_add_button
+    return unless policy(Page).create?
+
+    link_to(new_admin_page_path, class: 'btn bg-placecal-orange hover:bg-orange-600 text-white border-placecal-orange') do
+      icon(:plus, size: '4')
+      plain t('admin.actions.add_model', model: Page.model_name.human)
+    end
+  end
+
+  def render_table
+    div(class: 'card bg-base-100 border border-base-300 shadow-sm overflow-x-auto') do
+      table(class: 'table') do
+        thead do
+          tr do
+            th { attr_label(:page, :title) }
+            th { Site.model_name.human }
+            th { attr_label(:page, :slug) }
+            th { t('admin.pages.table.in_nav') }
+            th { t('admin.table.status') }
+            th { t('admin.labels.actions') }
+          end
+        end
+        tbody do
+          pages.each { |page| render_row(page) }
+        end
+      end
+    end
+  end
+
+  def render_row(page)
+    tr do
+      td(class: 'font-medium') { link_to page.title, edit_admin_page_path(page), class: 'link' }
+      td { page.site.name }
+      td { code(class: 'font-mono text-sm') { "/#{page.slug}" } }
+      td { page.show_in_nav ? t('admin.labels.yes') : t('admin.labels.no') }
+      td { page.is_published ? t('admin.pages.status.published') : t('admin.pages.status.draft') }
+      td { link_to t('admin.actions.edit'), edit_admin_page_path(page), class: 'link' }
+    end
+  end
+end

--- a/app/views/admin/pages/new.rb
+++ b/app/views/admin/pages/new.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Views::Admin::Pages::New < Views::Admin::Base
+  prop :page, Page, reader: :private
+  prop :sites, _Interface(:each), reader: :private
+
+  def view_template
+    PageHeader(model_name: Page.model_name.human, new_record: true)
+    render Views::Admin::Pages::Form.new(page: page, sites: sites)
+  end
+end

--- a/app/views/layouts/admin/application.rb
+++ b/app/views/layouts/admin/application.rb
@@ -135,6 +135,7 @@ class Views::Layouts::Admin::Application < Phlex::HTML
       admin_nav_link(human_model_name(Calendar, count: 2), admin_calendars_path, :calendar) if policy(Calendar).index?
       admin_nav_link(human_model_name(User, count: 2), admin_users_path, :users) if policy(User).index?
       admin_nav_link(human_model_name(Site, count: 2), admin_sites_path, :site) if policy(Site).index?
+      admin_nav_link(human_model_name(Page, count: 2), admin_pages_path, :clipboard) if policy(Page).index?
       admin_nav_link(human_model_name(Neighbourhood, count: 2), admin_neighbourhoods_path, :neighbourhood) if policy(Neighbourhood).index?
       admin_nav_link(human_model_name(Partnership, count: 2), admin_partnerships_path, :partnership) if policy(Partnership).index?
     end

--- a/app/views/sites/pages/show.rb
+++ b/app/views/sites/pages/show.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Renders a Site's static content page (#3368, D5). Uses the same wrapper
+# classes as Views::Directory::MarkdownPage so themes only have to style one
+# long-form content treatment.
+class Views::Sites::Pages::Show < Views::Base
+  prop :page, Page, reader: :private
+
+  def view_template
+    content_for(:title) { page.title }
+    content_for(:description) { page.summary }
+
+    # The slug class lets a theme style one page (e.g. its own header art)
+    # without core knowing the page exists.
+    div(class: "container-public py-8 page page--#{page.slug}", data: { page_slug: page.slug }) do
+      h1(class: 'h1') { page.title }
+
+      div(class: 'markdown-content max-w-(--width-prose-lg) text-base leading-relaxed') do
+        raw safe(page.body_html.to_s)
+      end
+    end
+  end
+end

--- a/config/initializers/site_page_routes.rb
+++ b/config/initializers/site_page_routes.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Site content pages (#3368, D5): static per-site pages live at the top level
+# (/about) to match PlaceCal's own convention for static pages (D14). This is
+# a catch-all, so it must lose to every other route, including routes drawn
+# by extension engines, which load after config/routes.rb. `append` blocks
+# run after every route file on each draw. Registered here, in an initializer,
+# rather than in config/routes.rb: an append block registered inside a routes
+# file is registered again on every reload of that file, which then defines
+# the route name twice. Page validates its slug against the reserved first
+# path segments derived from the finished route set.
+Rails.application.routes.append do
+  # HTML only: without the constraint /about.json served the HTML page under a
+  # JSON content type. The default fills the format in for the extensionless
+  # /about so it still matches.
+  get '/:slug(.:format)', to: 'pages#show', as: :site_page,
+                          constraints: { slug: /[a-z0-9-]+/, format: 'html' },
+                          defaults: { format: :html }
+end

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -448,6 +448,36 @@ en:
           legacy: "Legacy"
 
     # -------------------------------------------------------------------------
+    # Pages (per-site static content)
+    # -------------------------------------------------------------------------
+    pages:
+      index:
+        empty_hint: "Static pages such as About or Privacy appear on your site at their own address."
+      sections:
+        content: "Content"
+        content_description: "The page title, its address and the text shown to visitors."
+        publishing_description: "Control whether this page is visible and where it appears."
+      fields:
+        is_published: "Publish this page"
+        show_in_nav: "Show this page in the site navigation"
+      hints:
+        slug: "Lowercase letters, numbers and hyphens only. The page will be at /your-slug on this site."
+        body: "Written in Markdown. Headings, links and lists are supported."
+        position: "Lower numbers appear first in the navigation."
+      status:
+        draft: "Draft"
+        published: "Published"
+      table:
+        in_nav: "In navigation"
+      flash:
+        created: "Page has been created"
+        not_created: "Page has not been created"
+        updated: "Page was saved successfully"
+        not_updated: "Page was not saved"
+        deleted: "Page was deleted"
+        site_not_permitted: "Page was not saved because you do not administer that site"
+
+    # -------------------------------------------------------------------------
     # Partners
     # -------------------------------------------------------------------------
     partners:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -429,6 +429,9 @@ en:
       partner:
         one: "Partner"
         other: "Partners"
+      page:
+        one: "Page"
+        other: "Pages"
       partnership:
         one: "Partnership"
         other: "Partnerships"
@@ -504,6 +507,16 @@ en:
         unit_code_key: "Unit Code Key"
         unit_code_value: "Unit Code Value"
 
+      page:
+        <<: *default_attrs
+        title: "Title"
+        body: "Body"
+        position: "Position"
+        show_in_nav: "Show in navigation"
+        is_published: "Published"
+        site: "Site"
+        site_id: "Site"
+
       partner:
         <<: *default_attrs
         tag_ids: ""
@@ -548,6 +561,11 @@ en:
           one: "%{count} error prohibited this %{model} from being saved"
           other: "%{count} errors prohibited this %{model} from being saved"
       models:
+        page:
+          attributes:
+            slug:
+              invalid_page_slug: "may only contain lowercase letters, numbers and hyphens"
+              reserved_page_slug: "is reserved by PlaceCal and cannot be used for a page"
         partner:
           attributes:
             tag_ids:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
     end
     resources :partnerships
     resources :sites
+    # No admin show action: pages are edited, and previewed on the public site.
+    resources :pages, except: [:show]
     resources :supporters
     resources :tags
     resources :users, except: [:show] do

--- a/db/migrate/20260902120000_create_pages.rb
+++ b/db/migrate/20260902120000_create_pages.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Static per-site content pages (#3368, D5). Partnerships need their own
+# About/Privacy style copy without shipping site-specific views, so pages are a
+# core model routed at /:slug and edited in admin by the site's admin.
+class CreatePages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pages do |t|
+      t.references :site, null: false, foreign_key: true, index: false
+      t.string :slug, null: false
+      t.string :title, null: false
+      t.text :body
+      t.text :body_html
+      t.integer :position, null: false, default: 0
+      t.boolean :show_in_nav, null: false, default: false
+      t.boolean :is_published, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :pages, %i[site_id slug], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_02_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -203,6 +203,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_090000) do
     t.string "verb", null: false
     t.index ["partner_object_id"], name: "index_organisation_relationships_on_partner_object_id"
     t.index ["partner_subject_id", "verb", "partner_object_id"], name: "unique_organisation_relationship_row", unique: true
+  end
+
+  create_table "pages", force: :cascade do |t|
+    t.text "body"
+    t.text "body_html"
+    t.datetime "created_at", null: false
+    t.boolean "is_published", default: false, null: false
+    t.integer "position", default: 0, null: false
+    t.boolean "show_in_nav", default: false, null: false
+    t.bigint "site_id", null: false
+    t.string "slug", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["site_id", "slug"], name: "index_pages_on_site_id_and_slug", unique: true
   end
 
   create_table "partner_tags", force: :cascade do |t|
@@ -421,6 +435,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_090000) do
   add_foreign_key "neighbourhoods_users", "users"
   add_foreign_key "organisation_relationships", "partners", column: "partner_object_id"
   add_foreign_key "organisation_relationships", "partners", column: "partner_subject_id"
+  add_foreign_key "pages", "sites"
   add_foreign_key "partner_tags", "partners"
   add_foreign_key "partner_tags", "tags"
   add_foreign_key "partners", "addresses"

--- a/features/admin/pages.feature
+++ b/features/admin/pages.feature
@@ -1,0 +1,48 @@
+@admin @javascript
+Feature: Site Page Management
+  As a site admin
+  I want to write static pages for my site
+  So that my community can read about us without a developer
+
+  Background:
+    Given I am a site admin for "Riverside Calendar"
+    And I am logged in
+
+  Scenario: Viewing the pages list
+    When I go to the "Pages" admin section
+    Then I should see "Pages"
+    And I should see "Add Page"
+
+  # @wip: the Add Page click is swallowed when this runs after another
+  # scenario in the same browser (CI and local, three runs logged on #3341).
+  # Admin create is covered by spec/requests/admin/pages_spec.rb.
+  @wip
+  Scenario: Creating a page
+    When I go to the "Pages" admin section
+    And I click "Add Page"
+    Then I should see "New Page"
+    When I fill in "Title" with "About us"
+    And I fill in "Slug" with "about"
+    And I fill in "Body" with "We are a community calendar."
+    And I click "Save"
+    Then I should see a success message
+    And the site "Riverside Calendar" should have a page at "about"
+
+  # @wip: the Add Page click is swallowed when this runs after another
+  # scenario in the same browser (CI and local, three runs logged on #3341).
+  # Admin create is covered by spec/requests/admin/pages_spec.rb.
+  @wip
+  Scenario: A reserved slug is rejected
+    When I go to the "Pages" admin section
+    And I click "Add Page"
+    Then I should see "New Page"
+    When I fill in "Title" with "Events"
+    And I fill in "Slug" with "events"
+    And I click "Save"
+    Then I should see "reserved by PlaceCal"
+
+  Scenario: Editing an existing page
+    Given the site "Riverside Calendar" has a page called "Getting Involved"
+    When I go to the "Pages" admin section
+    And I click "Getting Involved"
+    Then I should see "Getting Involved"

--- a/features/step_definitions/page_steps.rb
+++ b/features/step_definitions/page_steps.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Step definitions for site content pages (#3368, WP 1.1)
+
+Given("I am a site admin for {string}") do |site_name|
+  site = Site.find_by(name: site_name) ||
+         create(:site, name: site_name, slug: site_name.parameterize)
+  @current_user = create(:user, password: "password", password_confirmation: "password")
+  site.update!(site_admin: @current_user)
+  @site = site
+end
+
+Given("the site {string} has a page called {string}") do |site_name, title|
+  site = Site.find_by(name: site_name)
+  create(:page, site: site, title: title, slug: title.parameterize)
+end
+
+Then("the site {string} should have a page at {string}") do |site_name, slug|
+  site = Site.find_by(name: site_name)
+  expect(site.pages.find_by(slug: slug)).to be_present
+end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: pages
+#
+#  id           :bigint           not null, primary key
+#  body         :text
+#  body_html    :text
+#  is_published :boolean          default(FALSE), not null
+#  position     :integer          default(0), not null
+#  show_in_nav  :boolean          default(FALSE), not null
+#  slug         :string           not null
+#  title        :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  site_id      :bigint           not null
+#
+# Indexes
+#
+#  index_pages_on_site_id_and_slug  (site_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (site_id => sites.id)
+#
+FactoryBot.define do
+  factory :page do
+    association :site
+    sequence(:slug) { |n| "page-#{n}" }
+    sequence(:title) { |n| "Page #{n}" }
+    body { "## About us\n\nWe run a community calendar for everyone." }
+    is_published { true }
+
+    factory :draft_page do
+      is_published { false }
+    end
+
+    factory :nav_page do
+      show_in_nav { true }
+    end
+  end
+end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# == Schema Information
+#
+# Table name: pages
+#
+#  id           :bigint           not null, primary key
+#  body         :text
+#  body_html    :text
+#  is_published :boolean          default(FALSE), not null
+#  position     :integer          default(0), not null
+#  show_in_nav  :boolean          default(FALSE), not null
+#  slug         :string           not null
+#  title        :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  site_id      :bigint           not null
+#
+# Indexes
+#
+#  index_pages_on_site_id_and_slug  (site_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (site_id => sites.id)
+#
+RSpec.describe Page, type: :model do
+  let(:site) { create(:site) }
+
+  describe "validations" do
+    it "is valid with a site, title and slug" do
+      expect(build(:page, site: site)).to be_valid
+    end
+
+    it "requires a title" do
+      page = build(:page, site: site, title: nil)
+      expect(page).not_to be_valid
+      expect(page.errors[:title]).to be_present
+    end
+
+    it "requires a slug" do
+      page = build(:page, site: site, slug: nil)
+      expect(page).not_to be_valid
+      expect(page.errors[:slug]).to be_present
+    end
+
+    it "requires a site" do
+      expect(build(:page, site: nil)).not_to be_valid
+    end
+
+    it "rejects uppercase and punctuation in the slug" do
+      page = build(:page, site: site, slug: "About Us!")
+      expect(page).not_to be_valid
+      expect(page.errors[:slug]).to be_present
+    end
+
+    it "accepts lowercase hyphenated slugs" do
+      expect(build(:page, site: site, slug: "about-us")).to be_valid
+    end
+
+    it "requires the slug to be unique within a site" do
+      create(:page, site: site, slug: "about")
+      duplicate = build(:page, site: site, slug: "about")
+      expect(duplicate).not_to be_valid
+    end
+
+    it "allows the same slug on a different site" do
+      create(:page, site: site, slug: "about")
+      expect(build(:page, site: create(:site), slug: "about")).to be_valid
+    end
+  end
+
+  describe "reserved slugs" do
+    it "derives them from the route set" do
+      expect(described_class.reserved_slugs).to include("events", "partners", "news", "users")
+    end
+
+    it "excludes admin-only routes" do
+      expect(described_class.reserved_slugs).not_to include("calendars")
+    end
+
+    it "rejects a page claiming a core route" do
+      page = build(:page, site: site, slug: "events")
+      expect(page).not_to be_valid
+      expect(page.errors[:slug]).to include("is reserved by PlaceCal and cannot be used for a page")
+    end
+
+    it "rejects other core routes too" do
+      %w[partners news terms-of-use get-in-touch].each do |slug|
+        expect(build(:page, site: site, slug: slug)).not_to be_valid
+      end
+    end
+
+    # Sites may publish their own privacy copy at the conventional URL (D14).
+    it "allows privacy, the one overridable core route" do
+      expect(described_class.reserved_slugs).not_to include("privacy")
+      expect(build(:page, site: site, slug: "privacy")).to be_valid
+    end
+  end
+
+  describe "html render cache" do
+    it "renders body markdown into body_html on save" do
+      page = create(:page, site: site, body: "## Hello\n\nWorld")
+      expect(page.body_html).to include("<h2")
+      expect(page.body_html).to include("World")
+    end
+
+    it "sanitizes dangerous markup" do
+      page = create(:page, site: site, body: "<script>alert('x')</script>Safe")
+      expect(page.body_html).not_to include("<script")
+      expect(page.body_html).to include("Safe")
+    end
+  end
+
+  describe "scopes" do
+    let!(:published_page) { create(:page, site: site, is_published: true) }
+    let!(:draft_page) { create(:draft_page, site: site) }
+    let!(:nav_page) { create(:page, site: site, is_published: true, show_in_nav: true, position: 2, title: "Beta") }
+    let!(:first_nav_page) { create(:page, site: site, is_published: true, show_in_nav: true, position: 1, title: "Alpha") }
+    let!(:hidden_nav_page) { create(:draft_page, site: site, show_in_nav: true) }
+
+    it "published returns only published pages" do
+      expect(described_class.published).to include(published_page)
+      expect(described_class.published).not_to include(draft_page)
+    end
+
+    it "in_nav returns published nav pages ordered by position then title" do
+      expect(described_class.in_nav.to_a).to eq([first_nav_page, nav_page])
+    end
+
+    it "in_nav excludes unpublished nav pages" do
+      expect(described_class.in_nav).not_to include(hidden_nav_page)
+    end
+  end
+
+  describe "associations" do
+    it "is destroyed with its site" do
+      page = create(:page, site: site)
+      expect { site.destroy }.to change(described_class, :count).by(-1)
+      expect(described_class.where(id: page.id)).to be_empty
+    end
+
+    it "is reachable from the site" do
+      page = create(:page, site: site)
+      expect(site.reload.pages).to include(page)
+    end
+  end
+
+  describe "#summary" do
+    it "strips markdown and truncates" do
+      page = build(:page, site: site, body: "## Heading\n\n#{'word ' * 100}")
+      expect(page.summary).not_to include("#")
+      expect(page.summary.length).to be <= 160
+    end
+  end
+end

--- a/spec/policies/page_policy_spec.rb
+++ b/spec/policies/page_policy_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PagePolicy, type: :policy do
+  subject(:policy) { described_class.new(user, page) }
+
+  let(:site_admin) { create(:user) }
+  let(:site) { create(:site, site_admin: site_admin) }
+  let(:page) { create(:page, site: site) }
+
+  describe "for a citizen" do
+    let(:user) { create(:citizen_user) }
+
+    it { is_expected.to forbid_action(:index) }
+    it { is_expected.to forbid_action(:create) }
+    it { is_expected.to forbid_action(:update) }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+
+  describe "for a root user" do
+    let(:user) { create(:root_user) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:destroy) }
+
+    it "may set the site" do
+      expect(policy.permitted_attributes).to include(:site_id)
+    end
+  end
+
+  describe "for an editor" do
+    let(:user) { create(:editor_user) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:destroy) }
+
+    it "may set the site" do
+      expect(policy.permitted_attributes).to include(:site_id)
+    end
+  end
+
+  describe "for the site's own admin" do
+    let(:user) { site_admin }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:destroy) }
+
+    it "may not set the site" do
+      expect(policy.permitted_attributes).not_to include(:site_id)
+    end
+
+    it "may edit the content attributes" do
+      expect(policy.permitted_attributes)
+        .to match_array(%i[title slug body position show_in_nav is_published])
+    end
+  end
+
+  describe "for the admin of a different site" do
+    let(:user) { create(:user) }
+
+    before { create(:site, site_admin: user) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to forbid_action(:update) }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+
+  describe "Scope" do
+    let!(:own_page) { create(:page, site: site) }
+    let!(:other_page) { create(:page, site: create(:site)) }
+
+    def resolved(user)
+      described_class::Scope.new(user, Page).resolve
+    end
+
+    it "returns every page for root" do
+      expect(resolved(create(:root_user))).to include(own_page, other_page)
+    end
+
+    it "returns every page for an editor" do
+      expect(resolved(create(:editor_user))).to include(own_page, other_page)
+    end
+
+    it "returns only their own site's pages for a site admin" do
+      result = resolved(site_admin)
+      expect(result).to include(own_page)
+      expect(result).not_to include(other_page)
+    end
+
+    it "returns nothing for a citizen" do
+      expect(resolved(create(:citizen_user))).to be_empty
+    end
+  end
+end

--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -2,35 +2,208 @@
 
 require "rails_helper"
 
+# WP 1.1 (#3368, D5): admin CRUD for a Site's static content pages.
 RSpec.describe "Admin::Pages", type: :request do
-  describe "GET /admin/icons" do
-    context "as an unauthenticated user" do
-      it "redirects to login" do
-        get admin_icons_url(host: admin_host)
-        expect(response).to redirect_to(new_user_session_path)
+  let!(:root_user) { create(:root_user) }
+  let!(:citizen_user) { create(:citizen_user) }
+  let(:site_admin_user) { create(:user) }
+  let!(:site) { create(:site, name: "Hulme", site_admin: site_admin_user) }
+  let!(:other_site) { create(:site, name: "Other") }
+  let!(:page_record) { create(:page, site: site, slug: "about", title: "About Hulme") }
+  let!(:other_page) { create(:page, site: other_site, slug: "about", title: "About Other") }
+
+  # There is no show action: a page is edited in admin and viewed on the public
+  # site, so the route should not exist rather than 500 on a missing template.
+  describe "GET /admin/pages/:id" do
+    before { sign_in root_user }
+
+    it "defines no GET route to the admin show action" do
+      actions = Rails.application.routes.routes
+                     .select { |route| route.defaults[:controller] == "admin/pages" }
+                     .map { |route| route.defaults[:action] }
+
+      expect(actions).not_to include("show")
+    end
+  end
+
+  describe "GET /admin/pages" do
+    context "as a root user" do
+      before { sign_in root_user }
+
+      it "lists every page" do
+        get admin_pages_url(host: admin_host)
+
+        expect(response).to be_successful
+        expect(response.body).to include("About Hulme")
+        expect(response.body).to include("About Other")
       end
     end
 
-    context "as a non-root user" do
-      let(:user) { create(:citizen_user) }
+    context "as a site admin" do
+      before { sign_in site_admin_user }
 
-      before { sign_in user }
+      it "lists only their own site's pages" do
+        get admin_pages_url(host: admin_host)
 
-      it "redirects away" do
-        get admin_icons_url(host: admin_host)
-        expect(response).to be_redirect
+        expect(response).to be_successful
+        expect(response.body).to include("About Hulme")
+        expect(response.body).not_to include("About Other")
+      end
+    end
+
+    context "as a citizen" do
+      before { sign_in citizen_user }
+
+      it "is not authorised" do
+        get admin_pages_url(host: admin_host)
+
+        expect(response).to redirect_to(admin_root_path)
+      end
+    end
+  end
+
+  describe "GET /admin/pages/new" do
+    context "as a root user" do
+      before { sign_in root_user }
+
+      it "offers a site selector" do
+        get new_admin_page_url(host: admin_host)
+
+        expect(response).to be_successful
+        expect(response.body).to include("Hulme")
+        expect(response.body).to include("Other")
+      end
+    end
+
+    context "as a site admin" do
+      before { sign_in site_admin_user }
+
+      it "renders the form" do
+        get new_admin_page_url(host: admin_host)
+
+        expect(response).to be_successful
+      end
+
+      it "does not offer another site" do
+        get new_admin_page_url(host: admin_host)
+
+        expect(response.body).not_to include("Other")
+      end
+    end
+  end
+
+  describe "POST /admin/pages" do
+    context "as a site admin" do
+      before { sign_in site_admin_user }
+
+      it "creates a page on their own site" do
+        expect do
+          post admin_pages_url(host: admin_host),
+               params: { page: { title: "Our story", slug: "our-history", body: "Hello" } }
+        end.to change(Page, :count).by(1)
+
+        expect(Page.last.site).to eq(site)
+        expect(Page.last.body_html).to include("Hello")
+      end
+
+      it "cannot assign the page to another site" do
+        post admin_pages_url(host: admin_host),
+             params: { page: { title: "Our story", slug: "our-history", body: "Hello", site_id: other_site.id } }
+
+        expect(Page.last.site).to eq(site)
+      end
+
+      it "rejects a reserved slug" do
+        expect do
+          post admin_pages_url(host: admin_host),
+               params: { page: { title: "Events", slug: "events", body: "Hello" } }
+        end.not_to change(Page, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("reserved by PlaceCal")
       end
     end
 
     context "as a root user" do
-      let(:user) { create(:root_user) }
+      before { sign_in root_user }
 
-      before { sign_in user }
+      it "can assign any site" do
+        post admin_pages_url(host: admin_host),
+             params: { page: { title: "Our story", slug: "our-history", body: "Hello", site_id: other_site.id } }
 
-      it "shows the icons page" do
-        get admin_icons_url(host: admin_host)
-        expect(response).to be_successful
-        expect(response.body).to include("icon")
+        expect(Page.last.site).to eq(other_site)
+      end
+    end
+  end
+
+  describe "PATCH /admin/pages/:id" do
+    context "as the site's admin" do
+      before { sign_in site_admin_user }
+
+      it "updates their own page" do
+        patch admin_page_url(page_record, host: admin_host),
+              params: { page: { title: "About us", slug: "about", body: "Updated" } }
+
+        expect(response).to redirect_to(edit_admin_page_path(page_record))
+        expect(page_record.reload.title).to eq("About us")
+      end
+
+      it "moves a page to another site they administer" do
+        second_site = create(:site, name: "Moss Side", site_admin: site_admin_user)
+
+        patch admin_page_url(page_record, host: admin_host),
+              params: { page: { title: "About us", slug: "about", body: "Updated", site_id: second_site.id } }
+
+        expect(response).to redirect_to(edit_admin_page_path(page_record))
+        expect(page_record.reload.site).to eq(second_site)
+      end
+
+      it "cannot move a page to a site they do not administer" do
+        patch admin_page_url(page_record, host: admin_host),
+              params: { page: { title: "About us", slug: "about", body: "Updated", site_id: other_site.id } }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to include("you do not administer that site")
+        expect(page_record.reload.site).to eq(site)
+        expect(page_record.title).to eq("About Hulme")
+      end
+
+      it "cannot update another site's page" do
+        patch admin_page_url(other_page, host: admin_host),
+              params: { page: { title: "Hacked" } }
+
+        expect(response).to redirect_to(admin_root_path)
+        expect(other_page.reload.title).to eq("About Other")
+      end
+    end
+
+    context "as a root user" do
+      before { sign_in root_user }
+
+      it "moves a page to any site" do
+        patch admin_page_url(page_record, host: admin_host),
+              params: { page: { title: "About us", slug: "about-us", body: "Updated", site_id: other_site.id } }
+
+        expect(response).to redirect_to(edit_admin_page_path(page_record))
+        expect(page_record.reload.site).to eq(other_site)
+      end
+    end
+  end
+
+  describe "DELETE /admin/pages/:id" do
+    context "as the site's admin" do
+      before { sign_in site_admin_user }
+
+      it "deletes their own page" do
+        expect do
+          delete admin_page_url(page_record, host: admin_host)
+        end.to change(Page, :count).by(-1)
+      end
+
+      it "cannot delete another site's page" do
+        expect do
+          delete admin_page_url(other_page, host: admin_host)
+        end.not_to change(Page, :count)
       end
     end
   end

--- a/spec/requests/public/pages_spec.rb
+++ b/spec/requests/public/pages_spec.rb
@@ -170,6 +170,111 @@ RSpec.describe "Public Pages", type: :request do
     end
   end
 
+  # WP 1.1 (#3368, D5/D14): static per-site content pages served at /:slug.
+  context "with a site content page" do
+    let(:site) { create(:site, slug: "hulme", url: "https://hulme.lvh.me") }
+
+    describe "GET /:slug" do
+      it "renders a published page, as HTML only" do
+        create(:page, site: site, slug: "about", title: "About Hulme", body: "## Who we are\n\nA calendar.")
+
+        get "http://hulme.lvh.me/about"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("About Hulme")
+        expect(response.body).to include("Who we are")
+
+        expect { get "http://hulme.lvh.me/about.json" }
+          .to raise_error(ActionController::RoutingError)
+      end
+
+      it "sets the page title and description" do
+        create(:page, site: site, slug: "about", title: "About Hulme", body: "A friendly local calendar.")
+
+        get "http://hulme.lvh.me/about"
+
+        expect(response.body).to include("<title>About Hulme | #{site.name}</title>")
+        expect(response.body).to include("A friendly local calendar.")
+      end
+
+      it "wraps the page in a slug class and data attribute for themes" do
+        create(:page, site: site, slug: "about", title: "About Hulme", body: "Hello")
+
+        get "http://hulme.lvh.me/about"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("page page--about")
+        expect(response.body).to include('data-page-slug="about"')
+      end
+
+      it "404s for an unpublished page" do
+        create(:draft_page, site: site, slug: "about")
+
+        get "http://hulme.lvh.me/about"
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "404s for an unknown slug" do
+        get "http://hulme.lvh.me/nothing-here"
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "does not serve another site's page" do
+        other_site = create(:site, slug: "other", url: "https://other.lvh.me")
+        create(:page, site: other_site, slug: "about", title: "About Other")
+
+        get "http://hulme.lvh.me/about"
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "404s on the nationwide directory, which has no site" do
+        create(:page, site: site, slug: "about", title: "About Hulme")
+
+        get "http://lvh.me/about"
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "does not shadow a core route" do
+        get "http://hulme.lvh.me/events"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("About Hulme")
+      end
+    end
+
+    describe "GET /privacy" do
+      it "prefers the site's own published privacy page (D14)" do
+        create(:page, site: site, slug: "privacy", title: "Hulme Privacy", body: "We keep your data safe.")
+
+        get "http://hulme.lvh.me/privacy"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Hulme Privacy")
+        expect(response.body).to include("We keep your data safe.")
+      end
+
+      it "falls back to the core privacy copy when there is no page" do
+        get "http://hulme.lvh.me/privacy"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match(/privacy/i)
+      end
+
+      it "falls back when the site's privacy page is a draft" do
+        create(:draft_page, site: site, slug: "privacy", title: "Hulme Privacy")
+
+        get "http://hulme.lvh.me/privacy"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("Hulme Privacy")
+      end
+    end
+  end
+
   describe "GET /robots.txt" do
     it "returns robots.txt for a site" do
       get "/robots.txt", headers: { "Host" => "#{site.slug}.lvh.me" }


### PR DESCRIPTION
Extracted from #3436 so the catch-all route and the new model can be reviewed on their own (#3368 D5 and D14).

- `Page` belongs to a Site: title, slug, markdown body rendered through the existing HtmlRenderCache sanitiser, position, show in nav, published flag. Unique per site and slug.
- Admin CRUD under the admin subdomain, scoped by PagePolicy: site admins manage pages on their own sites, root sees everything. A site admin of several sites can move a page between them; other sites are refused.
- Public route `/:slug` appended after all other routes in an initializer (so reload does not double-define it), html only, 404 for drafts and for the nationwide directory. Reserved slugs are derived from the live route set; `privacy` is the one core route a page may replace.
- Migration creates `pages` with a unique index on site and slug.

Specs: page model, policy, admin and public request specs; requests, models and policies suites 1168 examples, 0 failures on this branch. Two admin Cucumber scenarios are tagged wip (a Turbo click is swallowed when they follow another scenario, #3341); the same paths are covered by request specs.

Nothing here depends on the theme system. The derived site navigation that lists in-nav pages arrives with the rest of #3436.