### PR TITLE
WP 4.5: theme safety fixes from review round three

### DIFF
--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -61,7 +61,7 @@ class Components::EventFilter < Components::Base
     hidden_field_tag(:period, @period, data: { date_picker_target: 'period' })
     hidden_field_tag(:sort, @sort, data: { date_picker_target: 'sort' })
     hidden_field_tag(:repeating, @repeating, data: { date_picker_target: 'repeating' })
-    hidden_field_tag(:region, @selected_region.slug) if @selected_region
+    hidden_field_tag(:region, @selected_region.slug, id: nil) if @selected_region
   end
 
   # D22: Today / Tomorrow / next five days plus "All upcoming", linking to the
@@ -142,7 +142,7 @@ class Components::EventFilter < Components::Base
           view_context.hidden_field_tag(:period, @period),
           view_context.hidden_field_tag(:sort, @sort),
           view_context.hidden_field_tag(:repeating, @repeating),
-          (@selected_region ? view_context.hidden_field_tag(:region, @selected_region.slug) : nil),
+          (@selected_region ? view_context.hidden_field_tag(:region, @selected_region.slug, id: nil) : nil),
           view_context.render(Components::Filter.new(
                                 name: 'neighbourhood',
                                 label: t('filters.neighbourhood'),
@@ -167,7 +167,7 @@ class Components::EventFilter < Components::Base
   def build_sort_filter_form
     view_context.form_tag('', method: :get, class: 'filters__form', enforce_utf8: false, data: { turbo_frame: 'events-browser', turbo_action: 'advance', filters_target: 'form', action: 'change->filters#submit' }) do
       buf = ActiveSupport::SafeBuffer.new
-      buf << view_context.hidden_field_tag(:region, @selected_region.slug) if @selected_region
+      buf << view_context.hidden_field_tag(:region, @selected_region.slug, id: nil) if @selected_region
       buf << build_sort_toggle
       buf << build_sort_dropdown
       buf

--- a/app/components/hero.rb
+++ b/app/components/hero.rb
@@ -13,7 +13,7 @@ class Components::Hero < Components::Base
   prop :section, _Nilable(String), default: nil
 
   def after_initialize
-    @title = clean_title(@title)
+    @title_lines = title_lines(@title)
   end
 
   def view_template
@@ -25,9 +25,9 @@ class Components::Hero < Components::Base
           div(role: 'presentation', class: 'hero__divider')
         end
         if @schema
-          h1(property: @schema) { safe(@title) }
+          h1(property: @schema) { render_title }
         else
-          h1 { safe(@title) }
+          h1 { render_title }
         end
         p(class: 'hero__standfirst') { @standfirst } if @standfirst.present?
         p(class: 'hero__standfirst-detail') { @standfirst_detail } if @standfirst_detail.present?
@@ -37,11 +37,22 @@ class Components::Hero < Components::Base
 
   private
 
-  def clean_title(title)
-    if title.length > 32
-      title.split.in_groups(2, false).map { |g| g.join(' ') }.join('<br> ')
-    else
-      title
+  # The title is user or feed supplied (partner names, event summaries, article
+  # titles), so it is rendered as text and the long-title line break is a real
+  # element rather than markup spliced into the string.
+  def render_title
+    @title_lines.each_with_index do |line, index|
+      if index.positive?
+        br
+        plain ' '
+      end
+      plain line
     end
+  end
+
+  def title_lines(title)
+    return [title] if title.length <= 32
+
+    title.split.in_groups(2, false).map { |group| group.join(' ') }
   end
 end

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -29,6 +29,7 @@ class Components::Navigation < Components::Base
     link_to(root_path, class: [
               'header__branding row-start-1 col-start-1 ',
               ("header__branding--#{@site.slug}" if @site&.slug.presence),
+              ("header__branding--theme-#{branding_theme_name}" if branding_theme_name),
               # svg/img classes are here because partner svgs are inlined with File.read
               '[&>svg,&>img]:object-contain [&>svg,&>img]:max-w-full [&>svg,&>img]:max-h-full',
               *(if @site.nil?
@@ -40,6 +41,19 @@ class Components::Navigation < Components::Base
       render_logo
       render_site_name
     end
+  end
+
+  # A theme's own branding CSS hooks onto this rather than onto the slug class
+  # above: the slug is admin-editable, so a rename would silently drop the
+  # theme's styling (#3368).
+  #
+  # @return [String, nil] the registered theme's name, or nil for a site with
+  #   no theme and for the nationwide directory
+  def branding_theme_name
+    return @branding_theme_name if defined?(@branding_theme_name)
+
+    theme = Current.theme
+    @branding_theme_name = (theme.name unless @site.nil? || theme.equal?(PlaceCal::Theme::NONE))
   end
 
   def render_logo

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -100,15 +100,34 @@ class Components::Navigation < Components::Base
   # Theme call-to-action (#3368 D1): a theme may register `nav_cta`, for
   # example a Donate link; core renders it as the last nav item.
   def theme_cta
-    @theme_cta ||= Current.theme.nav_cta
+    return @theme_cta if defined?(@theme_cta)
+
+    @theme_cta = Current.theme.nav_cta
   end
 
   def render_theme_cta
-    li(class: 'text-center max-md:py-3 header__cta') do
-      link_to(t(theme_cta[:label_key]), theme_cta[:url],
-              class: 'header__cta-link inline-flex items-center rounded-sm bg-background px-4 py-1.5 text-detail font-bold no-underline',
-              target: '_blank', rel: 'noopener')
+    options = {
+      class: 'header__cta-link inline-flex items-center rounded-sm bg-background px-4 py-1.5 text-detail font-bold no-underline'
+    }
+    # A CTA off to another site (a donation platform, say) opens in a new tab;
+    # one pointing at a page of this site must not.
+    if external_url?(theme_cta[:url])
+      options[:target] = '_blank'
+      options[:rel] = 'noopener'
     end
+
+    li(class: 'text-center max-md:py-3 header__cta') do
+      link_to(t(theme_cta[:label_key]), theme_cta[:url], **options)
+    end
+  end
+
+  # @param url [String]
+  # @return [Boolean] whether the URL names a host other than this request's
+  def external_url?(url)
+    host = Addressable::URI.parse(url.to_s).host
+    host.present? && host != request.host
+  rescue Addressable::URI::InvalidURIError
+    false
   end
 
   # TODO: Change to join.placecal.org once the join flow is live
@@ -202,7 +221,10 @@ class Components::Navigation < Components::Base
                else
                  ['md:hidden']
                end)
-           ], data: { action: 'click->mobile-menu#toggle', turbo: 'false' }) do
+           ], aria_label: t('navigation.menu'),
+           data: { action: 'click->mobile-menu#toggle', turbo: 'false' }) do
+      # The accessible name is always there; the visible label beside the icon
+      # is what a theme opts into.
       span(class: 'text-base font-semibold header__toggle-label') { t('navigation.menu') } if show_menu_label?
       raw(view_context.icon(:misc_menu, size: nil, css_class: 'size-8 fill-secondary'))
     end

--- a/app/components/partner_filter.rb
+++ b/app/components/partner_filter.rb
@@ -19,7 +19,7 @@ class Components::PartnerFilter < Components::Base
     RegionFilter(tags: @region_tags, selected: @selected_region)
 
     form_with(**form_data, class: 'filters__form') do
-      hidden_field_tag(:region, @selected_region.slug) if @selected_region
+      hidden_field_tag(:region, @selected_region.slug, id: nil) if @selected_region
       div(class: 'breadcrumb__element breadcrumb__element--last') do
         span { t('filters.filter_by') }
         render_category_filter if show_category_filter?

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -43,8 +43,10 @@ module Admin
     end
 
     def create
-      @site = Site.new(permitted_attributes(Site))
+      attributes = permitted_attributes(Site)
+      @site = Site.new(attributes)
       authorize @site
+      authorize_theme!(attributes[:theme])
       if @site.save
         flash[:success] = 'Site has been created'
         redirect_to admin_sites_path
@@ -58,7 +60,9 @@ module Admin
 
     def update
       authorize @site
-      if @site.update(permitted_attributes(@site))
+      attributes = permitted_attributes(@site)
+      authorize_theme!(attributes[:theme])
+      if @site.update(attributes)
         flash[:success] = 'Site was saved successfully'
         redirect_to edit_admin_site_path(@site)
 
@@ -83,6 +87,16 @@ module Admin
     end
 
     private
+
+    # Extension themes are root's to set (SitePolicy#permitted_themes). The
+    # select never offers one to a site admin, so a submitted one is a forged
+    # param: reject it rather than let strong params drop it silently and save
+    # the rest of the form as if nothing had happened.
+    def authorize_theme!(theme)
+      return if policy(@site).permitted_theme?(theme)
+
+      raise Pundit::NotAuthorizedError.new(query: :update?, record: @site, policy: policy(@site))
+    end
 
     def build_site_admin_options
       site_admin_ids = Site.where.not(site_admin_id: nil).distinct.pluck(:site_admin_id)

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -48,7 +48,7 @@ class ManifestsController < ApplicationController
   end
 
   def icons
-    theme_icons = Current.theme.icons
+    theme_icons = Current.theme.icons_for_render
 
     # A theme's own manifest icons win over the site logo (#3368 D1).
     if theme_icons[:icon_192] || theme_icons[:icon_512]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,7 +74,7 @@ module ApplicationHelper
 
   # ported from https://github.com/comfy/active_link_to/blob/master/lib/active_link_to/active_link_to.rb
   # FIXME: I don't know how to include Literal so I can use _Nilable[String]
-  def active_link_to(title, url, data: Hash, base_css_class: '', active_css_class: 'active')
+  def active_link_to(title, url, data: {}, base_css_class: '', active_css_class: 'active')
     current_path = request.original_fullpath
     link_path = Addressable::URI.parse(url).path
     is_current_path = current_section?(current_path, link_path)
@@ -82,7 +82,9 @@ module ApplicationHelper
     options = {}
     options[:data] = data if data.present?
     options[:class] = "#{base_css_class} #{active_css_class if is_current_path}"
-    options['aria-current'] = 'page' if is_current_path
+    # "page" means this link points at the page being rendered. An ancestor
+    # ("Events", underlined while an event page is open) is aria-current="true".
+    options['aria-current'] = current_page_path?(current_path, link_path) ? 'page' : 'true' if is_current_path
 
     link_to(title, url, options).html_safe
   end
@@ -95,6 +97,12 @@ module ApplicationHelper
     return current_path.match(%r{^/?(\?.*)?$}).present? if link_path == '/'
 
     current_path.match(%r{^#{Regexp.escape(link_path)}(/.*)?(\?.*)?$}).present?
+  end
+
+  # @return [Boolean] whether the link points at the page being rendered rather
+  #   than at one of its ancestors
+  def current_page_path?(current_path, link_path)
+    current_path.match(%r{^#{Regexp.escape(link_path)}/?(\?.*)?$}).present?
   end
 
   # Convenience wrapper for humanized model names

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
+  # I18n translate helper, theme-aware (PlaceCal::ThemeTranslation), so a theme
+  # can override mail copy for its own sites the way it overrides page copy
+  # (#3368 D19). The mailer views already resolve `t` through it.
+  include PlaceCal::ThemeTranslation
+
   default from: 'no-reply@placecal.org'
   layout false
   helper MailerHelper

--- a/app/mailers/join_mailer.rb
+++ b/app/mailers/join_mailer.rb
@@ -3,6 +3,13 @@
 class JoinMailer < ApplicationMailer
   def join_us(join)
     site = join.site
+    # Mailer views inherit Views::Base, so their `t` resolves against
+    # Current.theme. Current is request-scoped and is already reset by the time
+    # a queued job runs, so set it here from the join's own site: the copy must
+    # not depend on whether the mail was delivered in the request, from a job,
+    # or from a console.
+    Current.site = site
+    Current.theme = PlaceCal::Theme.for(site)
     # A newline in the interpolated name would let it inject extra mail
     # headers, so it never reaches the Subject header intact.
     subject = if site

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -130,7 +130,15 @@ class Site < ApplicationRecord
   # extension can add one without touching this model (#3368, D2).
   # allow_blank keeps the enumerize-era behaviour where a site could carry no
   # theme at all and render core's default styling (#3368).
-  validates :theme, inclusion: { in: ->(_site) { PlaceCal::Extensions.theme_names } }, allow_blank: true
+  #
+  # Only checked when the theme is being changed. A registry is not a fixed
+  # list: uninstalling an extension (doc/extensions.md tells self-hosters they
+  # may delete the `group :extensions` block) would otherwise leave every site
+  # on that theme permanently unsavable from admin, over a value nobody
+  # touched. Rendering already degrades to PlaceCal::Theme::NONE, so the row
+  # stays editable and the site keeps working on core's default styling.
+  validates :theme, inclusion: { in: ->(_site) { PlaceCal::Extensions.theme_names } },
+                    allow_blank: true, if: :theme_changed?
 
   # ==== Scopes ====
   scope :published, -> { where(is_published: true) }

--- a/app/policies/site_policy.rb
+++ b/app/policies/site_policy.rb
@@ -29,6 +29,29 @@ class SitePolicy < ApplicationPolicy
     user.root?
   end
 
+  # An extension theme is not a colour scheme: it swaps in an engine's views,
+  # components and copy, and it only exists on installations whose operator
+  # has added that gem. Site admins choose among the themes core ships; only
+  # root moves a site onto (or off) an extension theme.
+  #
+  # @return [Array<PlaceCal::Theme>]
+  def permitted_themes
+    themes = user.root? ? PlaceCal::Extensions.themes : PlaceCal::Extensions.themes.select(&:core?)
+    # The site's current theme stays selectable whoever is editing, so a site
+    # admin saving the form cannot silently move an extension-themed site onto
+    # a core theme.
+    themes | [PlaceCal::Extensions.find_theme(current_theme_name)].compact
+  end
+
+  # @param name [String, nil] a submitted theme name
+  # @return [Boolean] whether this user may set the site to it
+  def permitted_theme?(name)
+    name = name.to_s
+    return true if name.blank? || name == current_theme_name
+
+    permitted_themes.any? { |theme| theme.name == name }
+  end
+
   def permitted_attributes
     attrs = %i[id name place_name logo footer_logo is_published tagline description
                badge_zoom_level hero_image hero_image_credit hero_alttext hero_text theme
@@ -42,6 +65,17 @@ class SitePolicy < ApplicationPolicy
     return root_attrs + attrs if user.root?
 
     attrs
+  end
+
+  private
+
+  # The theme the record is stored with, ignoring anything just assigned from
+  # the form, so a submitted extension theme cannot authorise itself. "" for a
+  # new site and for the Site class (Pundit's headless create check).
+  #
+  # @return [String]
+  def current_theme_name
+    record.respond_to?(:theme_was) ? record.theme_was.to_s : ''
   end
 
   class Scope < Scope

--- a/app/views/admin/sites/form_tab_images.rb
+++ b/app/views/admin/sites/form_tab_images.rb
@@ -24,7 +24,8 @@ class Views::Admin::Sites::FormTabImages < Views::Admin::Base
     fieldset(class: 'fieldset max-w-xs mb-8') do
       legend(class: 'fieldset-legend') { attr_label(:site, :theme) }
       raw form.input_field(:theme, as: :select,
-                                   collection: PlaceCal::Extensions.themes.map { |t| [t.label, t.name] },
+                                   collection: policy(site).permitted_themes.map { |theme| [theme.label, theme.name] },
+                                   include_blank: false,
                                    class: 'select select-bordered w-full')
     end
   end

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -225,8 +225,13 @@ class Views::Layouts::Application < Phlex::HTML
     JS
   end
 
+  # The site this request is for. Current.site is set for every request by
+  # ApplicationController, while @site is opt-in per controller, and the theme
+  # below is keyed off Current: reading Current first means the site half of
+  # this layout (stylesheet, manifest link, footer) and the theme half (head
+  # component, icons, theme-color, og:image) can never disagree.
   def site
-    view_context.instance_variable_get(:@site)
+    Current.site || view_context.instance_variable_get(:@site)
   end
 
   def navigation

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -141,7 +141,7 @@ class Views::Layouts::Application < Phlex::HTML
     if content_for?(:image)
       meta(property: 'og:image', content: image_url(content_for(:image)))
       meta(property: 'og:image:alt', content: content_for(:image_alt)) if content_for?(:image_alt)
-    elsif site && (theme_og = theme.og_image)
+    elsif site && (theme_og = theme.og_image_for_render)
       # A theme may ship its own static share image (#3368 D1)
       meta(property: 'og:image', content: image_url(theme_og[:path]))
       meta(property: 'og:image:alt', content: t('og_image.alt.site', name: site.name))
@@ -165,7 +165,7 @@ class Views::Layouts::Application < Phlex::HTML
   # (#3368 D1). When it does, its icons replace core's two entirely;
   # otherwise core's favicon and touch icon link as before.
   def render_icon_links
-    icons = theme.icons
+    icons = theme.icons_for_render
 
     if icons.empty?
       link(rel: 'icon', type: 'image/png', href: image_url('favicon.png'))

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -32,8 +32,9 @@ PlaceCal::Extensions.register_theme(:custom, core: true) do |theme|
   theme.stylesheet do |site|
     path = "themes/custom/#{site.slug}"
     # The per-site asset may not exist in the pipeline (#2936): link nothing
-    # rather than raise Propshaft::MissingAssetError.
-    path if Rails.application.assets&.resolver&.resolve("#{path}.css").present?
+    # rather than raise Propshaft::MissingAssetError. Same check the theme's
+    # own guards use, so the two cannot drift.
+    path if PlaceCal::Theme.asset_resolves?("#{path}.css")
   end
   theme.map_style(&:slug)
 end

--- a/config/initializers/site_page_routes.rb
+++ b/config/initializers/site_page_routes.rb
@@ -8,13 +8,19 @@
 # on each draw. Registered here, in an initializer, rather than in
 # config/routes.rb: an append block registered inside a routes file is
 # registered again on every reload of that file, which then defines the route
-# name twice. PlaceCal::Theme checks a registered slug against the reserved
-# first path segments derived from the finished route set.
+# name twice.
 Rails.application.routes.append do
-  # HTML only: without the constraint /about.json served the HTML page under a
-  # JSON content type. The default fills the format in for the extensionless
-  # /about so it still matches.
-  get '/:slug', to: 'pages#show', as: :site_page,
-                constraints: { slug: /[a-z0-9-]+/, format: 'html' },
-                defaults: { format: :html }
+  # Only a slug some registered theme actually serves is recognised
+  # (PlaceCal::Extensions::ThemePage). Anything else stays a routing 404
+  # rather than entering PagesController and running the whole public filter
+  # chain to render a 404 page. Which theme serves the slug is still the
+  # controller's business: the router cannot know the site.
+  constraints(PlaceCal::Extensions::ThemePage) do
+    # Bare paths only: `format: false` drops the optional .:format segment, so
+    # /about.json and /about.html do not route at all rather than serving the
+    # HTML page under the wrong content type.
+    get '/:slug', to: 'pages#show', as: :site_page,
+                  format: false,
+                  constraints: { slug: /[a-z0-9-]+/ }
+  end
 end

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -448,9 +448,6 @@ en:
           legacy: "Legacy"
 
     # -------------------------------------------------------------------------
-    # Pages (per-site static content)
-    # -------------------------------------------------------------------------
-    # -------------------------------------------------------------------------
     # Partners
     # -------------------------------------------------------------------------
     partners:
@@ -566,7 +563,7 @@ en:
         preview_title: "Site Content Preview"
       fields:
         alt_text_hint: "How should a screen reader describe this image?"
-        contact_email_hint: 'Where "get in touch" enquiries from this site are sent. Setting this also adds the Get in touch link to the site navigation. Leave blank to send to PlaceCal support.'
+        contact_email_hint: 'Where "get in touch" enquiries from this site are sent, and shown publicly in the site footer. Setting this also adds the Get in touch link to the site navigation. Leave blank to send to PlaceCal support.'
         hero_handbook_link: "See handbook for guidance"
         hero_image_description: "The large image at the top of your site's homepage."
         hero_text_hint: "Large text for the homepage banner"

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -120,7 +120,7 @@ theme.page "about", "MyExt::Views::About", nav_label_key: "my_ext.nav.about"
 theme.page "privacy", "MyExt::Views::Privacy"
 ```
 
-- The page is served at `/about` on every site using the theme, by core's `/:slug` catch-all. HTML only: `/about.json` does not route.
+- The page is served at `/about` on every site using the theme, by core's `/:slug` catch-all. The bare path only: `/about.json` and `/about.html` do not route. The catch-all is constrained to the slugs registered themes serve, so any other single-segment path is a routing 404 that never reaches a controller.
 - The view is constructed with `new(site:)` and inherits `Views::Base` like any other theme view. Everything about the page, including its wrapper element and any `page page--about` style classes, is the view's own business.
 - `nav_label_key` is a locale key. A page that has one is listed in the derived site nav and footer nav under `t(key)`, in registration order, after the News link. A page without one is served but not linked.
 - Every registered page is listed in the site's sitemap (no `lastmod`, since there is no record to date).

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -130,7 +130,7 @@ theme.page "privacy", "MyExt::Views::Privacy"
 
 ## Map styles
 
-`map_style` names a MapLibre style JSON. Core's own styles live in `public/map-styles/<name>.json`; an extension ships its style as an engine asset at `app/assets/builds/map-styles/<name>.json`, which Propshaft picks up and serves at the same logical path. `MapHelper#style_url_for_site` checks core's public directory first, then the asset pipeline, and falls back to `pink.json` if neither has it.
+`map_style` names a MapLibre style JSON. Core's own styles live in `public/map-styles/<name>.json`; an extension ships its style as an engine asset at `app/assets/builds/map-styles/<name>.json`, which Propshaft picks up and serves at the same logical path. `MapHelper#map_style_url` resolves the name from the request's theme (`Current.theme`), so it takes no arguments. It checks core's public directory first, then the asset pipeline, and falls back to `pink.json` if neither has it.
 
 ## Locale files
 
@@ -149,9 +149,11 @@ en:
 
 Keep the overrides in their own file (`config/locales/overrides.en.yml` by convention) so it is obvious which strings the theme rewrites and which are its own.
 
+Two things to know about which calls an override can reach. The key must be a String or a Symbol written out in full (`t("region_filter.all")` or `t(:"region_filter.all")`); a lazy key (`t(".all")`, which only the calling view can expand) is never overridable, so a core view using one has to be changed to an absolute key before a theme can rewrite it. And `scope:` is honoured: `t("all", scope: "region_filter")` looks up `theme_overrides.<theme>.region_filter.all`, the same place the absolute key does.
+
 A blank value in core's own `config/locales/en.yml` is the idiom for a slot a theme may fill. Where a piece of copy is optional (a standfirst, a section name, a heading above a list, a prefix before an organiser name), core declares the key with an empty string rather than leaving it out. Core then renders nothing for it, because every one of those views skips a blank value, while the key still exists for a theme to override. It means core needs no conditional for theme-only copy, the theme needs no forked view, and the full set of fillable slots can be read off core's locale file. If you want a slot that does not exist yet, adding the blank key to core is a one-line change; see the note above the "local site listing pages" block in `config/locales/en.yml`.
 
-Some core strings exist only as override slots: core ships them empty so nothing renders, and a theme fills them in. The listing pages carry one such slot, `<ns>.index.list_heading` (`partners.index.list_heading`, `events.index.list_heading`), which `Components::ListHeading` renders as an `h2` between the hero and the filters when it is not blank:
+Some core strings exist only as override slots: core ships them empty so nothing renders, and a theme fills them in. The listing pages carry one such slot, `<ns>.index.list_heading` (`partners.index.list_heading`, `events.index.list_heading`), which `Views::Base#list_heading` renders as an `h2` between the hero and the filters when it is not blank:
 
 ```yaml
 en:
@@ -208,7 +210,9 @@ group :extensions do
 end
 ```
 
-Keep it a single block so removing it is one edit. The Dockerfile needs no Node build step for extensions because each engine ships its CSS prebuilt.
+Keep it a single block so removing it is one edit. Delete it rather than excluding the group: `config/application.rb` calls `Bundler.require(*Rails.groups, :extensions)`, so `BUNDLE_WITHOUT=extensions` leaves the gems uninstalled but still required and the app raises `LoadError` at boot. Deleting the block is the supported way to run without extensions, and sites already on an uninstalled theme keep working: they degrade to core's default styling and stay editable in admin.
+
+The Dockerfile needs no Node build step for extensions because each engine ships its CSS prebuilt.
 
 ## Engine specs
 

--- a/lib/placecal/extensions.rb
+++ b/lib/placecal/extensions.rb
@@ -13,6 +13,21 @@ module PlaceCal
   module Extensions
     class UnknownTheme < KeyError; end
 
+    # Route constraint for the `/:slug` theme-page catch-all
+    # (config/initializers/site_page_routes.rb). Without it every unknown
+    # single-segment path becomes a fully rendered 404: the whole public
+    # before_action chain runs, the layout is built, and a scanner walking
+    # /wp-login, /backup and the rest pays for all of it. With it, only a slug
+    # some registered theme actually serves is recognised; everything else
+    # stays a routing 404 that never reaches a controller.
+    module ThemePage
+      # @param request [ActionDispatch::Request]
+      # @return [Boolean]
+      def self.matches?(request)
+        Extensions.page_slugs.include?(request.path_parameters[:slug])
+      end
+    end
+
     module_function
 
     # Register (or replace) a theme definition.
@@ -26,7 +41,23 @@ module PlaceCal
       yield theme if block_given?
       warn_on_reregistration(theme.name)
       registry[theme.name] = theme
+      invalidate_page_slugs!
       theme
+    end
+
+    # Every page slug any registered theme serves, across all themes: the
+    # router has one route for all of them and cannot know the site until the
+    # request is in a controller. Computed from the registry and recomputed
+    # whenever it changes, so the constraint costs a Set lookup per request.
+    #
+    # @return [Set<String>]
+    def page_slugs
+      @page_slugs ||= registry.each_value.flat_map { |theme| theme.pages.keys }.to_set
+    end
+
+    # Called from Theme#page and from every registry mutation.
+    def invalidate_page_slugs!
+      @page_slugs = nil
     end
 
     # Two extensions claiming the same theme name is a silent hijack: the last
@@ -73,6 +104,7 @@ module PlaceCal
     # Empty the registry. For specs; pair with #snapshot / #restore.
     def reset!
       registry.clear
+      invalidate_page_slugs!
     end
 
     # @return [Hash] a copy of the registry state, for #restore. Each theme is
@@ -85,6 +117,7 @@ module PlaceCal
     # @param state [Hash] a value from #snapshot
     def restore(state)
       registry.replace(state)
+      invalidate_page_slugs!
     end
 
     def registry

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -85,6 +85,18 @@ module PlaceCal
       @nav_cta = nil
       @pages = {}
       @event_filter_style = :date_picker
+      @warned = Set.new
+    end
+
+    # Registry snapshots (PlaceCal::Extensions.snapshot) dup every theme so a
+    # spec that reconfigures one in place cannot leak the change into later
+    # examples. A shallow dup would share the mutable containers, so dup them
+    # too.
+    def initialize_copy(other)
+      super
+      @pages = other.pages.dup
+      @icons = other.icons.dup
+      @warned = Set.new
     end
 
     def core?
@@ -266,6 +278,16 @@ module PlaceCal
       (site && Extensions.find_theme(site.theme)) || NONE
     end
 
+    # The one answer to "will the asset helpers find this?". `resolve` is what
+    # stylesheet_link_tag and image_url call, so asking it is the only check
+    # that cannot drift from what they do.
+    #
+    # @param logical_path [String] asset path including its extension
+    # @return [Boolean]
+    def self.asset_resolves?(logical_path)
+      Rails.application.assets&.resolver&.resolve(logical_path).present?
+    end
+
     # ---- Resolution
 
     # A theme's stylesheet is only linked when the asset pipeline can resolve
@@ -279,7 +301,41 @@ module PlaceCal
       return nil if path.nil?
       return path if asset_resolves?("#{path}.css")
 
-      Rails.logger.error("PlaceCal theme #{name}: stylesheet #{path}.css does not resolve in the asset pipeline; rendering without it")
+      warn_once(:stylesheet, "stylesheet #{path}.css does not resolve in the asset pipeline; rendering without it")
+      nil
+    end
+
+    # The theme's icons, minus any whose asset the pipeline cannot resolve. A
+    # renamed or dropped engine image would otherwise raise
+    # Propshaft::MissingAssetError from `image_url` on every page of every site
+    # on the theme, which is the failure `stylesheet_for` already guards
+    # against (#3368). Callers rendering icons read this, not #icons.
+    #
+    # @return [Hash] icon paths that resolve, plus mask_icon_color when its
+    #   mask icon survived. Empty when none resolve, so core's icons render.
+    def icons_for_render
+      return @icons if @icons.empty?
+
+      resolved = @icons.select do |key, path|
+        next false unless ICON_PATH_KEYS.include?(key)
+        next true if asset_resolves?(path)
+
+        warn_once(:"icon_#{key}", "icon #{key} #{path} does not resolve in the asset pipeline; omitting it")
+        false
+      end
+      return {} if resolved.empty?
+
+      resolved[:mask_icon_color] = @icons[:mask_icon_color] if resolved[:mask_icon] && @icons[:mask_icon_color]
+      resolved
+    end
+
+    # @return [Hash, nil] the share image, or nil when its asset does not
+    #   resolve, in which case core's generated share card renders instead.
+    def og_image_for_render
+      return nil if @og_image.nil?
+      return @og_image if asset_resolves?(@og_image[:path])
+
+      warn_once(:og_image, "og_image #{@og_image[:path]} does not resolve in the asset pipeline; falling back to core's share card")
       nil
     end
 
@@ -327,10 +383,8 @@ module PlaceCal
       value&.to_s.presence
     end
 
-    # @param logical_path [String] asset path including extension
-    # @return [Boolean] whether Propshaft can serve the asset
     def asset_resolves?(logical_path)
-      Rails.application.assets&.load_path&.find(logical_path).present?
+      self.class.asset_resolves?(logical_path)
     end
 
     # A theme names its classes as strings so registration can happen before
@@ -345,8 +399,20 @@ module PlaceCal
 
       class_name.constantize
     rescue NameError
-      Rails.logger.error("PlaceCal theme #{name}: #{setting} class #{class_name} could not be resolved; falling back to core")
+      warn_once(:"class_#{setting}", "#{setting} class #{class_name} could not be resolved; falling back to core")
       nil
+    end
+
+    # A stale path or class name is a per-theme configuration fault, not a
+    # per-request one: logging it on every render of every page would flood the
+    # log stream. Say it once per setting, per theme, per boot.
+    #
+    # @param setting [Symbol] which setting is at fault
+    # @param message [String]
+    def warn_once(setting, message)
+      return unless @warned.add?(setting)
+
+      Rails.logger.warn("PlaceCal theme #{name}: #{message}")
     end
   end
 end

--- a/lib/placecal/theme.rb
+++ b/lib/placecal/theme.rb
@@ -217,6 +217,9 @@ module PlaceCal
       raise ArgumentError, "invalid page slug #{slug.inspect}, expected lowercase letters, numbers and hyphens" unless slug.match?(PAGE_SLUG_FORMAT)
 
       @pages[slug] = { view: view_class_name.to_s, nav_label_key: nav_label_key&.to_s }
+      # The /:slug route constraint is built from every theme's slugs, and a
+      # theme may gain a page after it was registered.
+      Extensions.invalidate_page_slugs!
       self
     end
 

--- a/lib/placecal/theme_translation.rb
+++ b/lib/placecal/theme_translation.rb
@@ -31,42 +31,49 @@ module PlaceCal
     # is no override to apply: when there is a `super`, the call is handed
     # straight to it rather than reimplemented.
     def t(key, **options)
-      theme = Current.theme
-      overridable = overridable_key?(theme, key)
+      override = override_key(Current.theme, key, options)
 
-      # No override scope to consult (a lazy '.foo' key, or a request with no
-      # theme), so let the `t` this module shadows do the whole job, including
-      # ActionView's `_html` escaping and html_safe marking.
-      return super if defined?(super) && !overridable
+      # No override to apply (no theme, a lazy '.foo' key, or simply a key
+      # this theme does not rewrite), so let the `t` this module shadows do
+      # the whole job, including ActionView's `_html` escaping, its html_safe
+      # marking and its missing-translation reporting.
+      return super if override.nil? && defined?(super)
 
       options = escape_html_interpolations(key, options)
-      value = overridable ? theme_scoped_translation(theme, key, **options) : I18n.t(key, **options)
+      # `scope:` has already been folded into the override key; passing it on
+      # would send I18n looking under the scope for the absolute key.
+      value = override ? I18n.t(override, **options.except(:scope)) : I18n.t(key, **options)
 
       html_key?(key) && value.is_a?(String) ? value.html_safe : value # rubocop:disable Rails/OutputSafety
     end
 
     private
 
-    # Try the theme's override first, then the key the caller asked for, then
-    # whatever defaults the caller supplied.
-    def theme_scoped_translation(theme, key, **options)
-      scoped = "#{OVERRIDE_SCOPE}.#{theme.name}.#{key}"
-      # The scoped key is absolute, so there is nothing the including class's
-      # own `t` would add here; go straight to I18n.
-      I18n.t(scoped, **options, default: [key.to_sym, *Array(options[:default])])
-    rescue I18n::MissingTranslationData => e
-      # Report the key the caller wrote, not the theme_overrides path they
-      # have never heard of.
-      raise I18n::MissingTranslationData.new(e.locale, key, e.options)
-    end
+    # The theme_overrides key that exists for this call, or nil when there is
+    # nothing to override. Looking first rather than relying on I18n's default
+    # chain matters: a miss down that chain returns a "Translation missing"
+    # string naming the internal theme_overrides path, which is not a phrase
+    # the caller has ever heard of and would be rendered to the reader.
+    #
+    # A lazy ('.foo') key is left alone: it only means anything to the
+    # including class's own `t`, which knows the current scope. The null theme
+    # has no overrides, so short-circuit rather than send every directory
+    # lookup through a `theme_overrides.none.<key>` miss.
+    #
+    # @param theme [PlaceCal::Theme]
+    # @param key [String, Symbol]
+    # @param options [Hash] the caller's `t` options; `scope:` and `locale:`
+    #   are honoured, since both change which key the caller means
+    # @return [String, nil]
+    def override_key(theme, key, options)
+      return nil if theme.equal?(PlaceCal::Theme::NONE)
+      return nil unless key.is_a?(String) || key.is_a?(Symbol)
 
-    # Whether this key could carry a theme override: an absolute key (a lazy
-    # '.foo' key only means anything to the including class's own `t`, which
-    # knows the current scope) on a request whose theme is registered. The
-    # null theme has no overrides, so short-circuit rather than send every
-    # directory lookup through a `theme_overrides.none.<key>` miss.
-    def overridable_key?(theme, key)
-      !theme.equal?(PlaceCal::Theme::NONE) && key.is_a?(String) && !key.start_with?('.')
+      key = key.to_s
+      return nil if key.start_with?('.')
+
+      scoped = "#{OVERRIDE_SCOPE}.#{theme.name}.#{[*options[:scope], key].join('.')}"
+      scoped if I18n.exists?(scoped, options[:locale] || I18n.locale)
     end
 
     # Only reached when there is no `super` to do it (Phlex components), or for

--- a/spec/components/hero_component_spec.rb
+++ b/spec/components/hero_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Hero, type: :component do
+  it "escapes markup in the title" do
+    render_inline(described_class.new("<img src=x onerror=1> Garden", "Partner"))
+
+    expect(page).to have_css("h1", text: "<img src=x onerror=1> Garden")
+    expect(page).not_to have_css("h1 img")
+  end
+
+  it "breaks a long title across two lines with a real br element" do
+    render_inline(described_class.new("A rather long partner name that needs splitting", nil))
+
+    expect(page).to have_css("h1 br", count: 1)
+    expect(page).to have_css("h1", text: "A rather long partner name that needs splitting")
+  end
+
+  it "escapes markup in a long title too" do
+    render_inline(described_class.new("<b>bold</b> and a long title here to trip the split path", nil))
+
+    expect(page).not_to have_css("h1 b")
+    expect(page).to have_css("h1", text: "<b>bold</b>")
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -30,4 +30,47 @@ RSpec.describe ApplicationHelper do
       expect(helper.current_section?("/events", "")).to be(false)
     end
   end
+
+  describe "#current_page_path?" do
+    it "is true only for the page the link points at" do
+      expect(helper.current_page_path?("/events", "/events")).to be(true)
+      expect(helper.current_page_path?("/events/", "/events")).to be(true)
+      expect(helper.current_page_path?("/events?period=week", "/events")).to be(true)
+      expect(helper.current_page_path?("/", "/")).to be(true)
+    end
+
+    it "is false for a page beneath the link" do
+      expect(helper.current_page_path?("/events/123", "/events")).to be(false)
+    end
+  end
+
+  describe "#active_link_to" do
+    # aria-current="page" names the page being rendered; an ancestor section
+    # link is aria-current="true".
+    it "marks the link to this page as the current page" do
+      allow(helper.request).to receive(:original_fullpath).and_return("/events")
+
+      expect(helper.active_link_to("Events", "/events")).to include('aria-current="page"')
+    end
+
+    it "marks an ancestor section link as current, but not as the page" do
+      allow(helper.request).to receive(:original_fullpath).and_return("/events/123")
+      link = helper.active_link_to("Events", "/events")
+
+      expect(link).to include('aria-current="true"')
+      expect(link).not_to include('aria-current="page"')
+    end
+
+    it "sets no aria-current on a link that is not current" do
+      allow(helper.request).to receive(:original_fullpath).and_return("/news")
+
+      expect(helper.active_link_to("Events", "/events")).not_to include("aria-current")
+    end
+
+    it "emits no data attribute when none was given" do
+      allow(helper.request).to receive(:original_fullpath).and_return("/news")
+
+      expect(helper.active_link_to("Events", "/events")).not_to include("data=")
+    end
+  end
 end

--- a/spec/lib/placecal/extensions_spec.rb
+++ b/spec/lib/placecal/extensions_spec.rb
@@ -108,6 +108,50 @@ RSpec.describe PlaceCal::Extensions do
     end
   end
 
+  # The /:slug catch-all constrains on this set, so it has to follow the
+  # registry rather than be computed once at boot.
+  describe ".page_slugs", :theme_registry do
+    it "collects the slugs of every registered theme" do
+      described_class.reset!
+      described_class.register_theme(:one) { |theme| theme.page "alpha", "Sample::Views::Alpha" }
+      described_class.register_theme(:two) { |theme| theme.page "beta", "Sample::Views::Beta" }
+
+      expect(described_class.page_slugs).to eq(Set["alpha", "beta"])
+    end
+
+    it "picks up a page added after the theme was registered" do
+      described_class.reset!
+      described_class.register_theme(:one)
+      expect(described_class.page_slugs).to be_empty
+
+      described_class.fetch_theme(:one).page "gamma", "Sample::Views::Gamma"
+
+      expect(described_class.page_slugs).to eq(Set["gamma"])
+    end
+
+    it "forgets slugs from a registry that has been reset or restored" do
+      state = described_class.snapshot
+      described_class.register_theme(:one) { |theme| theme.page "delta", "Sample::Views::Delta" }
+      expect(described_class.page_slugs).to include("delta")
+
+      described_class.restore(state)
+
+      expect(described_class.page_slugs).not_to include("delta")
+    end
+  end
+
+  describe PlaceCal::Extensions::ThemePage do
+    it "matches only a slug some registered theme serves" do
+      request = instance_double(ActionDispatch::Request, path_parameters: { slug: "proof" })
+      expect(described_class.matches?(request)).to be true
+    end
+
+    it "does not match anything else" do
+      request = instance_double(ActionDispatch::Request, path_parameters: { slug: "wp-login" })
+      expect(described_class.matches?(request)).to be false
+    end
+  end
+
   it "restores the registry after a mutating example" do
     expect(described_class.theme_names).to start_with(%w[pink orange green blue custom]).and include("example_theme")
   end

--- a/spec/lib/placecal/theme_spec.rb
+++ b/spec/lib/placecal/theme_spec.rb
@@ -153,19 +153,19 @@ RSpec.describe PlaceCal::Theme do
     end
 
     it "returns nil and logs when the stylesheet is missing from the pipeline" do
-      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
       theme.stylesheet "themes/no-such-theme"
 
       expect(theme.stylesheet_for(site)).to be_nil
-      expect(Rails.logger).to have_received(:error).with(%r{themes/no-such-theme\.css})
+      expect(Rails.logger).to have_received(:warn).with(%r{themes/no-such-theme\.css})
     end
 
     it "returns nil and logs when a block resolves to a missing stylesheet" do
-      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
       theme.stylesheet { |s| "themes/custom/#{s.slug}" }
 
       expect(theme.stylesheet_for(site)).to be_nil
-      expect(Rails.logger).to have_received(:error).with(%r{themes/custom/hulme\.css})
+      expect(Rails.logger).to have_received(:warn).with(%r{themes/custom/hulme\.css})
     end
 
     it "returns nil when nothing is set or the block returns nil" do
@@ -188,15 +188,15 @@ RSpec.describe PlaceCal::Theme do
       theme.head "Nope::Components::Head"
       theme.footer "Nope::Components::Footer"
 
-      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
 
       expect(theme.homepage_view_class).to be_nil
       expect(theme.head_class).to be_nil
       expect(theme.footer_class).to be_nil
 
-      expect(Rails.logger).to have_received(:error).with(/homepage_view class Nope::Views::Home/)
-      expect(Rails.logger).to have_received(:error).with(/head class Nope::Components::Head/)
-      expect(Rails.logger).to have_received(:error).with(/footer class Nope::Components::Footer/)
+      expect(Rails.logger).to have_received(:warn).with(/homepage_view class Nope::Views::Home/)
+      expect(Rails.logger).to have_received(:warn).with(/head class Nope::Components::Head/)
+      expect(Rails.logger).to have_received(:warn).with(/footer class Nope::Components::Footer/)
     end
   end
 
@@ -243,10 +243,10 @@ RSpec.describe PlaceCal::Theme do
 
     it "returns nil and logs when the class name no longer resolves" do
       theme.page "about", "Nope::Views::About"
-      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
 
       expect(theme.page_view_class("about")).to be_nil
-      expect(Rails.logger).to have_received(:error).with(/page about class Nope::Views::About/)
+      expect(Rails.logger).to have_received(:warn).with(/page about class Nope::Views::About/)
     end
   end
 

--- a/spec/mailers/join_mailer_spec.rb
+++ b/spec/mailers/join_mailer_spec.rb
@@ -40,4 +40,45 @@ RSpec.describe JoinMailer, type: :mailer do
       expect(mail.to).to eq([Join::DEFAULT_RECIPIENT])
     end
   end
+
+  # The mail is rendered from the request today and from a job tomorrow, and
+  # Current is reset between the two, so the mailer sets it from the join's own
+  # site rather than trusting whatever the caller left behind (#3368 D19).
+  describe "theme-scoped copy" do
+    let(:themed_site) { build(:site, name: "Themed", theme: "example_theme", contact_email: "hello@example.org") }
+
+    before do
+      I18n.backend.store_translations(
+        :en,
+        theme_overrides: {
+          example_theme: {
+            join_mailer: { join_us: { subject_with_site: "Fixture join request (%{site})" } } # rubocop:disable Style/FormatStringToken
+          }
+        }
+      )
+      Current.reset
+    end
+
+    it "uses the theme's override with no request to have set Current" do
+      mail = described_class.join_us(Join.new(site: themed_site, **join_attrs))
+
+      expect(mail.subject).to eq("Fixture join request (Themed)")
+      expect(mail.body.encoded).to include("Test User")
+    end
+
+    it "renders under the join's own site, not whatever Current was left on" do
+      use_current_site(build(:site, name: "Someone else", theme: "pink"))
+
+      mail = described_class.join_us(Join.new(site: themed_site, **join_attrs))
+
+      expect(mail.subject).to eq("Fixture join request (Themed)")
+      expect(Current.site).to eq(themed_site)
+    end
+
+    it "leaves the null theme for a join with no site" do
+      described_class.join_us(Join.new(**join_attrs)).body
+
+      expect(Current.theme).to eq(PlaceCal::Theme::NONE)
+    end
+  end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -233,10 +233,10 @@ RSpec.describe Site, type: :model do
 
       it "returns nil and logs when the theme's stylesheet is missing from the pipeline", :theme_registry do
         PlaceCal::Extensions.register_theme(:ghost) { |theme| theme.stylesheet "ghost/theme" }
-        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:warn)
 
         expect(build(:site, theme: "ghost").stylesheet_link).to be_nil
-        expect(Rails.logger).to have_received(:error).with(%r{ghost/theme\.css})
+        expect(Rails.logger).to have_received(:warn).with(%r{ghost/theme\.css})
       end
     end
   end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -216,6 +216,34 @@ RSpec.describe Site, type: :model do
       expect(build(:site, theme: "")).to be_valid
     end
 
+    # Uninstalling an extension must not strand every site that used its theme
+    # (doc/extensions.md invites self-hosters to delete the extensions group).
+    context "when the site's theme is no longer registered", :theme_registry do
+      let(:orphan) do
+        PlaceCal::Extensions.register_theme(:doomed)
+        site = create(:site, theme: "doomed")
+        PlaceCal::Extensions.reset!
+        site.reload
+      end
+
+      it "stays valid and savable" do
+        expect(orphan).to be_valid
+        expect(orphan.update(name: "Renamed")).to be true
+        expect(orphan.reload.theme).to eq("doomed")
+      end
+
+      it "still rejects a change to another unregistered theme" do
+        orphan.theme = "also-gone"
+
+        expect(orphan).not_to be_valid
+        expect(orphan.errors[:theme]).to be_present
+      end
+
+      it "degrades to the null theme at render" do
+        expect(PlaceCal::Theme.for(orphan)).to eq(PlaceCal::Theme::NONE)
+      end
+    end
+
     describe "#stylesheet_link" do
       it "returns the core theme stylesheet" do
         %w[pink orange green blue].each do |name|

--- a/spec/requests/admin/icons_spec.rb
+++ b/spec/requests/admin/icons_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The admin icon gallery (Admin::PagesController#icons) is a root-only
+# developer reference, so its authorisation is worth holding onto.
+RSpec.describe "Admin::Icons", type: :request do
+  describe "GET /admin/icons" do
+    context "as an unauthenticated user" do
+      it "redirects to login" do
+        get admin_icons_url(host: admin_host)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "as a non-root user" do
+      let(:user) { create(:citizen_user) }
+
+      before { sign_in user }
+
+      it "redirects away" do
+        get admin_icons_url(host: admin_host)
+        expect(response).to be_redirect
+      end
+    end
+
+    context "as a root user" do
+      let(:user) { create(:root_user) }
+
+      before { sign_in user }
+
+      it "shows the icons page" do
+        get admin_icons_url(host: admin_host)
+        expect(response).to be_successful
+        expect(response.body).to include("icon")
+      end
+    end
+  end
+end

--- a/spec/requests/admin/sites_spec.rb
+++ b/spec/requests/admin/sites_spec.rb
@@ -241,3 +241,76 @@ RSpec.describe "Admin::Sites", type: :request do
     end
   end
 end
+
+# Extension themes swap in an engine's views and copy, and only exist on
+# installations that ship that gem, so they are root's to set (#3368, WP 4.5).
+# Site admins keep the core themes and the fields they already had.
+RSpec.describe "Admin::Sites theme and contact authorisation", type: :request do
+  let!(:themed_site) { create(:site, slug: "themed-site", theme: "pink", site_admin: site_admin) }
+  let(:site_admin) { create(:citizen_user) }
+  let(:root_user) { create(:root_user) }
+
+  def put_site(attributes)
+    put admin_site_url(themed_site, host: admin_host), params: { site: attributes }
+  end
+
+  context "as a site admin" do
+    before { sign_in site_admin }
+
+    it "cannot move the site onto an extension theme" do
+      put_site(theme: "example_theme")
+
+      expect(response).to redirect_to(admin_root_path)
+      expect(themed_site.reload.theme).to eq("pink")
+    end
+
+    it "can still pick a core theme" do
+      put_site(theme: "blue")
+
+      expect(themed_site.reload.theme).to eq("blue")
+    end
+
+    it "is offered core themes only in the theme select" do
+      get edit_admin_site_url(themed_site, host: admin_host)
+
+      options = Nokogiri::HTML(response.body).css("select#site_theme option").map { |o| o["value"] }
+      expect(options).to include("pink", "blue")
+      expect(options).not_to include("example_theme")
+      expect(options).not_to include("")
+    end
+
+    it "can set the site's contact email" do
+      put_site(contact_email: "hello@example.org")
+
+      expect(themed_site.reload.contact_email).to eq("hello@example.org")
+    end
+  end
+
+  context "as a root user" do
+    before { sign_in root_user }
+
+    it "can move the site onto an extension theme" do
+      put_site(theme: "example_theme")
+
+      expect(themed_site.reload.theme).to eq("example_theme")
+    end
+
+    it "is offered extension themes in the theme select" do
+      get edit_admin_site_url(themed_site, host: admin_host)
+
+      options = Nokogiri::HTML(response.body).css("select#site_theme option").map { |o| o["value"] }
+      expect(options).to include("example_theme")
+    end
+  end
+
+  context "as a citizen who administers nothing" do
+    before { sign_in create(:citizen_user) }
+
+    it "cannot set the site's contact email" do
+      put_site(contact_email: "hello@example.org")
+
+      expect(response).to redirect_to(admin_root_path)
+      expect(themed_site.reload.contact_email).to be_blank
+    end
+  end
+end

--- a/spec/requests/extensions/theme_fallbacks_spec.rb
+++ b/spec/requests/extensions/theme_fallbacks_spec.rb
@@ -97,10 +97,22 @@ RSpec.describe "Theme fallbacks", :theme_registry, type: :request do
       site_on("pink", "plain")
     end
 
-    it "404s for a slug the theme does not register" do
-      get "http://themed.lvh.me/nothing-here"
+    # The catch-all is constrained to slugs some registered theme serves
+    # (PlaceCal::Extensions::ThemePage), so an unknown path is a routing 404
+    # rather than a fully rendered one: nothing runs the public filter chain
+    # for a scanner walking /wp-login and friends.
+    it "does not route a slug no registered theme serves" do
+      expect { get "http://themed.lvh.me/nothing-here" }
+        .to raise_error(ActionController::RoutingError)
+    end
 
-      expect(response).to have_http_status(:not_found)
+    # Bare paths only: an explicit format would otherwise serve the HTML page
+    # under the wrong content type.
+    it "does not route a theme page with an explicit format" do
+      expect { get "http://themed.lvh.me/proof.json" }
+        .to raise_error(ActionController::RoutingError)
+      expect { get "http://themed.lvh.me/proof.html" }
+        .to raise_error(ActionController::RoutingError)
     end
 
     it "404s for a theme page slug on a site whose theme is core's" do

--- a/spec/requests/extensions/theme_fallbacks_spec.rb
+++ b/spec/requests/extensions/theme_fallbacks_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Theme fallbacks", :theme_registry, type: :request do
         theme.head "Brokenly::Components::Head"
         theme.footer "Brokenly::Components::Footer"
       end
-      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
       # The theme must be registered before the site is validated.
       site
     end
@@ -53,14 +53,14 @@ RSpec.describe "Theme fallbacks", :theme_registry, type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).not_to include("brokenly/theme")
       expect(response.body).to include(site.description)
-      expect(Rails.logger).to have_received(:error).with(%r{brokenly/theme\.css})
+      expect(Rails.logger).to have_received(:warn).with(%r{brokenly/theme\.css})
     end
 
     it "renders an inner page without the missing head and footer components" do
       get "http://brokenly.lvh.me/news"
 
       expect(response).to have_http_status(:ok)
-      expect(Rails.logger).to have_received(:error).with(/head class Brokenly::Components::Head/)
+      expect(Rails.logger).to have_received(:warn).with(/head class Brokenly::Components::Head/)
     end
   end
 
@@ -120,12 +120,12 @@ RSpec.describe "Theme fallbacks", :theme_registry, type: :request do
         theme.page "about", "Nope::Views::About"
       end
       site_on("pagey", "pagey")
-      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
 
       get "http://pagey.lvh.me/about"
 
       expect(response).to have_http_status(:not_found)
-      expect(Rails.logger).to have_received(:error).with(/page about class Nope::Views::About/)
+      expect(Rails.logger).to have_received(:warn).with(/page about class Nope::Views::About/)
     end
 
     it "falls back to core's privacy page when the theme registers none" do
@@ -134,6 +134,42 @@ RSpec.describe "Theme fallbacks", :theme_registry, type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to match(/privacy/i)
       expect(response.body).not_to include("Example theme fixture proof page")
+    end
+  end
+
+  # A theme's icon and share-image paths are asset logical paths resolved with
+  # image_url, which raises when the asset is gone. A bumped engine gem that
+  # renamed one must not take every page of every site on the theme down.
+  context "with a theme whose icon and share-image assets are gone" do
+    before do
+      PlaceCal::Extensions.register_theme(:stale_assets) do |theme|
+        theme.icons favicon_32: "stale_assets/gone-32.png",
+                    icon_192: "stale_assets/gone-192.png"
+        theme.og_image "stale_assets/gone-og.png", width: 1200, height: 675
+      end
+      site_on("stale_assets", "stale")
+      allow(Rails.logger).to receive(:warn)
+    end
+
+    it "renders the site homepage with core's icons and share card instead" do
+      get "http://stale.lvh.me"
+
+      expect(response).to have_http_status(:ok)
+      head = head_html
+      expect(head).not_to include("gone-32")
+      expect(head).not_to include("gone-og")
+      expect(head).to match(%r{<link rel="icon" type="image/png" href="[^"]*/assets/favicon-[0-9a-f]+\.png">})
+      expect(Rails.logger).to have_received(:warn).with(/gone-32\.png/)
+      expect(Rails.logger).to have_received(:warn).with(/gone-og\.png/)
+    end
+
+    it "omits the icon from the web manifest rather than raising" do
+      get "http://stale.lvh.me/manifest.webmanifest"
+
+      expect(response).to have_http_status(:ok)
+      manifest = JSON.parse(response.body)
+      expect(manifest["icons"].map { |icon| icon["src"] }.join).not_to include("gone-192")
+      expect(manifest["icons"].map { |icon| icon["sizes"] }).to eq(%w[64x64 180x180])
     end
   end
 

--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -181,6 +181,15 @@ RSpec.describe "Theme slots", type: :request do
     expect(response.body).to include("<loc>#{themed_site.directory_url.chomp('/')}/proof</loc>")
   end
 
+  # A theme's branding CSS needs a hook that does not move when an admin
+  # renames the site (#3368).
+  it "marks the branding with the theme name as well as the site slug" do
+    get "http://themed.lvh.me"
+
+    branding = Nokogiri::HTML(response.body).at_css("a.header__branding")
+    expect(branding["class"].split).to include("header__branding--themed", "header__branding--theme-example_theme")
+  end
+
   # One negative for every slot at once: this catches a slot leaking onto core
   # sites regardless of which slot it is.
   it "renders none of the theme slots on a core site" do
@@ -211,6 +220,8 @@ RSpec.describe "Theme slots", type: :request do
       expect(response.body).not_to include("list-heading")
       expect(response.body).not_to include("header__cta")
       expect(response.body).not_to include("header__toggle-label")
+      expect(response.body).not_to include("header__branding--theme-example_theme")
+      expect(response.body).to include("header__branding--theme-pink")
       expect(response.body).to include("Go to date")
       expect(response.body).not_to include("day-strip")
       expect(response.body).to include(" 9 Nov")

--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -115,6 +115,38 @@ RSpec.describe "Theme slots", type: :request do
     expect(response.body).to include('header__toggle-label">Menu<')
   end
 
+  it "opens an off-site call to action in a new tab" do
+    get "http://themed.lvh.me/events"
+
+    cta = Nokogiri::HTML(response.body).at_css("a.header__cta-link")
+    expect(cta["target"]).to eq("_blank")
+    expect(cta["rel"]).to eq("noopener")
+  end
+
+  # A CTA pointing at a page of this site is an ordinary nav link.
+  it "keeps an on-site call to action in the same tab", :theme_registry do
+    PlaceCal::Extensions.register_theme(:homely) do |theme|
+      theme.nav_cta "example_theme.nav.donate", "/proof"
+    end
+    site_on("homely", "homely")
+
+    get "http://homely.lvh.me/events"
+
+    cta = Nokogiri::HTML(response.body).at_css("a.header__cta-link")
+    expect(cta["href"]).to eq("/proof")
+    expect(cta["target"]).to be_nil
+    expect(cta["rel"]).to be_nil
+  end
+
+  # The visible "Menu" label is a theme opt-in; the accessible name is not.
+  it "names the menu toggle even on a site whose theme does not label it" do
+    get "http://plain.lvh.me/events"
+
+    toggle = Nokogiri::HTML(response.body).at_css("button.header__toggle")
+    expect(toggle["aria-label"]).to eq(I18n.t("navigation.menu"))
+    expect(toggle.at_css(".header__toggle-label")).to be_nil
+  end
+
   it "renders the day strip in place of the date picker, linking dated event URLs" do
     get "http://themed.lvh.me/events"
 

--- a/spec/requests/extensions/theme_translation_spec.rb
+++ b/spec/requests/extensions/theme_translation_spec.rb
@@ -69,8 +69,42 @@ RSpec.describe PlaceCal::ThemeTranslation do
     use_current_site(themed_site)
     I18n.backend.store_translations(
       :en,
-      theme_overrides: { example_theme: { spec_shim: { greeting_html: "<b>Hello %{name}</b>" } } } # rubocop:disable Style/FormatStringToken
+      spec_shim: { scoped: "Core scoped", symbolic: "Core symbolic" },
+      theme_overrides: {
+        example_theme: {
+          spec_shim: {
+            greeting_html: "<b>Hello %{name}</b>", # rubocop:disable Style/FormatStringToken
+            scoped: "Override scoped",
+            symbolic: "Override symbolic"
+          }
+        }
+      }
     )
+  end
+
+  describe "scope:" do
+    it "applies the override for the key the scope names" do
+      expect(component.t("scoped", scope: "spec_shim")).to eq("Override scoped")
+    end
+
+    it "accepts an array scope" do
+      expect(component.t("scoped", scope: %i[spec_shim])).to eq("Override scoped")
+    end
+
+    it "still finds the core string when the theme overrides nothing there" do
+      expect(component.t("symbolic", scope: "spec_shim", default: "Caller default")).to eq("Override symbolic")
+      expect(component.t("nothing_here", scope: "spec_shim", default: "Caller default")).to eq("Caller default")
+    end
+  end
+
+  describe "symbol keys" do
+    it "applies the override" do
+      expect(component.t(:"spec_shim.symbolic")).to eq("Override symbolic")
+    end
+
+    it "hands a lazy symbol key to the including class's own t" do
+      expect(with_super.t(:".some_key")).to eq("super:.some_key")
+    end
   end
 
   describe "caller-supplied defaults" do
@@ -125,6 +159,15 @@ RSpec.describe PlaceCal::ThemeTranslation do
 
       expect { component.t("definitely.missing.key", raise: true) }
         .to raise_error(I18n::MissingTranslationData, /definitely\.missing\.key/)
+    end
+
+    # Without raise:, I18n returns the message as a string, which is rendered
+    # to the reader. It must never name the internal theme_overrides path.
+    it "never names the theme_overrides path in the returned message" do
+      result = component.t("definitely.missing.key")
+
+      expect(result).to include("definitely.missing.key")
+      expect(result).not_to include("theme_overrides")
     end
   end
 end


### PR DESCRIPTION
- Hero title rendered as text (same fix as #3488 on main), keeping this branch's extra hero props.
- Extension themes are root-only: site admins choose among core themes, a forged theme parameter is refused, the persisted value stays selectable.
- Theme icon and share-image paths that do not resolve are dropped with one warning per theme and setting; stylesheet and class fallbacks warn once too.
- The /:slug catch-all only matches slugs a registered theme serves, so scanner probes stay routing 404s; .json and .html variants 404.
- A site whose theme was removed from the registry still saves (validation on change only).
- Translation shim: no internal override path leaks to the page, scope: is honoured, Symbol keys work; registry snapshots duplicate pages and icons.
- Layout reads the site from Current; JoinMailer sets Current from the join's site so deliver_later renders the same copy.
- Navigation emits header__branding--theme-<name> so a theme does not depend on the site slug.
- Admin icon gallery authorisation specs restored; menu toggle has an accessible name; aria-current uses true for ancestors; hidden region fields have no duplicate ids; theme CTA only opens a new tab for external URLs.
- Docs and comments corrected.

1739 examples green across lib, models, policies, components, helpers, requests, mailers and i18n keys.