### PR TITLE
Escape the hero title

### DIFF
--- a/app/components/hero.rb
+++ b/app/components/hero.rb
@@ -6,7 +6,7 @@ class Components::Hero < Components::Base
   prop :schema, _Nilable(String), :positional, default: nil
 
   def after_initialize
-    @title = clean_title(@title)
+    @title_lines = title_lines(@title)
   end
 
   def view_template
@@ -17,9 +17,9 @@ class Components::Hero < Components::Base
           div(role: 'presentation', class: 'hero__divider')
         end
         if @schema
-          h1(property: @schema) { safe(@title) }
+          h1(property: @schema) { render_title }
         else
-          h1 { safe(@title) }
+          h1 { render_title }
         end
       end
     end
@@ -27,11 +27,22 @@ class Components::Hero < Components::Base
 
   private
 
-  def clean_title(title)
-    if title.length > 32
-      title.split.in_groups(2, false).map { |g| g.join(' ') }.join('<br> ')
-    else
-      title
+  # The title is user or feed supplied (partner names, event summaries, article
+  # titles), so it is rendered as text and the long-title line break is a real
+  # element rather than markup spliced into the string.
+  def render_title
+    @title_lines.each_with_index do |line, index|
+      if index.positive?
+        br
+        plain ' '
+      end
+      plain line
     end
+  end
+
+  def title_lines(title)
+    return [title] if title.length <= 32
+
+    title.split.in_groups(2, false).map { |group| group.join(' ') }
   end
 end

--- a/spec/components/hero_component_spec.rb
+++ b/spec/components/hero_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Hero, type: :component do
+  it "escapes markup in the title" do
+    render_inline(described_class.new("<img src=x onerror=1> Garden", "Partner"))
+
+    expect(page).to have_css("h1", text: "<img src=x onerror=1> Garden")
+    expect(page).not_to have_css("h1 img")
+  end
+
+  it "breaks a long title across two lines with a real br element" do
+    render_inline(described_class.new("A rather long partner name that needs splitting", nil))
+
+    expect(page).to have_css("h1 br", count: 1)
+    expect(page).to have_css("h1", text: "A rather long partner name that needs splitting")
+  end
+
+  it "escapes markup in a long title too" do
+    render_inline(described_class.new("<b>bold</b> and a long title here to trip the split path", nil))
+
+    expect(page).not_to have_css("h1 b")
+    expect(page).to have_css("h1", text: "<b>bold</b>")
+  end
+end


### PR DESCRIPTION
The hero heading passed its title through safe() after a helper that only splices a line break, so a partner name, article title or event summary containing markup rendered as HTML. Event summaries come from third-party calendar feeds, so this is reachable without admin access.

The title is now rendered as text and the long-title line break is a real br element. Three component examples cover escaping on short and long titles and the line break.

Found during the third review pass on #3436; it predates that branch.