### PR TITLE
WP 4.1: footer from derived nav, theme settings table, theme resolved once, one region guard, consistency

### DIFF
--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -75,7 +75,7 @@ class Components::EventFilter < Components::Base
   # existing dated event URLs. No new query parameters; sort and repeating ride
   # along only when they differ from the controller defaults.
   def render_day_strip
-    nav(class: 'day-strip min-w-0 overflow-x-auto', aria: { label: t('events.filter.day_strip.label') }) do
+    nav(class: 'day-strip min-w-0 overflow-x-auto', aria: { label: t('filters.day_strip.label') }) do
       ul(class: 'flex list-none gap-2 whitespace-nowrap p-0 m-0') do
         day_strip_dates.each_with_index do |date, index|
           li(class: 'shrink-0') { render_day_strip_day(date, index) }
@@ -96,7 +96,7 @@ class Components::EventFilter < Components::Base
 
   def render_day_strip_all_upcoming
     current = @period == 'future'
-    link_to(t('events.filter.day_strip.all_upcoming'),
+    link_to(t('filters.day_strip.all_upcoming'),
             "#{events_path(**day_strip_params, period: 'future')}#paginator",
             class: day_strip_link_class(current),
             aria: { current: current ? 'true' : nil },
@@ -110,9 +110,9 @@ class Components::EventFilter < Components::Base
 
   def day_strip_label(date, index)
     case index
-    when 0 then t('events.filter.day_strip.today')
-    when 1 then t('events.filter.day_strip.tomorrow')
-    else date.strftime(t('events.filter.day_strip.date_format'))
+    when 0 then t('filters.day_strip.today')
+    when 1 then t('filters.day_strip.tomorrow')
+    else date.strftime(t('filters.day_strip.date_format'))
     end
   end
 

--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -24,7 +24,7 @@ class Components::EventFilter < Components::Base
   end
 
   def view_template
-    RegionFilter(tags: @region_tags, selected: @selected_region) if @region_tags.size > 1
+    RegionFilter(tags: @region_tags, selected: @selected_region)
     if filter_style == :day_strip
       render_day_strip
     else

--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -38,7 +38,7 @@ class Components::EventFilter < Components::Base
 
   # @return [Symbol] :date_picker or :day_strip, from the site's theme (D22)
   def filter_style
-    @filter_style || @site&.theme_definition&.event_filter_style || :date_picker
+    @filter_style || PlaceCal::Theme.for(@site).event_filter_style
   end
 
   def render_date_picker

--- a/app/components/footer.rb
+++ b/app/components/footer.rb
@@ -4,6 +4,8 @@ class Components::Footer < Components::Base
   include Phlex::Rails::Helpers::MailTo
 
   prop :site, _Nilable(::Site), :positional, default: nil
+  # The derived site navigation (SiteNavigation), passed through by the layout.
+  prop :navigation, _Nilable(_Array(_Any)), default: nil
 
   def view_template
     footer(class: 'footer') do
@@ -54,36 +56,24 @@ class Components::Footer < Components::Base
     end
   end
 
-  # The footer mirrors the derived site nav (#3368 D6), plus the legal and
-  # log-in links the footer has always carried.
+  # The footer shows the same derived site nav as the header (#3368 D6), so the
+  # region param, the news link and the theme's nav_join rule all follow from
+  # one place, plus the legal and log-in links the footer has always carried.
   def nav_links
     return directory_nav_links if @site.nil?
 
-    links = [
-      [t('navigation.site.home'), root_path],
-      [t('navigation.site.events'), events_path],
-      [t('navigation.site.partners'), partners_path]
-    ]
-    links << [t('navigation.site.news'), news_index_path] if @site.news_article_count.positive?
-    links += site_page_links
-    links << [privacy_label, privacy_path]
+    links = Array(@navigation).dup
+    links << [privacy_label, privacy_path] unless links.any? { |(_label, path)| path == privacy_path }
     links << [t('navigation.site.terms'), terms_of_use_path]
-    links << [t('navigation.site.join'), get_in_touch_path] if @site.contact_email.present?
     links << [t('navigation.site.log_in'), new_user_session_path]
     links
   end
 
   # When the site publishes its own privacy page, the footer link carries that
-  # page's title so it matches the header nav.
+  # page's title so it matches the header nav. A privacy page that is already in
+  # the nav arrives with the derived links and is not added again.
   def privacy_label
     @site.pages.published.find_by(slug: 'privacy')&.title.presence || t('navigation.site.privacy')
-  end
-
-  # A site's own `privacy` page is served by privacy_path (see Page's
-  # OVERRIDABLE_ROUTE_SLUGS), so listing it here too would duplicate the link.
-  def site_page_links
-    @site.pages.in_nav.reject { |page| page.slug == 'privacy' }
-         .map { |page| [page.title, site_page_path(page.slug)] }
   end
 
   def directory_nav_links

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -86,7 +86,7 @@ class Components::Navigation < Components::Base
   # Theme call-to-action (#3368 D1): a theme may register `nav_cta`, for
   # example a Donate link; core renders it as the last nav item.
   def theme_cta
-    @theme_cta ||= @site&.theme_definition&.nav_cta
+    @theme_cta ||= PlaceCal::Theme.for(@site).nav_cta
   end
 
   def render_theme_cta
@@ -175,7 +175,7 @@ class Components::Navigation < Components::Base
   # The directory always labels its menu toggle; a site does so only when its
   # theme opts in with `menu_label true` (#3368 D1).
   def show_menu_label?
-    @site.nil? || @site.theme_definition&.menu_label? || false
+    @site.nil? || PlaceCal::Theme.for(@site).menu_label?
   end
 
   def render_toggle

--- a/app/components/partner_filter.rb
+++ b/app/components/partner_filter.rb
@@ -16,7 +16,7 @@ class Components::PartnerFilter < Components::Base
   end
 
   def view_template
-    RegionFilter(tags: @region_tags, selected: @selected_region) if @region_tags.size > 1
+    RegionFilter(tags: @region_tags, selected: @selected_region)
 
     form_with(**form_data, class: 'filters__form') do
       hidden_field_tag(:region, @selected_region.slug) if @selected_region

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   # Serves both the admin dashboard (#home, the admin root) and CRUD for a
-  # Site's static content pages (#3368, WP 1.1). The dashboard actions predate
+  # Site's static content pages (#3368, D5). The dashboard actions predate
   # the Page model and are exempt from Pundit's verification callbacks.
   class PagesController < Admin::ApplicationController
     DASHBOARD_ACTIONS = %i[home icons].freeze

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -238,10 +238,11 @@ class ApplicationController < ActionController::Base
     @site = current_site
   end
 
-  # Makes the resolved site available to the view layer for the request
-  # (see Current and PlaceCal::ThemeTranslation).
+  # Makes the resolved site and its theme available to the view layer for the
+  # request (see Current and PlaceCal::ThemeTranslation).
   def set_current_site
     Current.site = current_site
+    Current.theme = PlaceCal::Theme.for(current_site)
   end
 
   def redirect_from_directory

--- a/app/controllers/concerns/region_filterable.rb
+++ b/app/controllers/concerns/region_filterable.rb
@@ -23,8 +23,10 @@ module RegionFilterable
     @region_tags ||= current_site ? current_site.tags.where(type: 'Partnership').order(:name).to_a : []
   end
 
-  # Only worth offering the filter when there is more than one region to
-  # choose between; sites with zero or one Partnership tag see no change.
+  # Whether the filter is worth offering: only when there is more than one
+  # region to choose between. Components::RegionFilter applies this rule itself,
+  # so callers pass region_tags unconditionally; this predicate is for views
+  # that wrap the filter in their own markup and need to know first.
   #
   # @return [Boolean]
   def region_filter?

--- a/app/controllers/concerns/site_navigation.rb
+++ b/app/controllers/concerns/site_navigation.rb
@@ -52,7 +52,7 @@ module SiteNavigation
 
   def join_navigation
     return [] if current_site&.contact_email.blank?
-    return [] if current_site.theme_definition&.nav_join? == false
+    return [] unless Current.theme.nav_join?
 
     [[t('navigation.site.join'), get_in_touch_path]]
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -140,7 +140,7 @@ class EventsController < ApplicationController
             selected_neighbourhood: @selected_neighbourhood,
             next_date: @next_date, truncated: @truncated,
             show_monthly: @show_monthly,
-            region_tags: (region_filter? ? region_tags : []), selected_region: @region
+            region_tags: region_tags, selected_region: @region
           )
         end
       end

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -34,18 +34,14 @@ class ManifestsController < ApplicationController
     head :not_found if site.nil?
   end
 
-  def theme_definition
-    site&.theme_definition
-  end
-
   def theme_color
-    theme_definition&.theme_color || '#f19089'
+    Current.theme.theme_color || '#f19089'
   end
 
-  # A theme may set a distinct splash background (#3368 WP 3.9); it falls
-  # back to the theme colour, which is what core has always used for both.
+  # A theme may set a distinct splash background (#3368 D1); it falls back to
+  # the theme colour, which is what core has always used for both.
   def background_color
-    theme_definition&.manifest_background_color || theme_color
+    Current.theme.manifest_background_color || theme_color
   end
 
   # The site's tagline, when it has one. Site#og_description returns false
@@ -55,9 +51,9 @@ class ManifestsController < ApplicationController
   end
 
   def icons
-    theme_icons = theme_definition&.icons || {}
+    theme_icons = Current.theme.icons
 
-    # A theme's own manifest icons win over the site logo (#3368 WP 3.9).
+    # A theme's own manifest icons win over the site logo (#3368 D1).
     if theme_icons[:icon_192] || theme_icons[:icon_512]
       manifest_icons_for(theme_icons)
     elsif site.logo.present? && site.logo.file&.content_type == 'image/png'

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -42,13 +42,13 @@ class NewsController < ApplicationController
   end
 
   # Sites that consumed PlaceCal news through the API built their own URLs
-  # from the article title (#3368 WP 1.9), which does not always match the
+  # from the article title (#3368), which does not always match the
   # slug stored here. When the requested slug matches a published article's
   # title-derived slug, send the visitor to the canonical URL instead of a
   # 404. Generic: keyed on nothing site-specific.
   #
   # Only slugs and titles are read, and only from the articles this site
-  # publishes, so a 404 never loads every article body (#3368 WP 3.1).
+  # publishes, so a 404 never loads every article body (#3368).
   #
   # @return [String, nil] canonical slug of the matching article
   def published_slug_by_title_slug

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -189,7 +189,7 @@ class PartnersController < ApplicationController
       partners: @partners, site: @site,
       map: @map, selected_category: @selected_category,
       selected_neighbourhood: @selected_neighbourhood,
-      region_tags: (region_filter? ? region_tags : []), selected_region: @region
+      region_tags: region_tags, selected_region: @region
     )
   end
 end

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -156,7 +156,7 @@ class SitemapsController < ApplicationController
     wrap_urlset(urls.uniq)
   end
 
-  # Editable per-site pages (WP 1.1).
+  # Editable per-site pages (#3368 D5).
   def site_page_entries
     site_pages.map do |slug, updated_at|
       url_entry("#{base_url}/#{slug}", updated_at)

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -10,7 +10,7 @@ class SitesController < ApplicationController
   def index
     # A theme registered by an extension may supply its own homepage view
     # (#3368, D3); otherwise core's existing behaviour applies.
-    view_class = current_site.theme_definition&.homepage_view_class
+    view_class = Current.theme.homepage_view_class
 
     if view_class
       render view_class.new(site: @site)

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -20,7 +20,7 @@ class SitesController < ApplicationController
       render Views::Sites::Default.new(
         site: @site, places_to_get_computer_access: @places_to_get_computer_access,
         places_with_free_wifi: @places_with_free_wifi,
-        region_tags: (region_filter? ? region_tags : []), selected_region: current_region
+        region_tags: region_tags, selected_region: current_region
       )
     end
   end

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -67,7 +67,7 @@ module MapHelper
     # The theme definition resolves the style name (the legacy :custom theme
     # resolves it from the site's slug, e.g. 'mossley'). Sites with no site
     # record or an unregistered theme fall back to pink.
-    style_name = site_record&.theme_definition&.map_style_for(site_record) || 'pink'
+    style_name = PlaceCal::Theme.for(site_record).map_style_for(site_record) || 'pink'
 
     # A style ships either in core's public/map-styles or, for extensions, as
     # an asset at map-styles/<name>.json (e.g. app/assets/builds/map-styles/).

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -6,5 +6,12 @@
 # translations (PlaceCal::ThemeTranslation) can reach it without threading
 # the site through every component.
 class Current < ActiveSupport::CurrentAttributes
-  attribute :site
+  attribute :site, :theme
+
+  # The resolved theme for the request. Never nil: PlaceCal::Theme::NONE stands
+  # in for the directory, for an unthemed site and for code running outside a
+  # request, so callers read theme settings without a nil check.
+  def theme
+    super || PlaceCal::Theme::NONE
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -132,7 +132,7 @@ class Site < ApplicationRecord
   # Themes come from the extension registry, not a static list, so an
   # extension can add one without touching this model (#3368, D2).
   # allow_blank keeps the enumerize-era behaviour where a site could carry no
-  # theme at all and render core's default styling (#3368 WP 3.1).
+  # theme at all and render core's default styling (#3368).
   validates :theme, inclusion: { in: ->(_site) { PlaceCal::Extensions.theme_names } }, allow_blank: true
 
   # ==== Scopes ====
@@ -272,7 +272,7 @@ class Site < ApplicationRecord
   #   or nil when no stylesheet should be linked. Any theme whose stylesheet is
   #   missing from the pipeline resolves to nil, so the page renders with the
   #   default styling instead of raising Propshaft::MissingAssetError
-  #   (#2936, #3368 WP 3.1).
+  #   (#2936, #3368).
   def stylesheet_link
     theme_settings.stylesheet_for(self)
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -261,13 +261,20 @@ class Site < ApplicationRecord
     PlaceCal::Extensions.find_theme(theme)
   end
 
+  # @return [PlaceCal::Theme] the site's theme, or the null theme
+  #   (PlaceCal::Theme::NONE) when it has none or names an unregistered one.
+  #   Callers read settings from this without a nil check.
+  def theme_settings
+    theme_definition || PlaceCal::Theme::NONE
+  end
+
   # @return [String, nil] asset pipeline stylesheet path for this site's theme,
   #   or nil when no stylesheet should be linked. Any theme whose stylesheet is
   #   missing from the pipeline resolves to nil, so the page renders with the
   #   default styling instead of raising Propshaft::MissingAssetError
   #   (#2936, #3368 WP 3.1).
   def stylesheet_link
-    theme_definition&.stylesheet_for(self)
+    theme_settings.stylesheet_for(self)
   end
 
   # @return [String, false] Open Graph image URL, or false

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -66,7 +66,7 @@ class Views::Layouts::Application < Phlex::HTML
           end
           if site.nil?
             Directory::Footer()
-          elsif (footer_class = site.theme_definition&.footer_class)
+          elsif (footer_class = theme.footer_class)
             # Theme footer slot (#3368 D1): the theme owns the whole footer.
             render footer_class.new(site: site, navigation: navigation)
           else
@@ -86,7 +86,7 @@ class Views::Layouts::Application < Phlex::HTML
   # way this layout does, or the theme's views can push markup through
   # content_for(:theme_head), which also works alongside a head component.
   def render_theme_head
-    head_class = site&.theme_definition&.head_class
+    head_class = theme.head_class
     render head_class.new if head_class
     raw content_for(:theme_head) if content_for?(:theme_head)
   end
@@ -102,7 +102,7 @@ class Views::Layouts::Application < Phlex::HTML
     render_icon_links
     link(rel: 'manifest', href: '/manifest.webmanifest') if site
     meta(name: 'viewport', content: 'width=device-width, initial-scale=1')
-    theme_color = site&.theme_definition&.theme_color
+    theme_color = theme.theme_color
     meta(name: 'theme-color', content: theme_color) if theme_color
 
     meta(name: 'description', content: description_text)
@@ -141,8 +141,8 @@ class Views::Layouts::Application < Phlex::HTML
     if content_for?(:image)
       meta(property: 'og:image', content: image_url(content_for(:image)))
       meta(property: 'og:image:alt', content: content_for(:image_alt)) if content_for?(:image_alt)
-    elsif site && (theme_og = site.theme_definition&.og_image)
-      # A theme may ship its own static share image (#3368 WP 3.9)
+    elsif site && (theme_og = theme.og_image)
+      # A theme may ship its own static share image (#3368 D1)
       meta(property: 'og:image', content: image_url(theme_og[:path]))
       meta(property: 'og:image:alt', content: t('og_image.alt.site', name: site.name))
       meta(property: 'og:image:width', content: theme_og[:width].to_s) if theme_og[:width]
@@ -162,11 +162,10 @@ class Views::Layouts::Application < Phlex::HTML
   end
 
   # A theme may supply its own favicons, touch icon and Safari mask icon
-  # (#3368 WP 3.9). When it does, its icons replace core's two entirely;
+  # (#3368 D1). When it does, its icons replace core's two entirely;
   # otherwise core's favicon and touch icon link as before.
   def render_icon_links
-    theme = site&.theme_definition
-    icons = theme&.icons || {}
+    icons = theme.icons
 
     if icons.empty?
       link(rel: 'icon', type: 'image/png', href: image_url('favicon.png'))
@@ -232,5 +231,12 @@ class Views::Layouts::Application < Phlex::HTML
 
   def navigation
     view_context.instance_variable_get(:@navigation)
+  end
+
+  # The theme for this request, resolved once. PlaceCal::Theme::NONE stands in
+  # for the directory and for a site with no registered theme, so the settings
+  # above read without a nil check.
+  def theme
+    @theme ||= PlaceCal::Theme.for(site)
   end
 end

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -70,7 +70,7 @@ class Views::Layouts::Application < Phlex::HTML
             # Theme footer slot (#3368 D1): the theme owns the whole footer.
             render footer_class.new(site: site, navigation: navigation)
           else
-            Footer(site)
+            Footer(site, navigation: navigation)
           end
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,11 +67,21 @@ en:
 
   # Labels for the partner and event listing filters on a site (the nationwide
   # directory has its own set under directory.filters).
+  # All public listing-filter copy lives here, whichever listing renders it.
   filters:
     filter_by: "Filter by:"
     category: "Category"
     neighbourhood: "Neighbourhood"
     reset: "Reset filters"
+    # Day strip event filter (D22): the Today / Tomorrow / next five days
+    # navigation rendered for themes with event_filter_style :day_strip.
+    day_strip:
+      label: "Filter events by day"
+      today: "Today"
+      tomorrow: "Tomorrow"
+      all_upcoming: "All upcoming"
+      # strftime pattern for the other day buttons; themes may override
+      date_format: "%a %-d"
 
   # Region selector shown on local sites with more than one Partnership tag
   # (#3368 D7). Labels only: the URL param is always ?region=<tag slug>, so a
@@ -361,6 +371,11 @@ en:
   # ===========================================================================
   # LOCAL SITE LISTING PAGES (heroes; themes override via theme_overrides.*)
   # ===========================================================================
+  #
+  # Several keys below are deliberately blank. A blank core key is the idiom
+  # for a slot a theme may fill: core renders nothing for it, and a theme
+  # supplies copy through theme_overrides.<theme>.<key> without core needing a
+  # conditional or the theme forking the view. See doc/extensions.md.
 
   partners:
     show:
@@ -408,16 +423,6 @@ en:
       standfirst: ""
       standfirst_detail: ""
       list_heading: ""
-    # Day strip event filter (D22): the Today / Tomorrow / next five days
-    # navigation rendered for themes with event_filter_style :day_strip.
-    filter:
-      day_strip:
-        label: "Filter events by day"
-        today: "Today"
-        tomorrow: "Tomorrow"
-        all_upcoming: "All upcoming"
-        # strftime pattern for the other day buttons; themes may override
-        date_format: "%a %-d"
     card:
       # strftime patterns for the event list date; themes may override
       date_format: "%e %b"
@@ -453,7 +458,6 @@ en:
   date:
     formats:
       datetime: "%b %-d, %Y %l:%M"
-      # Day strip filter buttons, e.g. "Thu 13"
 
   time:
     formats:

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -132,6 +132,8 @@ en:
 
 Keep the overrides in their own file (`config/locales/overrides.en.yml` by convention) so it is obvious which strings the theme rewrites and which are its own.
 
+A blank value in core's own `config/locales/en.yml` is the idiom for a slot a theme may fill. Where a piece of copy is optional (a standfirst, a section name, a heading above a list, a prefix before an organiser name), core declares the key with an empty string rather than leaving it out. Core then renders nothing for it, because every one of those views skips a blank value, while the key still exists for a theme to override. It means core needs no conditional for theme-only copy, the theme needs no forked view, and the full set of fillable slots can be read off core's locale file. If you want a slot that does not exist yet, adding the blank key to core is a one-line change; see the note above the "local site listing pages" block in `config/locales/en.yml`.
+
 Some core strings exist only as override slots: core ships them empty so nothing renders, and a theme fills them in. The listing pages carry one such slot, `<ns>.index.list_heading` (`partners.index.list_heading`, `events.index.list_heading`), which `Components::ListHeading` renders as an `h2` between the hero and the filters when it is not blank:
 
 ```yaml

--- a/features/step_definitions/page_steps.rb
+++ b/features/step_definitions/page_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Step definitions for site content pages (#3368, WP 1.1)
+# Step definitions for site content pages (#3368, D5)
 
 Given("I am a site admin for {string}") do |site_name|
   site = Site.find_by(name: site_name) ||

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -217,7 +217,7 @@ module PlaceCal
 
     # A theme's stylesheet is only linked when the asset pipeline can resolve
     # it. A renamed or unbuilt engine CSS file would otherwise raise
-    # Propshaft::MissingAssetError on every page of the site (#3368 WP 3.1).
+    # Propshaft::MissingAssetError on every page of the site (#3368).
     #
     # @param site [Site]
     # @return [String, nil] stylesheet logical path for this site, or nil
@@ -276,7 +276,7 @@ module PlaceCal
 
     # A theme names its classes as strings so registration can happen before
     # autoloading is ready. A renamed or removed class must not take the site
-    # down: log it and let core's default render instead (#3368 WP 3.1).
+    # down: log it and let core's default render instead (#3368).
     #
     # @param class_name [String, nil]
     # @param setting [String] which DSL setting is being resolved, for the log

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -202,6 +202,17 @@ module PlaceCal
       @event_filter_style = value
     end
 
+    # Null theme for a site whose theme is blank or unregistered, and for the
+    # nationwide directory, which has no site at all. It answers every setting
+    # with its default, so callers read theme settings without a nil check.
+    NONE = new(:none).freeze
+
+    # @param site [Site, nil]
+    # @return [PlaceCal::Theme] the site's theme, or NONE
+    def self.for(site)
+      site&.theme_settings || NONE
+    end
+
     # ---- Resolution
 
     # A theme's stylesheet is only linked when the asset pipeline can resolve

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -24,6 +24,35 @@ module PlaceCal
     # any of these replaces core's favicon and touch icon entirely.
     ICON_KEYS = %i[favicon_32 favicon_16 apple_touch_icon mask_icon icon_192 icon_512].freeze
 
+    # Declared settings. Each `setting` call defines one method that stores a
+    # cast value when called with one and reads the current value when called
+    # with none, and registers the default an instance starts with. Settings
+    # that validate, take structured arguments or accept a block keep their own
+    # bodies below.
+    @settings = {}
+
+    class << self
+      # @return [Hash{Symbol => Object}] declared setting names and their defaults
+      attr_reader :settings
+
+      # @param name [Symbol] setting and method name
+      # @param cast [Symbol] :to_s or :boolean
+      # @param default [Object] the value an instance starts with
+      # @param predicate [Boolean] also define a `name?` reader
+      def setting(name, cast: :to_s, default: nil, predicate: false)
+        settings[name] = default
+        ivar = :"@#{name}"
+
+        define_method(name) do |value = nil|
+          return instance_variable_get(ivar) if value.nil?
+
+          instance_variable_set(ivar, cast == :boolean ? value != false : value.to_s)
+        end
+
+        define_method(:"#{name}?") { instance_variable_get(ivar) } if predicate
+      end
+    end
+
     attr_reader :name
 
     # @param name [Symbol, String]
@@ -32,20 +61,14 @@ module PlaceCal
     def initialize(name, core: false)
       @name = name.to_s
       @core = core
+      self.class.settings.each { |setting, default| instance_variable_set(:"@#{setting}", default) }
+      # Defaults for the settings whose bodies are written out below.
       @stylesheet = nil
-      @homepage_view = nil
       @map_style = nil
-      @head = nil
-      @theme_color = nil
-      @footer = nil
+      @icons = {}
+      @og_image = nil
       @nav_cta = nil
       @event_filter_style = :date_picker
-      @nav_join = true
-      @menu_label = false
-      @icons = {}
-      @mask_icon_color = nil
-      @background_color = nil
-      @og_image = nil
     end
 
     def core?
@@ -63,11 +86,7 @@ module PlaceCal
 
     # @param value [String, nil] Phlex view class name, resolved lazily so
     #   registration can happen before autoloading is set up.
-    def homepage_view(value = nil)
-      return @homepage_view if value.nil?
-
-      @homepage_view = value.to_s
-    end
+    setting :homepage_view
 
     # @param value [String, nil] name of public/map-styles/<name>.json
     def map_style(value = nil, &block)
@@ -77,18 +96,10 @@ module PlaceCal
     end
 
     # @param value [String, nil] Phlex component class name rendered in <head>
-    def head(value = nil)
-      return @head if value.nil?
-
-      @head = value.to_s
-    end
+    setting :head
 
     # @param value [String, nil] hex colour code for web manifest, e.g. "#f19089"
-    def theme_color(value = nil)
-      return @theme_color if value.nil?
-
-      @theme_color = value.to_s
-    end
+    setting :theme_color
 
     # The theme's own favicons, touch icon, Safari mask icon and manifest
     # icons. Given as asset logical paths, resolved with `image_url` at render
@@ -120,21 +131,13 @@ module PlaceCal
     # attribute of `<link rel="mask-icon">`.
     #
     # @param value [String, nil] hex colour code, e.g. "#FF7AA7"
-    def mask_icon_color(value = nil)
-      return @mask_icon_color if value.nil?
-
-      @mask_icon_color = value.to_s
-    end
+    setting :mask_icon_color
 
     # Splash background colour for the web manifest. Distinct from
     # `theme_color`, which colours the browser chrome.
     #
     # @param value [String, nil] hex colour code, e.g. "#040f39"
-    def background_color(value = nil)
-      return @background_color if value.nil?
-
-      @background_color = value.to_s
-    end
+    setting :background_color
 
     # The manifest's background_color, falling back to the theme colour when
     # the theme sets only one of the two.
@@ -161,11 +164,7 @@ module PlaceCal
 
     # @param value [String, nil] Phlex component class name rendered in place
     #   of core's site footer; constructed with `new(site:, navigation:)`
-    def footer(value = nil)
-      return @footer if value.nil?
-
-      @footer = value.to_s
-    end
+    setting :footer
 
     # Optional call-to-action button at the end of the site nav (for example
     # a Donate link). Rendered as a link to `url` labelled by the locale key.
@@ -184,30 +183,14 @@ module PlaceCal
     # instead sets this to false. Defaults to true.
     #
     # @param value [Boolean, nil]
-    def nav_join(value = nil)
-      return @nav_join if value.nil?
-
-      @nav_join = value ? true : false
-    end
-
-    def nav_join?
-      @nav_join
-    end
+    setting :nav_join, cast: :boolean, default: true, predicate: true
 
     # Whether the mobile menu toggle shows a "Menu" text label beside the icon.
     # The nationwide directory always shows it; sites show it only when their
     # theme opts in. Defaults to false.
     #
     # @param value [Boolean, nil]
-    def menu_label(value = nil)
-      return @menu_label if value.nil?
-
-      @menu_label = value ? true : false
-    end
-
-    def menu_label?
-      @menu_label
-    end
+    setting :menu_label, cast: :boolean, default: false, predicate: true
 
     # @param value [Symbol, nil] one of EVENT_FILTER_STYLES
     def event_filter_style(value = nil)

--- a/lib/placecal/theme_translation.rb
+++ b/lib/placecal/theme_translation.rb
@@ -19,20 +19,28 @@ module PlaceCal
     # and gets escaped for an `_html` key, as ActionView's `t` does.
     RESERVED_INTERPOLATIONS = %i[count default scope locale raise throw separator].freeze
 
+    # This shadows ActionView's `t` (and the controller's) for the whole
+    # application: the module is included into Components::Base, Views::Base,
+    # Views::Layouts::Application and ApplicationController, which is the
+    # ancestor of Admin::* too. That breadth is deliberate. The fidelity goal
+    # is that any core string may be overridden by a theme without core
+    # growing a conditional or the theme forking a view, and there is no way
+    # to know in advance which of the several hundred strings a theme will
+    # want. The cost is that every `t` call in the app passes through here, so
+    # this method must behave exactly like the `t` it replaces whenever there
+    # is no override to apply: when there is a `super`, the call is handed
+    # straight to it rather than reimplemented.
     def t(key, **options)
       theme = Current.site&.theme_definition
-      options = escape_html_interpolations(key, options)
+      overridable = overridable_key?(theme, key)
 
-      value =
-        if theme && key.is_a?(String) && !key.start_with?('.')
-          theme_scoped_translation(theme, key, **options)
-        elsif defined?(super)
-          # A lazy ('.foo') key only means anything to the including class's
-          # own `t` (controllers, ActionView), which knows the current scope.
-          super
-        else
-          I18n.t(key, **options)
-        end
+      # No override scope to consult (a lazy '.foo' key, or a request with no
+      # theme), so let the `t` this module shadows do the whole job, including
+      # ActionView's `_html` escaping and html_safe marking.
+      return super if defined?(super) && !overridable
+
+      options = escape_html_interpolations(key, options)
+      value = overridable ? theme_scoped_translation(theme, key, **options) : I18n.t(key, **options)
 
       html_key?(key) && value.is_a?(String) ? value.html_safe : value # rubocop:disable Rails/OutputSafety
     end
@@ -52,6 +60,15 @@ module PlaceCal
       raise I18n::MissingTranslationData.new(e.locale, key, e.options)
     end
 
+    # Whether this key could carry a theme override: an absolute key (a lazy
+    # '.foo' key only means anything to the including class's own `t`, which
+    # knows the current scope) on a site whose theme is registered.
+    def overridable_key?(theme, key)
+      !theme.nil? && key.is_a?(String) && !key.start_with?('.')
+    end
+
+    # Only reached when there is no `super` to do it (Phlex components), or for
+    # a key the theme may override, which I18n resolves directly.
     def escape_html_interpolations(key, options)
       return options unless html_key?(key)
 

--- a/spec/components/footer_component_spec.rb
+++ b/spec/components/footer_component_spec.rb
@@ -35,39 +35,50 @@ RSpec.describe Components::Footer, type: :component do
 
   describe "site navigation links" do
     let(:site) { create(:site) }
+    let(:core_navigation) do
+      [
+        [I18n.t("navigation.site.home"), "/"],
+        [I18n.t("navigation.site.events"), "/events"],
+        [I18n.t("navigation.site.partners"), "/partners"]
+      ]
+    end
 
-    def footer_nav_labels
-      render_inline(described_class.new(site))
+    # The layout hands the footer the same derived navigation as the header
+    # (SiteNavigation), so the spec constructs one the same way.
+    def footer_nav_labels(navigation)
+      render_inline(described_class.new(site, navigation: navigation))
       page.all(".footer__nav nav ul li a").map(&:text)
     end
 
-    context "with news, an in-nav page and a contact email" do
-      before do
-        create(:nav_page, site: site, title: "About", slug: "about")
-        allow(site).to receive(:news_article_count).and_return(3)
-        site.contact_email = "hello@example.com"
+    context "with news, an in-nav page and a join link" do
+      let(:navigation) do
+        core_navigation + [
+          [I18n.t("navigation.site.news"), "/news"],
+          ["About", "/about"],
+          [I18n.t("navigation.site.join"), "/get-in-touch"]
+        ]
       end
 
-      it "renders the derived nav in order" do
-        expect(footer_nav_labels).to eq(
+      it "renders the derived nav, then the footer's own extras" do
+        expect(footer_nav_labels(navigation)).to eq(
           [
             I18n.t("navigation.site.home"),
             I18n.t("navigation.site.events"),
             I18n.t("navigation.site.partners"),
             I18n.t("navigation.site.news"),
             "About",
+            I18n.t("navigation.site.join"),
             I18n.t("navigation.site.privacy"),
             I18n.t("navigation.site.terms"),
-            I18n.t("navigation.site.join"),
             I18n.t("navigation.site.log_in")
           ]
         )
       end
     end
 
-    context "with no news, no pages and no contact email" do
-      it "renders only the core links" do
-        expect(footer_nav_labels).to eq(
+    context "with only the core links" do
+      it "renders them plus the legal and log-in links" do
+        expect(footer_nav_labels(core_navigation)).to eq(
           [
             I18n.t("navigation.site.home"),
             I18n.t("navigation.site.events"),
@@ -76,6 +87,29 @@ RSpec.describe Components::Footer, type: :component do
             I18n.t("navigation.site.terms"),
             I18n.t("navigation.site.log_in")
           ]
+        )
+      end
+
+      it "omits Join when the derived navigation has none" do
+        expect(footer_nav_labels(core_navigation)).not_to include(I18n.t("navigation.site.join"))
+      end
+    end
+
+    context "when a region is selected" do
+      let(:navigation) do
+        [
+          [I18n.t("navigation.site.home"), "/?region=hulme"],
+          [I18n.t("navigation.site.events"), "/events?region=hulme"],
+          [I18n.t("navigation.site.partners"), "/partners?region=hulme"]
+        ]
+      end
+
+      it "keeps the region param the derived links carry" do
+        footer_nav_labels(navigation)
+
+        expect(page).to have_css(
+          ".footer__nav nav a[href='/events?region=hulme']",
+          text: I18n.t("navigation.site.events")
         )
       end
     end
@@ -83,9 +117,13 @@ RSpec.describe Components::Footer, type: :component do
     context "when the site has its own privacy page in the nav" do
       before { create(:nav_page, site: site, title: "Privacy notice", slug: "privacy") }
 
+      let(:navigation) { core_navigation + [["Privacy notice", "/privacy"]] }
+
       it "lists it once, under the page's own title, at /privacy" do
-        expect(footer_nav_labels.count("Privacy notice")).to eq(1)
-        expect(footer_nav_labels).not_to include(I18n.t("navigation.site.privacy"))
+        labels = footer_nav_labels(navigation)
+
+        expect(labels.count("Privacy notice")).to eq(1)
+        expect(labels).not_to include(I18n.t("navigation.site.privacy"))
         expect(page).to have_css(".footer__nav nav a[href='/privacy']", text: "Privacy notice")
       end
     end

--- a/spec/fixtures/extensions/example_theme/config/locales/en.yml
+++ b/spec/fixtures/extensions/example_theme/config/locales/en.yml
@@ -10,6 +10,9 @@ en:
     example_theme:
       region_filter:
         all: Anywhere
+      filters:
+        day_strip:
+          date_format: "%a %d %b"
       events:
         show:
           section: Fixture events section
@@ -18,9 +21,6 @@ en:
         card:
           date_format: "%d %b"
           organiser_prefix: "by "
-        filter:
-          day_strip:
-            date_format: "%a %d %b"
         index:
           standfirst: Fixture standfirst for events
           standfirst_detail: Fixture detail for events

--- a/spec/lib/placecal/theme_spec.rb
+++ b/spec/lib/placecal/theme_spec.rb
@@ -11,23 +11,43 @@ RSpec.describe PlaceCal::Theme do
     expect(theme).not_to be_core
   end
 
-  it "defaults every setting to nil and the date picker filter style" do
+  # The settings declared with `setting` in PlaceCal::Theme all behave the same
+  # way, so they are asserted as a table rather than one example each.
+  string_settings = %i[homepage_view head theme_color footer mask_icon_color background_color]
+  boolean_settings = { nav_join: true, menu_label: false }
+
+  describe "declared settings" do
+    string_settings.each do |name|
+      it "defaults ##{name} to nil and stores what it is given as a string" do
+        expect(theme.public_send(name)).to be_nil
+
+        theme.public_send(name, :"sample-#{name}")
+
+        expect(theme.public_send(name)).to eq("sample-#{name}")
+      end
+    end
+
+    boolean_settings.each do |name, default|
+      it "defaults ##{name} to #{default} and stores the opposite" do
+        expect(theme.public_send(name)).to be(default)
+        expect(theme.public_send(:"#{name}?")).to be(default)
+
+        theme.public_send(name, !default)
+
+        expect(theme.public_send(name)).to be(!default)
+        expect(theme.public_send(:"#{name}?")).to be(!default)
+      end
+    end
+  end
+
+  it "defaults the structured settings to nil and the date picker filter style" do
     expect(theme.stylesheet).to be_nil
-    expect(theme.homepage_view).to be_nil
     expect(theme.map_style).to be_nil
-    expect(theme.head).to be_nil
-    expect(theme.theme_color).to be_nil
-    expect(theme.footer).to be_nil
     expect(theme.nav_cta).to be_nil
-    expect(theme.event_filter_style).to eq(:date_picker)
-    expect(theme).to be_nav_join
-    expect(theme.menu_label).to be(false)
-    expect(theme).not_to be_menu_label
     expect(theme.icons).to eq({})
-    expect(theme.mask_icon_color).to be_nil
-    expect(theme.background_color).to be_nil
-    expect(theme.manifest_background_color).to be_nil
     expect(theme.og_image).to be_nil
+    expect(theme.manifest_background_color).to be_nil
+    expect(theme.event_filter_style).to eq(:date_picker)
   end
 
   describe "#icons" do
@@ -67,14 +87,6 @@ RSpec.describe PlaceCal::Theme do
     end
   end
 
-  describe "#mask_icon_color" do
-    it "stores the colour as a string" do
-      theme.mask_icon_color "#FF7AA7"
-
-      expect(theme.mask_icon_color).to eq("#FF7AA7")
-    end
-  end
-
   describe "#background_color" do
     it "stores the manifest background colour" do
       theme.background_color "#040f39"
@@ -105,33 +117,13 @@ RSpec.describe PlaceCal::Theme do
     end
   end
 
-  it "lets a theme label the mobile menu toggle" do
-    theme.menu_label true
-
-    expect(theme.menu_label).to be(true)
-    expect(theme).to be_menu_label
-  end
-
-  it "lets a theme drop the Join link from the main nav" do
-    theme.nav_join false
-
-    expect(theme.nav_join).to be(false)
-    expect(theme).not_to be_nav_join
-  end
-
-  it "sets and reads values through the DSL" do
+  it "sets and reads the block-capable and validated settings" do
     theme.stylesheet "sample/theme"
-    theme.homepage_view "Views::Sites::Default"
     theme.map_style "sample"
-    theme.head "Components::Footer"
-    theme.theme_color "#f19089"
     theme.event_filter_style :day_strip
 
     expect(theme.stylesheet).to eq("sample/theme")
-    expect(theme.homepage_view).to eq("Views::Sites::Default")
     expect(theme.map_style).to eq("sample")
-    expect(theme.head).to eq("Components::Footer")
-    expect(theme.theme_color).to eq("#f19089")
     expect(theme.event_filter_style).to eq(:day_strip)
   end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -232,6 +232,31 @@ RSpec.describe Site, type: :model do
       end
     end
 
+    describe "#theme_settings" do
+      it "returns the registered theme" do
+        site = build(:site, theme: "orange")
+        expect(site.theme_settings).to eq(PlaceCal::Extensions.fetch_theme("orange"))
+      end
+
+      it "returns the null theme when the theme is blank or unregistered" do
+        expect(build(:site, theme: nil).theme_settings).to eq(PlaceCal::Theme::NONE)
+        expect(build(:site, theme: "nope").theme_settings).to eq(PlaceCal::Theme::NONE)
+      end
+
+      it "answers every setting with its default through the null theme" do
+        theme = build(:site, theme: nil).theme_settings
+
+        expect(theme.head_class).to be_nil
+        expect(theme.footer_class).to be_nil
+        expect(theme.homepage_view_class).to be_nil
+        expect(theme.theme_color).to be_nil
+        expect(theme.icons).to eq({})
+        expect(theme.event_filter_style).to eq(:date_picker)
+        expect(theme).to be_nav_join
+        expect(theme).not_to be_menu_label
+      end
+    end
+
     describe "#stylesheet_link" do
       it "returns the core theme stylesheet" do
         %w[pink orange green blue].each do |name|


### PR DESCRIPTION
Structural refactors from the review of #3436, behaviour unchanged (no assertion weakened).

- Footer consumes the derived site navigation, so footer links carry the region, honour the theme's Join setting and the pages query runs once.
- PlaceCal::Theme declares simple settings through a class macro; public API unchanged, spec table-driven.
- A null theme object replaces nineteen safe-navigation lookups; the layout and controllers resolve the theme once per request.
- The region filter guard lives in the component only.
- Work-package comments normalised to PRD decision ids, filter copy under one locale namespace, the blank-key override idiom documented, the translation shim documented and returning super untouched when there is no override.

1204 examples green across lib, components, helpers, public, extension and admin requests, i18n keys and the site model.