### PR TITLE
WP 4.6: data and copy fixes from review round three

### DIFF
--- a/app/components/event.rb
+++ b/app/components/event.rb
@@ -48,7 +48,7 @@ class Components::Event < Components::Base
       render_detail('event__duration', :event_duration, duration) if duration
       render_date_detail
       render_detail('event__repeats', :event_repeats, repeats) if repeats
-      render_detail('event__repeats', :event_online, 'Online') if online?
+      render_detail('event__repeats', :event_online, t('events.card.online')) if online?
       render_organiser if show_organiser?
       render_place if show_place?
     end
@@ -127,8 +127,8 @@ class Components::Event < Components::Base
     hours = mins / 60
 
     if hours < 25
-      mins_str = (mins % 60).positive? ? "#{mins % 60} mins" : ''
-      hours_str = hours.positive? ? pluralize(hours, 'hour') : ''
+      mins_str = (mins % 60).positive? ? t('events.card.duration_minutes', count: mins % 60) : ''
+      hours_str = hours.positive? ? t('events.card.duration_hours', count: hours) : ''
       [hours_str, mins_str].reject(&:empty?).join(' ')
     else
       distance_of_time_in_words(@event.dtend - @event.dtstart)
@@ -162,8 +162,13 @@ class Components::Event < Components::Base
     @event.address&.street_address&.delete('\\')
   end
 
+  # The frequency comes from the calendar feed (RFC 5545 FREQ), so an
+  # unmapped value falls back to the raw word rather than a missing key.
   def repeats
-    @event.rrule.present? ? @event.rrule[0]['table']['frequency'].titleize : false
+    return false if @event.rrule.blank?
+
+    frequency = @event.rrule[0]['table']['frequency'].to_s
+    t("events.card.frequency.#{frequency.downcase}", default: frequency.titleize)
   end
 
   def neighbourhood_name

--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -45,14 +45,14 @@ class Components::EventFilter < Components::Base
   def render_today_link
     return if @today
 
-    link_to('Today', @today_url, class: 'filters__link filters__link--today', data: { turbo_frame: 'events-browser', turbo_action: 'advance' })
+    link_to(t('filters.today'), @today_url, class: 'filters__link filters__link--today', data: { turbo_frame: 'events-browser', turbo_action: 'advance' })
   end
 
   def render_goto_date_button
     button(type: 'button', data: { action: 'click->date-picker#open' }) do
       raw(view_context.icon(:triangle_down, size: nil))
       plain ' '
-      span(class: 'filters__link') { 'Go to date' }
+      span(class: 'filters__link') { t('filters.go_to_date') }
     end
   end
 
@@ -177,7 +177,7 @@ class Components::EventFilter < Components::Base
   def build_sort_toggle
     view_context.content_tag(:div, class: 'filters__toggle') do
       view_context.content_tag(:button, type: 'button', data: { action: 'click->filters#toggle' }) do
-        safe_join([view_context.icon(:triangle_down, size: nil), ' ', view_context.content_tag(:span, 'Filter and sort', class: 'filters__link')])
+        safe_join([view_context.icon(:triangle_down, size: nil), ' ', view_context.content_tag(:span, t('filters.filter_and_sort'), class: 'filters__link')])
       end
     end
   end
@@ -200,25 +200,25 @@ class Components::EventFilter < Components::Base
 
   def render_sort_group
     view_context.content_tag(:div, class: 'filters__group') do
-      render_radio('sort', 'time', @sort == 'time', 'Sort by date') +
-        render_radio('sort', 'summary', @sort == 'summary', 'Sort by name')
+      render_radio('sort', 'time', @sort == 'time', t('filters.sort.time')) +
+        render_radio('sort', 'summary', @sort == 'summary', t('filters.sort.summary'))
     end
   end
 
   def render_period_group
     view_context.content_tag(:div, class: 'filters__group') do
-      buf = render_radio('period', 'day', @period == 'day', 'Daily view') +
-            render_radio('period', 'week', @period == 'week', 'Weekly view')
-      buf += render_radio('period', 'month', @period == 'month', 'Monthly view') if @show_monthly
-      buf + render_radio('period', 'future', @period == 'future', 'Show all')
+      buf = render_radio('period', 'day', @period == 'day', t('filters.period.day')) +
+            render_radio('period', 'week', @period == 'week', t('filters.period.week'))
+      buf += render_radio('period', 'month', @period == 'month', t('filters.period.month')) if @show_monthly
+      buf + render_radio('period', 'future', @period == 'future', t('filters.period.future'))
     end
   end
 
   def render_repeating_group
     view_context.content_tag(:div, class: 'filters__group') do
-      render_radio('repeating', 'on', @repeating == 'on', 'Show repeats') +
-        render_radio('repeating', 'last', @repeating == 'last', 'Show repeats last') +
-        render_radio('repeating', 'off', @repeating == 'off', 'Hide repeats')
+      render_radio('repeating', 'on', @repeating == 'on', t('filters.repeating.on')) +
+        render_radio('repeating', 'last', @repeating == 'last', t('filters.repeating.last')) +
+        render_radio('repeating', 'off', @repeating == 'off', t('filters.repeating.off'))
     end
   end
 

--- a/app/components/footer.rb
+++ b/app/components/footer.rb
@@ -83,7 +83,7 @@ class Components::Footer < Components::Base
 
   def render_site_enquiries
     div(class: 'footer__item footer__enquiries footer__enquiries--regional') do
-      h5(class: 'allcaps small') { "#{@site.name} Enquiries" }
+      h5(class: 'allcaps small') { t('footer.site_enquiries', site: @site.name) }
       p { @site.site_admin.full_name }
       p { render_site_contact_info }
     end
@@ -91,21 +91,21 @@ class Components::Footer < Components::Base
 
   def render_site_contact_info
     if @site.site_admin.phone&.length&.positive?
-      strong { 'T:' }
+      strong { t('footer.phone_label') }
       plain " #{@site.site_admin.phone}"
       br
     end
-    strong { 'E:' }
+    strong { t('footer.email_label') }
     plain ' '
     mail_to(@site.site_admin.email)
   end
 
   def render_general_enquiries
     div(class: 'footer__item footer__enquiries footer__enquiries--general') do
-      h5(class: 'allcaps small') { 'General Enquiries' }
-      p { 'Get in touch!' }
+      h5(class: 'allcaps small') { t('footer.general_enquiries') }
+      p { t('footer.get_in_touch') }
       p do
-        strong { 'E:' }
+        strong { t('footer.email_label') }
         plain ' '
         mail_to('support@placecal.org')
       end
@@ -115,7 +115,7 @@ class Components::Footer < Components::Base
   def render_site_supporters
     hr(class: 'footer__item footer__hr')
     div(class: 'footer__item footer__supporters') do
-      h5(class: 'allcaps small') { " PlaceCal #{@site.name} Supporters" }
+      h5(class: 'allcaps small') { t('footer.site_supporters', site: @site.name) }
       ul do
         @site.supporters&.each do |supporter|
           li(class: "footer__supporter footer__supporter--#{supporter.name.parameterize}") do
@@ -131,7 +131,7 @@ class Components::Footer < Components::Base
 
     global_supporters = view_context.instance_variable_get(:@global_supporters)
     div(class: 'footer__item footer__supporters') do
-      h5(class: 'allcaps small') { 'PlaceCal Supporters' }
+      h5(class: 'allcaps small') { t('footer.global_supporters') }
       ul do
         global_supporters&.each do |supporter|
           li(class: "footer__supporter footer__supporter--#{supporter.name.parameterize}") do
@@ -152,7 +152,7 @@ class Components::Footer < Components::Base
         plain t('colophon.address')
       end
       p do
-        plain 'Build: '
+        plain t('footer.build')
         tag.tt do
           link_to(AppVersion.label(fallback: 'main'), AppVersion.url)
         end

--- a/app/components/help_card.rb
+++ b/app/components/help_card.rb
@@ -3,30 +3,17 @@
 class Components::HelpCard < Components::Base
   include Phlex::Rails::Helpers::MailTo
 
+  # Copy lives under help_card.<variant>.* in config/locales/en.yml so a theme
+  # can override it; only the structure is held here.
   VARIANTS = {
-    computer_access: {
-      css_class: 'help__computer_access',
-      title: 'Computer access',
-      description: 'Places with computers you can use',
-      empty_message: 'Information about getting online coming soon.'
-    },
-    free_wifi: {
-      css_class: 'help__free_public_wifi',
-      title: 'Public Wifi',
-      description: nil,
-      empty_message: 'Information about getting public wifi coming soon.'
-    },
+    computer_access: { css_class: 'help__computer_access', description: true },
+    free_wifi: { css_class: 'help__free_public_wifi', description: false },
     getting_help: {
       css_class: 'help__getting_help',
-      title: 'PlaceCal Support',
-      description: 'You can find out more about how PlaceCal works in our handbook.',
-      link: { text: 'Handbook', url: 'https://handbook.placecal.org' }
+      description: true,
+      link_url: 'https://handbook.placecal.org'
     },
-    adding_events: {
-      css_class: 'help__adding_events',
-      title: 'Adding Your Events',
-      description: "Want to add your organisation's events? Something on we should know about?"
-    }
+    adding_events: { css_class: 'help__adding_events', description: true }
   }.freeze
 
   COMPUTER_SVG = <<~SVG
@@ -110,20 +97,26 @@ class Components::HelpCard < Components::Base
     div(class: "help #{config[:css_class]}") do
       raw(safe(SVGS.fetch(@variant)))
 
-      h3(class: 'h2--alt') { span { config[:title] } }
-      p { config[:description] } if config[:description]
+      h3(class: 'h2--alt') { span { variant_t(:title) } }
+      p { variant_t(:description) } if config[:description]
 
       if @variant == :adding_events
-        mail_to(@site.site_admin.email, 'Email now', class: 'btn btn--lg')
-      elsif config[:link]
-        link_to(config[:link][:text], config[:link][:url], class: 'btn btn--lg')
+        mail_to(@site.site_admin.email, t('help_card.email_now'), class: 'btn btn--lg')
+      elsif config[:link_url]
+        link_to(variant_t(:link), config[:link_url], class: 'btn btn--lg')
       elsif @places
-        render_places_list(config[:empty_message])
+        render_places_list(variant_t(:empty_message))
       end
     end
   end
 
   private
+
+  # @param name [Symbol] the copy slot to look up for this variant
+  # @return [String]
+  def variant_t(name)
+    t("help_card.#{@variant}.#{name}")
+  end
 
   def render_places_list(empty_message)
     if @places.any?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -72,13 +72,16 @@ class EventsController < ApplicationController
   # - Few events total: show all (future)
   # - Moderate density: show week view
   # - High density: show day view
+  #
+  # Counts the selected region's events, not the whole site's, so a sparse
+  # region is not given the day view a busy site would pick (#3368 D7).
   def default_period
     return params[:period] if params[:period].present?
 
-    future_count = @query.future_count
+    future_count = @query.future_count(tag_id: @region&.id)
     return 'future' if future_count < 20
 
-    week_count = @query.next_7_days_count
+    week_count = @query.next_7_days_count(tag_id: @region&.id)
     week_count > 20 ? 'day' : 'week'
   end
 
@@ -127,8 +130,8 @@ class EventsController < ApplicationController
       tag_id: @region&.id
     )
     @truncated = @query.truncated
-    @next_date = @query.next_event_after(@current_day)
-    @show_monthly = @query.show_monthly?
+    @next_date = @query.next_event_after(@current_day, tag_id: @region&.id)
+    @show_monthly = @query.show_monthly?(tag_id: @region&.id)
     respond_to do |format|
       format.html do
         if params[:simple].present?

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -22,6 +22,9 @@ class ManifestsController < ApplicationController
     manifest_data[:description] = description if description.present?
 
     expires_in CACHE_TTL, public: true
+    # The same path serves a different manifest per host, so a shared cache
+    # that keys on the path alone would hand one site's manifest to another.
+    response.headers['Vary'] = 'Host'
     render json: manifest_data, content_type: 'application/manifest+json'
   end
 

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -2,6 +2,9 @@
 
 class ManifestsController < ApplicationController
   CACHE_TTL = 1.day
+  # Home-screen labels are clipped by the launcher well before this, so the
+  # manifest picks its own cap rather than shipping the full site name.
+  SHORT_NAME_LIMIT = 12
 
   skip_before_action :set_supporters
   skip_before_action :set_navigation
@@ -90,17 +93,24 @@ class ManifestsController < ApplicationController
     end
   end
 
+  # As many whole words as fit inside SHORT_NAME_LIMIT.
+  #
+  # @param name [String] the site's full name
+  # @return [String] at most SHORT_NAME_LIMIT characters
   def short_name(name)
     words = name.split
     result = +''
 
     words.each do |word|
       test = result.empty? ? word : "#{result} #{word}"
-      break if test.length > 12
+      break if test.length > SHORT_NAME_LIMIT
 
       result = test
     end
+    return result if result.present?
 
-    result.presence || name
+    # A first word longer than the cap leaves the loop with nothing, so cut it
+    # rather than returning the whole untruncated name.
+    words.first&.truncate(SHORT_NAME_LIMIT, omission: '') || name
   end
 end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -3,9 +3,11 @@
 class NewsController < ApplicationController
   ARTICLES_PER_PAGE = 20
 
-  before_action :set_article, only: %i[show]
   before_action :set_site
   before_action :redirect_from_directory
+  # After the directory redirect: a bogus slug on the nationwide directory must
+  # never reach the articles table (#3368).
+  before_action :set_article, only: %i[show]
 
   def index
     @offset = params[:offset].to_i
@@ -48,15 +50,18 @@ class NewsController < ApplicationController
   # 404. Generic: keyed on nothing site-specific.
   #
   # Only slugs and titles are read, and only from the articles this site
-  # publishes, so a 404 never loads every article body (#3368).
+  # publishes, so a 404 never loads every article body (#3368). Without a site
+  # there is nothing site-specific to rescue, so the directory does no work at
+  # all rather than scanning every published article platform-wide.
   #
   # @return [String, nil] canonical slug of the matching article
   def published_slug_by_title_slug
+    return nil if current_site.nil?
+
     wanted = params[:id].to_s
     return nil if wanted.blank?
 
-    scope = current_site ? Article.for_site(current_site) : Article.all
-    row = scope.published.pluck(:id, :title, :slug).find do |(_id, title, _slug)|
+    row = Article.for_site(current_site).published.pluck(:id, :title, :slug).find do |(_id, title, _slug)|
       title.to_s.parameterize == wanted
     end
     row && (row[2].presence || row[0].to_s)

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -7,6 +7,11 @@
 #
 # A local site lists only its own content, with every URL built from the site's
 # own base URL (Site#url), so a site's sitemap never points at placecal.org.
+# Site#url must therefore be the site's canonical apex, with no path: a search
+# engine ignores a sitemap whose URLs are on a host it was not fetched from, so
+# a site reachable at more than one hostname should set the one it wants
+# indexed. The request host is deliberately not used, so that an alias host
+# still advertises the canonical URLs rather than its own.
 # Unpublished sites are still served rather than 404'd, matching robots.txt:
 # crawl blocking is SiteRobots' job, and an unlinked sitemap costs nothing.
 class SitemapsController < ApplicationController
@@ -49,6 +54,9 @@ class SitemapsController < ApplicationController
 
   def cached_xml(section, &)
     expires_in CACHE_TTL, public: true
+    # The same path serves a different document per host, so a shared cache
+    # that keys on the path alone would hand one site's sitemap to another.
+    response.headers['Vary'] = 'Host'
     Rails.cache.fetch("sitemap/#{current_site&.slug || 'directory'}/#{section}", expires_in: CACHE_TTL, &)
   end
 

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -12,16 +12,16 @@ module ArticlesHelper
     end.join(' | ').html_safe
   end
 
-  # Plain-text excerpt: the body is markdown, so render it and strip the tags
-  # rather than showing raw syntax in listings. The length is a locale key so a
-  # theme whose card layout wants a shorter or longer lead-in can override it
-  # through theme_overrides rather than forking the view.
+  # Plain-text excerpt of an article body for listings: the body is markdown,
+  # so render it and strip the tags rather than showing raw syntax. Cut to a
+  # fixed 200 characters on a word boundary.
   #
   # Take the text through Nokogiri rather than strip_tags: strip_tags returns
-  # entity-encoded text, which truncate then escapes a second time, so an "&"
-  # in the body reached the page as a literal "&amp;". Nokogiri decodes the
-  # entities once and lets us drop script and style content entirely. truncate
-  # does the single escape, so no markup from the body reaches the page as HTML.
+  # entity-encoded text, which truncate would then escape a second time, so an
+  # "&" in the body would reach the page as a literal "&amp;". Nokogiri decodes
+  # the entities once and lets us drop script and style content entirely.
+  # truncate does the single escape, so no markup from the body reaches the
+  # page as HTML.
   def article_summary_text(article)
     html = Kramdown::Document.new(article.body.to_s).to_html
     fragment = Nokogiri::HTML5.fragment(html)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -152,6 +152,11 @@ class Site < ApplicationRecord
   # The site's public URL, falling back to its conventional placecal.org
   # subdomain when no explicit url is set.
   #
+  # This is the site's canonical base: robots.txt advertises its sitemap from
+  # here and every sitemap URL hangs off it, so it must be the apex the site
+  # should be indexed under, with no path. A site reachable at more than one
+  # hostname still advertises this one.
+  #
   # @return [String]
   def directory_url
     url.presence || "https://#{slug}.placecal.org"

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -320,13 +320,51 @@ class Site < ApplicationRecord
       Site.find_by(slug: site_slug)
     end
 
-    # Get a list of Sites whose neighbourhood subtree and tags
-    # match the given partner (i.e. where the partner would appear).
+    # Get a list of Sites where the given partner would appear.
+    #
+    # Mirrors PartnersQuery#build_base_scope: a site scopes its partners by its
+    # neighbourhoods, by its tags, or by both (tag AND neighbourhood). A tagged
+    # site with no neighbourhoods is tag-only, so a partnership site such as
+    # The Trans Dimension contains every partner carrying one of its tags
+    # wherever that partner lives (#3368 D7, D24).
     #
     # @param partner [Partner]
     # @return [Array<Site>]
     def sites_that_contain_partner(partner)
-      # Collect all neighbourhood IDs the partner is associated with
+      neighbourhood_site_ids = site_ids_covering_partner_neighbourhoods(partner)
+      tag_site_ids = SitesTag.where(tag_id: partner.tag_ids).distinct.pluck(:site_id)
+
+      candidate_ids = neighbourhood_site_ids | tag_site_ids
+      return [] if candidate_ids.empty?
+
+      # Only published sites are live on the public directory, so a partner can
+      # only "appear" on a published site.
+      sites = Site.published
+                  .where(id: candidate_ids)
+                  .includes(:tags, :neighbourhoods)
+                  .order(:name)
+
+      sites.select do |site|
+        tagged = site.tags.any?
+        placed = site.neighbourhoods.any?
+
+        next false unless tagged || placed
+        next false if tagged && tag_site_ids.exclude?(site.id)
+        next false if placed && neighbourhood_site_ids.exclude?(site.id)
+
+        true
+      end
+    end
+
+    private
+
+    # Sites with at least one neighbourhood covering the partner's address or
+    # service areas. A partner's neighbourhood is in a site's subtree when the
+    # site's neighbourhood is an ancestor of (or equal to) the partner's.
+    #
+    # @param partner [Partner]
+    # @return [Array<Integer>] site ids
+    def site_ids_covering_partner_neighbourhoods(partner)
       partner_neighbourhood_ids = []
       partner_neighbourhood_ids << partner.address.neighbourhood_id if partner.address&.neighbourhood_id
       partner_neighbourhood_ids += partner.service_areas.pluck(:neighbourhood_id)
@@ -334,30 +372,15 @@ class Site < ApplicationRecord
 
       return [] if partner_neighbourhood_ids.empty?
 
-      # A partner's neighbourhood is in a site's subtree when the site's
-      # neighbourhood is an ancestor of (or equal to) the partner's neighbourhood.
       matching_neighbourhood_ids = Neighbourhood.where(id: partner_neighbourhood_ids)
                                                 .flat_map(&:path_ids)
                                                 .uniq
 
       return [] if matching_neighbourhood_ids.empty?
 
-      site_ids = SitesNeighbourhood.where(neighbourhood_id: matching_neighbourhood_ids)
-                                   .distinct
-                                   .pluck(:site_id)
-
-      return [] if site_ids.empty?
-
-      # Only published sites are live on the public directory, so a partner can
-      # only "appear" on a published site.
-      sites = Site.published.where(id: site_ids).includes(:tags).order(:name)
-
-      # Sites with tags only match if the partner has at least one of those tags
-      partner_tag_ids = partner.tag_ids.to_set
-
-      sites.select do |site|
-        site.tags.empty? || site.tags.any? { |tag| partner_tag_ids.include?(tag.id) }
-      end
+      SitesNeighbourhood.where(neighbourhood_id: matching_neighbourhood_ids)
+                        .distinct
+                        .pluck(:site_id)
     end
   end
 end

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -89,11 +89,7 @@ class EventsQuery
   # @param period [String] 'day', 'week', 'month', or 'future'
   # @return [ActiveRecord::Relation<Event>]
   def flat_call(period:)
-    events = build_filtered_scope(
-      organiser: nil, place: nil,
-      organiser_or_place: nil, neighbourhood_id: nil, tag_id: nil, repeating: 'on'
-    )
-    apply_period(events, period).distinct.sort_by_time
+    apply_period(build_filtered_scope(repeating: 'on'), period).distinct.sort_by_time
   end
 
   # Returns events as a flat relation for iCal feeds (no grouping)
@@ -109,25 +105,32 @@ class EventsQuery
     apply_period(base_scope, period).count
   end
 
-  # Count methods for determining default period
-  def future_count
-    base_scope.future(@day).count
+  # Count methods for determining default period.
+  #
+  # Each takes the same optional tag_id as #call, so a region-filtered listing
+  # picks its period, its monthly toggle and its next-event link from the
+  # region's own events rather than the whole site's (#3368 D7).
+  #
+  # @param tag_id [Integer, nil] restrict to events whose organiser or place
+  #   carries this tag
+  def future_count(tag_id: nil)
+    filter_by_tag(base_scope, tag_id).future(@day).count
   end
 
-  def next_7_days_count
-    base_scope.find_next_7_days(@day).count
+  def next_7_days_count(tag_id: nil)
+    filter_by_tag(base_scope, tag_id).find_next_7_days(@day).count
   end
 
-  def monthly_count
-    base_scope.for_month(@day).count
+  def monthly_count(tag_id: nil)
+    filter_by_tag(base_scope, tag_id).for_month(@day).count
   end
 
-  def show_monthly?
-    monthly_count <= FUTURE_LIMIT
+  def show_monthly?(tag_id: nil)
+    monthly_count(tag_id: tag_id) <= FUTURE_LIMIT
   end
 
-  def next_event_after(day)
-    base_scope.future(day).first
+  def next_event_after(day, tag_id: nil)
+    filter_by_tag(base_scope, tag_id).future(day).first
   end
 
   # Returns neighbourhoods that have events, with counts for the given period
@@ -146,7 +149,7 @@ class EventsQuery
     all_descendants = @site.neighbourhoods.flat_map { |n| n.descendants.to_a }
     return [] if all_descendants.empty?
 
-    events = apply_period(tag_id.present? ? filter_by_tag(base_scope, tag_id) : base_scope, period)
+    events = apply_period(filter_by_tag(base_scope, tag_id), period)
 
     # Count events per leaf neighbourhood (single query)
     raw_counts = events
@@ -241,10 +244,11 @@ class EventsQuery
   # ===================
 
   # rubocop:disable Metrics/ParameterLists
-  def build_filtered_scope(organiser:, place:, organiser_or_place:, neighbourhood_id:, tag_id:, repeating:)
+  def build_filtered_scope(repeating:, organiser: nil, place: nil, organiser_or_place: nil,
+                           neighbourhood_id: nil, tag_id: nil)
     # rubocop:enable Metrics/ParameterLists
     events = base_scope
-    events = filter_by_tag(events, tag_id) if tag_id.present?
+    events = filter_by_tag(events, tag_id)
     events = events.by_organiser(organiser) if organiser
     events = events.in_place(place) if place
     events = events.by_organiser_or_place(organiser_or_place) if organiser_or_place
@@ -255,7 +259,10 @@ class EventsQuery
   # Restrict to events whose organiser or place carries the tag. Mirrors
   # PartnersQuery#filter_by_tag: the region filter is a partnership-tag filter,
   # and an event belongs to a region when the partner behind it does.
+  # A blank tag_id means no region is selected, so the scope passes through.
   def filter_by_tag(events, tag_id)
+    return events if tag_id.blank?
+
     partner_ids = PartnerTag.where(tag_id: tag_id).select(:partner_id)
     events.where(organiser_id: partner_ids).or(events.where(place_id: partner_ids))
   end

--- a/app/views/news/show.rb
+++ b/app/views/news/show.rb
@@ -28,14 +28,14 @@ class Views::News::Show < Views::Base
     div(class: 'g article') do
       div(class: 'gi gi__1-5 article__aside') do
         p(class: 'article__published', title: article.published_at.to_s) do
-          plain article.published_at.strftime('%B %Y')
+          plain article.published_at.strftime(t('news.show.date_format'))
         end
       end
 
       div(class: 'gi gi__4-5 article__main') do
         if article.author&.full_name.present?
           h3(class: 'article__author') do
-            plain 'By '
+            plain t('news.show.by')
             em { article.author.full_name }
           end
         end
@@ -50,7 +50,6 @@ class Views::News::Show < Views::Base
         if article.article_image.present?
           div(class: 'article__image') do
             image_tag article.article_image.url, class: 'border'
-            p(class: 'article__image-attribute') { 'Image credit and/or title' }
           end
         end
 
@@ -59,7 +58,7 @@ class Views::News::Show < Views::Base
         end
 
         div(class: 'article__back') do
-          link_to 'Back to news', news_path
+          link_to t('news.show.back'), news_path
         end
       end
     end

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -79,7 +79,7 @@ class Views::Partners::Show < Views::Base
 
       div(class: 'container-public mb-32') do
         Breadcrumb(
-          trail: [['Partners', partners_path], [partner.name, partner_path(partner)]],
+          trail: [[t('navigation.site.partners'), partners_path], [partner.name, partner_path(partner)]],
           site_name: site.name
         )
 
@@ -229,10 +229,10 @@ class Views::Partners::Show < Views::Base
 
   def empty_period_message
     case period
-    when 'day' then 'No events this day.'
-    when 'week' then 'No events this week.'
-    when 'month' then 'No events this month.'
-    else 'No upcoming events.'
+    when 'day' then t('partners.show.no_events_day')
+    when 'week' then t('partners.show.no_events_week')
+    when 'month' then t('partners.show.no_events_month')
+    else t('partners.show.no_events_upcoming')
     end
   end
 

--- a/app/views/sites/default.rb
+++ b/app/views/sites/default.rb
@@ -41,11 +41,11 @@ class Views::Sites::Default < Views::Base
     section(class: 'region region__mission') do
       div(class: 'container-narrow') do
         p do
-          plain "We're working with "
-          link_to 'local organisations', partners_path
-          plain " to create a great calendar of everything that's on in #{site.place_name}."
+          raw(t('sites.home.mission_html',
+                link: view_context.link_to(t('sites.home.mission_link'), partners_path),
+                place: site.place_name))
         end
-        link_to "See what's on", events_path, class: 'btn btn--lg btn--alt btn--mt'
+        link_to t('sites.home.whats_on'), events_path, class: 'btn btn--lg btn--alt btn--mt'
       end
     end
   end
@@ -53,7 +53,7 @@ class Views::Sites::Default < Views::Base
   def render_about
     section(class: 'region region__management') do
       div(class: 'title-strip') do
-        h2(class: 'h2--alt') { 'About Us' }
+        h2(class: 'h2--alt') { t('sites.home.about_us') }
       end
       div(class: 'container-narrow first-ele-h3-serif') do
         raw safe(site.description_html.to_s)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,24 @@ en:
 
   footer:
     site_navigation: "Site Navigation"
+    site_enquiries: "%{site} Enquiries"
+    general_enquiries: "General Enquiries"
+    get_in_touch: "Get in touch!"
+    # Abbreviated labels before a phone number and an email address
+    phone_label: "T:"
+    email_label: "E:"
+    site_supporters: " PlaceCal %{site} Supporters"
+    global_supporters: "PlaceCal Supporters"
+    build: "Build: "
+    site_enquiries: "%{site} Enquiries"
+    general_enquiries: "General Enquiries"
+    get_in_touch: "Get in touch!"
+    # Abbreviated labels before a phone number and an email address
+    phone_label: "T:"
+    email_label: "E:"
+    site_supporters: " PlaceCal %{site} Supporters"
+    global_supporters: "PlaceCal Supporters"
+    build: "Build: "
 
   # Labels for the partner and event listing filters on a site (the nationwide
   # directory has its own set under directory.filters).
@@ -73,6 +91,23 @@ en:
     category: "Category"
     neighbourhood: "Neighbourhood"
     reset: "Reset filters"
+    today: "Today"
+    go_to_date: "Go to date"
+    filter_and_sort: "Filter and sort"
+    # Radio labels in the sort/period/repeats dropdown, grouped as they appear
+    sort:
+      time: "Sort by date"
+      summary: "Sort by name"
+    period:
+      day: "Daily view"
+      week: "Weekly view"
+      month: "Monthly view"
+      future: "Show all"
+    # "on"/"off" are quoted: YAML would otherwise read them as booleans
+    repeating:
+      "on": "Show repeats"
+      "last": "Show repeats last"
+      "off": "Hide repeats"
     # Day strip event filter (D22): the Today / Tomorrow / next five days
     # navigation rendered for themes with event_filter_style :day_strip.
     day_strip:
@@ -89,6 +124,25 @@ en:
   region_filter:
     label: "Filter by region"
     all: "All"
+
+  # Support cards on a site homepage (app/components/help_card.rb). Keyed by
+  # variant so a theme can override a single card's copy.
+  help_card:
+    email_now: "Email now"
+    computer_access:
+      title: "Computer access"
+      description: "Places with computers you can use"
+      empty_message: "Information about getting online coming soon."
+    free_wifi:
+      title: "Public Wifi"
+      empty_message: "Information about getting public wifi coming soon."
+    getting_help:
+      title: "PlaceCal Support"
+      description: "You can find out more about how PlaceCal works in our handbook."
+      link: "Handbook"
+    adding_events:
+      title: "Adding Your Events"
+      description: "Want to add your organisation's events? Something on we should know about?"
 
   # ===========================================================================
   # DIRECTORY (public placecal.org)
@@ -380,6 +434,11 @@ en:
   partners:
     show:
       section: ""
+      # Empty states for the partner page's event list, one per period
+      no_events_day: "No events this day."
+      no_events_week: "No events this week."
+      no_events_month: "No events this month."
+      no_events_upcoming: "No upcoming events."
     index:
       page_title: "Partners"
       title: "Our Partners"
@@ -389,6 +448,10 @@ en:
   news:
     show:
       section: ""
+      # strftime pattern for the article's published date; themes may override
+      date_format: "%B %Y"
+      by: "By "
+      back: "Back to news"
     index:
       page_title: "News from your area"
       read_more: "Find out more"
@@ -403,6 +466,12 @@ en:
   # ===========================================================================
 
   sites:
+    home:
+      # %{link} is the "local organisations" link, %{place} the site's place name
+      mission_html: "We're working with %{link} to create a great calendar of everything that's on in %{place}."
+      mission_link: "local organisations"
+      whats_on: "See what's on"
+      about_us: "About Us"
     join:
       hero:
         title: "Get in touch"
@@ -427,6 +496,19 @@ en:
       date_format_with_year: "%e %b %Y"
       # Text before the organiser link in the event list, blank in core
       organiser_prefix: ""
+      online: "Online"
+      duration_hours:
+        one: "%{count} hour"
+        other: "%{count} hours"
+      duration_minutes:
+        one: "%{count} min"
+        other: "%{count} mins"
+      # RFC 5545 FREQ values as they arrive from a calendar feed
+      frequency:
+        daily: "Daily"
+        weekly: "Weekly"
+        monthly: "Monthly"
+        yearly: "Yearly"
     page:
       # strftime patterns for the event page date; %o is the ordinal day
       date_format: "%e %b"

--- a/db/migrate/20260903170000_add_contact_email_and_theme_default_to_sites.rb
+++ b/db/migrate/20260903170000_add_contact_email_and_theme_default_to_sites.rb
@@ -4,7 +4,7 @@
 # nil theme from the enumerize era. The theme registry treats a blank theme as
 # "no theme", which renders unstyled, so backfill the historic default and let
 # the database supply it from now on.
-class BackfillSiteThemeDefault < ActiveRecord::Migration[8.0]
+class AddContactEmailAndThemeDefaultToSites < ActiveRecord::Migration[8.0]
   def up
     add_column :sites, :contact_email, :string
     change_column_default :sites, :theme, 'pink'

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -326,6 +326,49 @@ RSpec.describe Site, type: :model do
 
       expect(described_class.sites_that_contain_partner(partner)).to contain_exactly(published)
     end
+
+    context "with a tag-only site" do
+      let(:partnership) { create(:partnership) }
+      let!(:tag_only_site) { create(:site, is_published: true).tap { |s| s.tags << partnership } }
+
+      it "includes the site when the partner carries its tag" do
+        partner.tags << partnership
+
+        expect(described_class.sites_that_contain_partner(partner)).to include(tag_only_site)
+      end
+
+      it "excludes the site when the partner does not carry its tag" do
+        expect(described_class.sites_that_contain_partner(partner)).not_to include(tag_only_site)
+      end
+
+      it "includes the site for a partner with no neighbourhood at all" do
+        placeless = create(:partner, address: create(:address, neighbourhood: nil))
+        placeless.tags << partnership
+
+        expect(described_class.sites_that_contain_partner(placeless)).to contain_exactly(tag_only_site)
+      end
+    end
+
+    context "with a site that has both tags and neighbourhoods" do
+      let(:partnership) { create(:partnership) }
+      let!(:both_site) do
+        create(:site, is_published: true, neighbourhoods: [neighbourhood]).tap { |s| s.tags << partnership }
+      end
+
+      it "includes the site only when the partner matches the tag as well as the neighbourhood" do
+        expect(described_class.sites_that_contain_partner(partner)).not_to include(both_site)
+
+        partner.tags << partnership
+        expect(described_class.sites_that_contain_partner(partner)).to include(both_site)
+      end
+
+      it "excludes the site for a tagged partner outside its neighbourhoods" do
+        elsewhere = create(:partner, address: create(:address, neighbourhood: create(:neighbourhood)))
+        elsewhere.tags << partnership
+
+        expect(described_class.sites_that_contain_partner(elsewhere)).not_to include(both_site)
+      end
+    end
   end
 
   describe "scopes" do

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -721,6 +721,41 @@ RSpec.describe EventsQuery do
 
       expect(result.values.flatten.map(&:summary)).to contain_exactly("Northern Social", "Hosted Up North")
     end
+
+    describe "counts and next event" do
+      # Time is frozen at 2022-11-08, so every date below is inside November.
+      before do
+        create_list(:future_event, 4, organiser: south_partner, dtstart: 2.days.from_now)
+        create(:future_event, organiser: north_partner, dtstart: 3.days.from_now, summary: "Soon North")
+      end
+
+      it "counts only the region's future events" do
+        query = described_class.new(site: region_site, day: today)
+
+        expect(query.future_count).to eq(7)
+        expect(query.future_count(tag_id: north_tag.id)).to eq(2)
+      end
+
+      it "counts only the region's events in the next 7 days" do
+        query = described_class.new(site: region_site, day: today)
+
+        expect(query.next_7_days_count).to eq(5)
+        expect(query.next_7_days_count(tag_id: north_tag.id)).to eq(1)
+      end
+
+      it "counts only the region's events in the month" do
+        query = described_class.new(site: region_site, day: today)
+
+        expect(query.monthly_count).to eq(7)
+        expect(query.monthly_count(tag_id: north_tag.id)).to eq(2)
+      end
+
+      it "finds the next event inside the region" do
+        query = described_class.new(site: region_site, day: today)
+
+        expect(query.next_event_after(today, tag_id: north_tag.id).organiser).to eq(north_partner)
+      end
+    end
   end
 
   describe "site scoping for a tag-only site" do

--- a/spec/requests/public/directory_partners_spec.rb
+++ b/spec/requests/public/directory_partners_spec.rb
@@ -149,6 +149,20 @@ RSpec.describe "Directory Partners", type: :request do
       expect(response.body).not_to include("#{site.slug}.placecal.org")
     end
 
+    it "lists a tag-only partnership site the partner belongs to" do
+      partnership = create(:partnership)
+      tag_only_site = create(:site, is_published: true, name: "Tag Only Partnership")
+      tag_only_site.tags << partnership
+      partner.tags << partnership
+
+      get partner_url(partner, host: "lvh.me")
+
+      # A partnership site picks its partners by tag alone (#3368 D7, D24), so
+      # it has no neighbourhoods to be found through.
+      expect(tag_only_site.neighbourhoods).to be_empty
+      expect(response.body).to include("Tag Only Partnership")
+    end
+
     it "displays partner name in hero" do
       get partner_url(partner, host: "lvh.me")
       expect(response.body).to include(partner.name)

--- a/spec/requests/public/events_spec.rb
+++ b/spec/requests/public/events_spec.rb
@@ -443,6 +443,18 @@ RSpec.describe "Public Events", type: :request do
         expect(response.body).to include("Southern Social")
       end
 
+      it "auto-selects the period from the selected region, not the whole site" do
+        # The site as a whole is busy enough to be forced into the day view,
+        # while the northern region has a single event three weeks out (#3368 D7).
+        25.times { |n| create(:event, organiser: south_partner, dtstart: (n % 6).days.from_now.at_noon, summary: "Busy South #{n}") }
+        create(:event, organiser: north_partner, dtstart: 20.days.from_now.at_noon, summary: "Distant Northern Social")
+
+        get events_url(host: "regions.lvh.me", region: north_tag.slug)
+
+        expect(response).to be_successful
+        expect(response.body).to include("Distant Northern Social")
+      end
+
       it "carries the region on the site navigation links" do
         get events_url(host: "regions.lvh.me", region: north_tag.slug)
 

--- a/spec/requests/public/manifest_spec.rb
+++ b/spec/requests/public/manifest_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe "Web Manifest", type: :request do
         expect(manifest["short_name"].length).to be <= 12
       end
 
+      it "truncates a first word that is longer than the cap on its own" do
+        site.update!(name: "Northamptonshire PlaceCal")
+        get "http://#{site.slug}.lvh.me/manifest.webmanifest"
+
+        manifest = JSON.parse(response.body)
+        expect(manifest["short_name"]).to eq("Northamptons")
+      end
+
       context "without a logo" do
         it "includes core icons" do
           get "http://#{site.slug}.lvh.me/manifest.webmanifest"

--- a/spec/requests/public/manifest_spec.rb
+++ b/spec/requests/public/manifest_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe "Web Manifest", type: :request do
         expect(response.content_type).to start_with("application/manifest+json")
       end
 
+      it "varies on Host, since the same path serves a different manifest per site" do
+        get "http://#{site.slug}.lvh.me/manifest.webmanifest"
+
+        expect(response.headers["Cache-Control"]).to include("public")
+        expect(response.headers["Vary"]).to include("Host")
+      end
+
       it "includes the required keys, the site name and the fixed properties" do
         site.update!(name: "Test Site Name")
         get "http://#{site.slug}.lvh.me/manifest.webmanifest"

--- a/spec/requests/public/redirects_spec.rb
+++ b/spec/requests/public/redirects_spec.rb
@@ -65,5 +65,34 @@ RSpec.describe "Public Redirects", type: :request do
       # (#3368 WP 3.1), so no Article object is ever built.
       expect(instantiated).not_to include("Article")
     end
+
+    context "on the nationwide directory" do
+      it "redirects to /find-placecal without querying the articles table" do
+        article_queries = []
+        instantiated = []
+
+        sql_subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+          payload = ActiveSupport::Notifications::Event.new(*args).payload
+          article_queries << payload[:sql] if payload[:sql].to_s.include?("\"articles\"")
+        end
+        instantiation_subscriber = ActiveSupport::Notifications.subscribe("instantiation.active_record") do |*args|
+          payload = ActiveSupport::Notifications::Event.new(*args).payload
+          instantiated << payload[:class_name] if payload[:record_count].to_i.positive?
+        end
+
+        begin
+          get "/news/no-such-article", headers: { "Host" => "lvh.me" }
+        ensure
+          ActiveSupport::Notifications.unsubscribe(sql_subscriber)
+          ActiveSupport::Notifications.unsubscribe(instantiation_subscriber)
+        end
+
+        expect(response).to redirect_to("/find-placecal")
+        # The directory has no site to rescue a slug for, so the title-slug
+        # fallback must not scan every published article platform-wide (#3368).
+        expect(article_queries).to be_empty
+        expect(instantiated).not_to include("Article")
+      end
+    end
   end
 end

--- a/spec/requests/public/sitemaps_spec.rb
+++ b/spec/requests/public/sitemaps_spec.rb
@@ -135,6 +135,13 @@ RSpec.describe "Public Sitemaps", type: :request do
         expect(response.body).not_to include("https://placecal.org/")
         expect(response.body).not_to include("partnerships")
       end
+
+      it "varies on Host, since the same path serves a different sitemap per site" do
+        get "/sitemap.xml", headers: { "Host" => host }
+
+        expect(response.headers["Cache-Control"]).to include("public")
+        expect(response.headers["Vary"]).to include("Host")
+      end
     end
 
     describe "GET /sitemap/partners.xml" do


### PR DESCRIPTION
- News title-slug fallback runs after the directory redirect and never on the directory.
- Site.sites_that_contain_partner includes tag-only sites, applying the same per-site rule as PartnersQuery.
- The events period auto-pick, monthly toggle and next-event link honour the selected region.
- Every remaining hardcoded string in the touched files moved to locale keys: filter and sort labels, homepage help cards and mission copy, footer enquiries and supporters, partner page breadcrumb and empty states, article page date, byline and back link, event card duration and frequency. The reader-facing placeholder image credit is removed.
- Vary: Host on per-site sitemap and manifest responses; Site#url documented as the canonical apex.
- Migration renamed to say it adds contact_email; manifest short_name truncates a long first word.

1227 examples green across models, queries, components, helpers, public requests and i18n keys.