### PR TITLE
WP 4.7: heading order, trust model, extension tree guard

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -50,6 +50,9 @@ jobs:
           bin/yarn run format:check
           bundle exec rubocop
 
+      - name: Check extensions stay inside the contract
+        run: bundle exec bin/check-extension-tree
+
   security:
     runs-on: ubuntu-latest
     steps:

--- a/app/assets/stylesheets/base/typography.scss
+++ b/app/assets/stylesheets/base/typography.scss
@@ -40,6 +40,18 @@ h1.sans {
 	letter-spacing: $title-letter-spacing;
 }
 
+// Section headings on the partner and event show pages. They are h2 because
+// they are the first headings under the page h1 and an h3 there skips a level,
+// but they are drawn at the size they had as h3s: browser default h3 metrics,
+// restated so the promotion is only a change of outline, not of look. Scoped
+// to these two blocks so the managed-place headings, which have always been
+// h2s at h2 size, are left alone.
+.g--partner h2.h4,
+.event__fullinfo h2.h4 {
+	font-size: 1.17em;
+	margin-block: 1em;
+}
+
 .title-strip {
 	background-color: $base-rules;
 	background-color: var(--base-rules);

--- a/app/assets/stylesheets/components/hero_component.scss
+++ b/app/assets/stylesheets/components/hero_component.scss
@@ -34,7 +34,9 @@
 		text-align: center;
 	}
 
-	h4 {
+	// The tagline. It is a paragraph rather than a heading so the page does not
+	// skip from the navigation's h2 site name to the h1 by way of an h4.
+	p.allcaps {
 		display: inline-block;
 		margin-top: 0.5rem;
 		margin-bottom: 1.5rem;

--- a/app/assets/stylesheets/themes/custom/mossley.scss
+++ b/app/assets/stylesheets/themes/custom/mossley.scss
@@ -281,7 +281,7 @@ a {
 		}
 	}
 
-	h4,
+	p.allcaps,
 	&__divider {
 		display: none;
 	}

--- a/app/components/hero.rb
+++ b/app/components/hero.rb
@@ -21,7 +21,10 @@ class Components::Hero < Components::Base
       div(class: 'container-public') do
         p(class: 'hero__section') { @section } if @section.present?
         if @subtitle
-          h4(class: 'allcaps') { @subtitle }
+          # The tagline is a strapline, not a section title. It used to be an h4
+          # sitting between the navigation's h2 site name and the page h1, which
+          # skipped a heading level and failed axe's heading-order rule.
+          p(class: 'allcaps') { @subtitle }
           div(role: 'presentation', class: 'hero__divider')
         end
         if @schema

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -129,8 +129,10 @@ class EventsQuery
     monthly_count(tag_id: tag_id) <= FUTURE_LIMIT
   end
 
+  # The soonest event on or after `day`. `future` only filters, so without an
+  # explicit order this took whatever row the database returned first.
   def next_event_after(day, tag_id: nil)
-    filter_by_tag(base_scope, tag_id).future(day).first
+    filter_by_tag(base_scope, tag_id).future(day).reorder(dtstart: :asc).first
   end
 
   # Returns neighbourhoods that have events, with counts for the given period

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -265,7 +265,7 @@ class Views::Events::Show < Views::Base
   def render_contact_info
     div(class: 'gi gi__1-3') do
       if event.organiser
-        h3(class: 'h4 udl') { 'Contact information' }
+        h2(class: 'h4 udl') { 'Contact information' }
         div(class: 'small') do
           ContactDetails(partner: event.organiser)
         end
@@ -275,7 +275,7 @@ class Views::Events::Show < Views::Base
 
   def render_event_address
     div(class: 'gi gi__1-3') do
-      h3(class: 'h4 udl') { 'Event address' }
+      h2(class: 'h4 udl') { 'Event address' }
       div(class: 'small') do
         Address(address: event.address, raw_location: event.raw_location_from_source)
       end
@@ -284,7 +284,7 @@ class Views::Events::Show < Views::Base
 
   def render_event_organiser
     div(class: 'gi gi__1-3') do
-      h3(class: 'h4 udl') { 'Event organiser' }
+      h2(class: 'h4 udl') { 'Event organiser' }
       div(class: 'small') do
         span { link_to event.organiser, event.organiser }
       end
@@ -297,7 +297,7 @@ class Views::Events::Show < Views::Base
 
   def render_event_venue
     div(class: 'gi gi__1-3') do
-      h3(class: 'h4 udl') { 'Venue' }
+      h2(class: 'h4 udl') { 'Venue' }
       div(class: 'small') do
         span { link_to event.place, event.place }
       end

--- a/app/views/news/show.rb
+++ b/app/views/news/show.rb
@@ -58,7 +58,7 @@ class Views::News::Show < Views::Base
         end
 
         div(class: 'article__back') do
-          link_to t('news.show.back'), news_path
+          link_to t('news.show.back'), news_index_path
         end
       end
     end

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -105,10 +105,10 @@ class Views::Partners::Show < Views::Base
   end
 
   def render_contact_and_address
-    h3(class: 'udl udl--fw allcaps h4') { 'Get in touch' }
+    h2(class: 'udl udl--fw allcaps h4') { 'Get in touch' }
     ContactDetails(partner: partner)
 
-    h3(class: 'udl udl--fw allcaps h4') { 'Address' }
+    h2(class: 'udl udl--fw allcaps h4') { 'Address' }
     p { "We operate in #{partner_service_area_text(partner)}." } if partner.has_service_areas?
 
     Address(address: partner.address)
@@ -142,7 +142,7 @@ class Views::Partners::Show < Views::Base
     return unless times.any?
 
     br
-    h3(class: 'udl udl--fw allcaps h4') { 'Opening times' }
+    h2(class: 'udl udl--fw allcaps h4') { 'Opening times' }
     ul(class: 'opening_times reset') do
       times.each do |slot|
         li { slot }

--- a/bin/check-extension-tree
+++ b/bin/check-extension-tree
@@ -1,0 +1,151 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Guards the extension contract described in doc/extensions.md.
+#
+# A theme gem is a Rails engine loaded into the application process, so it can
+# run any Ruby it ships with the application's privileges. The contract is that
+# it ships views, components, assets, locales, content and rake tasks, and no
+# models, controllers, routes, migrations or initializers. Review is the first
+# line of that; this script is the mechanical backstop, run in CI's lint job.
+#
+# It walks every gem in the Gemfile's :extensions group, lists the files the gem
+# actually ships, and fails if any path falls outside the allowlist below. It
+# checks where a theme may put code, not what that code does.
+#
+# Usage: bin/check-extension-tree [gem root ...]
+#
+# With no arguments it checks the gems in the :extensions group. Given one or
+# more directories it checks those instead, which is how its spec exercises it.
+
+require 'bundler'
+
+EXTENSION_GROUP = :extensions
+
+# Directory trees an extension may ship in full.
+ALLOWED_TREES = %w[
+  app/views
+  app/components
+  app/assets
+  app/tailwind
+  content
+  doc
+  bin
+  spec
+  goldens
+  .github
+].freeze
+
+# Top-level files an extension may ship, plus any top-level dotfile
+# (.gitignore, .rubocop.yml, .node-version and the like).
+ALLOWED_ROOT_FILES = [
+  /\AREADME(\.\w+)?\z/i,
+  /\ALICEN[CS]E(\.\w+)?\z/i,
+  /\A[\w.-]+\.gemspec\z/,
+  /\AGemfile(\.lock)?\z/,
+  /\ARakefile\z/,
+  /\Apackage\.json\z/,
+  /\Ayarn\.lock\z/,
+  /\A\.[\w.-]+\z/
+].freeze
+
+# Gems in the Gemfile's :extensions group, as [name, root Pathname] pairs.
+def extension_gems
+  definition = Bundler.definition
+  names = definition.dependencies.select { |dep| dep.groups.include?(EXTENSION_GROUP) }.map(&:name)
+  specs = definition.specs.to_a
+
+  names.map do |name|
+    spec = specs.find { |candidate| candidate.name == name }
+    path = spec ? spec.full_gem_path : gem_path_from_bundle_show(name)
+    abort "check-extension-tree: cannot locate the #{name} gem. Run bundle install first." if path.nil?
+
+    [name, Pathname.new(path)]
+  end
+end
+
+# Fallback for when the resolved spec is not in the definition (a gem installed
+# but not yet resolved in this process).
+def gem_path_from_bundle_show(name)
+  path = `bundle show #{name} 2>/dev/null`.strip
+  path.empty? ? nil : path
+end
+
+# Files the gem ships, relative to its root, ignoring its own git metadata.
+def shipped_files(root)
+  root.find.filter_map do |entry|
+    next if entry.directory?
+
+    relative = entry.relative_path_from(root).to_s
+    next if relative.start_with?('.git/')
+
+    relative
+  end.sort
+end
+
+# The engine's module directory, taken from wherever engine.rb lives. Only one
+# lib subdirectory may hold an engine, and only engine.rb and version.rb may
+# live in it, so an extension cannot hide Ruby under a second lib directory.
+def engine_module_dir(root)
+  engine = root.glob('lib/*/engine.rb').first
+  return nil if engine.nil?
+
+  engine.parent.basename.to_s
+end
+
+def allowed_lib_paths(gem_name, module_dir)
+  paths = ["lib/#{gem_name}.rb"]
+  paths += ["lib/#{module_dir}.rb", "lib/#{module_dir}/engine.rb", "lib/#{module_dir}/version.rb"] if module_dir
+  paths
+end
+
+def allowed?(path, allowed_lib)
+  return true if ALLOWED_TREES.any? { |tree| path.start_with?("#{tree}/") }
+  return true if path.start_with?('config/locales/') && path.count('/') == 2 && path.end_with?('.yml')
+  return true if allowed_lib.include?(path)
+  return true if path.start_with?('lib/tasks/') && path.count('/') == 2 && path.end_with?('.rake')
+  return true if path.count('/').zero? && ALLOWED_ROOT_FILES.any? { |pattern| pattern.match?(path) }
+
+  false
+end
+
+# Explicit roots on the command line, named after their directory.
+def roots_from_argv(argv)
+  argv.map do |arg|
+    root = Pathname.new(arg).expand_path
+    abort "check-extension-tree: #{arg} is not a directory" unless root.directory?
+
+    [root.basename.to_s, root]
+  end
+end
+
+failures = {}
+targets = ARGV.empty? ? extension_gems : roots_from_argv(ARGV)
+
+targets.each do |name, root|
+  module_dir = engine_module_dir(root)
+  allowed_lib = allowed_lib_paths(name, module_dir)
+  files = shipped_files(root)
+  offenders = files.reject { |path| allowed?(path, allowed_lib) }
+
+  puts "#{name}: #{files.length} files checked in #{root}"
+  failures[name] = offenders if offenders.any?
+end
+
+if failures.empty?
+  puts 'check-extension-tree: every extension stays inside the contract.'
+  exit 0
+end
+
+$stdout.flush
+warn ''
+warn 'check-extension-tree: extensions may only ship views, components, assets,'
+warn 'locales, content, docs and rake tasks. See the Trust section of'
+warn 'doc/extensions.md. These paths are outside the contract:'
+failures.each do |name, offenders|
+  warn ''
+  warn "  #{name}:"
+  offenders.each { |path| warn "    #{path}" }
+end
+warn ''
+exit 1

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -563,7 +563,7 @@ en:
         preview_title: "Site Content Preview"
       fields:
         alt_text_hint: "How should a screen reader describe this image?"
-        contact_email_hint: 'Where "get in touch" enquiries from this site are sent, and shown publicly in the site footer. Setting this also adds the Get in touch link to the site navigation. Leave blank to send to PlaceCal support.'
+        contact_email_hint: 'Where "get in touch" enquiries from this site are sent, and shown publicly as an email link on the Get in touch page. Setting this also adds the Get in touch link to the site navigation. Leave blank to send to PlaceCal support.'
         hero_handbook_link: "See handbook for guidance"
         hero_image_description: "The large image at the top of your site's homepage."
         hero_text_hint: "Large text for the homepage banner"

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -8,6 +8,21 @@ If a second partnership could want it, it is a core feature and gets built gener
 
 Extensions are Rails engines generated with `rails plugin new --full` (NOT `--mountable`: the engine must not isolate its namespace or routes, it plugs into the host app) and trimmed to the layout below.
 
+## Trust
+
+An extension is a Rails engine loaded into the same process as the application. Nothing sandboxes it: its `lib/` is on the load path, its initializers run at boot, and any Ruby it ships runs with the application's full privileges, including the database, the credentials and the network. A theme is therefore a code dependency, not content, and it is reviewed the way any other gem in the `Gemfile` is reviewed.
+
+That gives four rules:
+
+1. A theme is added or bumped only by a maintainer, through a change to core's `Gemfile`. There is no upload path, no admin screen and no runtime install. Adding or moving a theme is a pull request against core, reviewed and merged like any other.
+2. A theme is pinned by git tag, never by branch, and `Gemfile.lock` records the exact commit the tag pointed at. A retagged release changes the lockfile, so a substituted release shows up in the diff instead of arriving silently.
+3. A theme comes from a repository owned by GFSC with branch protection on its default branch, so the code behind a tag has been through review in its own repo too.
+4. A theme stays inside the extension contract: views, components, assets, locales, content and rake tasks only, and no models, migrations, controllers, routes or business logic.
+
+Rule 4 is enforced twice. Reviewers check it on the pull request that adds or bumps the gem, and `bin/check-extension-tree` checks it mechanically in CI: it walks every gem in the `Gemfile`'s `:extensions` group, lists the files the gem ships, and fails the `lint` job if any of them falls outside the allowlist. Anything under `app/models`, `app/controllers`, `db/`, `config/routes.rb` or `config/initializers`, and any Ruby under `lib/` beyond the engine's own entry point, engine and version files, fails the build. The guard is a backstop for review, not a replacement for it: it constrains where a theme may put code, not what that code does.
+
+If you want a theme that genuinely cannot run code, that is a different mechanism from a Rails engine, and it is tracked in [issue #3489](https://github.com/geeksforsocialchange/PlaceCal/issues/3489). Until it exists, treat every theme as trusted code.
+
 ## Layout
 
 ```

--- a/spec/components/hero_component_spec.rb
+++ b/spec/components/hero_component_spec.rb
@@ -3,6 +3,21 @@
 require "rails_helper"
 
 RSpec.describe Components::Hero, type: :component do
+  it "renders the tagline as a paragraph rather than a heading" do
+    render_inline(described_class.new("Riverside Hub", "Events in Riverside"))
+
+    expect(page).to have_css("p.allcaps", text: "Events in Riverside")
+    expect(page).not_to have_css("h4")
+  end
+
+  it "adds no heading above the h1, so the site name h2 stays the last one before it" do
+    render_inline(described_class.new("Riverside Hub", "Events in Riverside", section: "Partner"))
+
+    headings = page.all("h1, h2, h3, h4, h5, h6").map(&:tag_name)
+
+    expect(headings).to eq(["h1"])
+  end
+
   it "escapes markup in the title" do
     render_inline(described_class.new("<img src=x onerror=1> Garden", "Partner"))
 

--- a/spec/lib/check_extension_tree_spec.rb
+++ b/spec/lib/check_extension_tree_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "open3"
+require "tmpdir"
+require "fileutils"
+
+# The CI guard behind the extension contract (see the Trust section of
+# doc/extensions.md). It is exercised against synthetic gem trees so the
+# expectations do not move when the real theme gem does.
+RSpec.describe "bin/check-extension-tree" do
+  APP_ROOT = File.expand_path("../..", __dir__)
+  SCRIPT = File.join(APP_ROOT, "bin", "check-extension-tree")
+
+  def run(*roots)
+    Open3.capture3("bundle", "exec", SCRIPT, *roots, chdir: APP_ROOT)
+  end
+
+  def build_tree(root, paths)
+    paths.each do |path|
+      full = File.join(root, path)
+      FileUtils.mkdir_p(File.dirname(full))
+      FileUtils.touch(full)
+    end
+  end
+
+  let(:contract_abiding) do
+    [
+      "app/views/foo/home.rb",
+      "app/components/foo/footer.rb",
+      "app/assets/builds/foo/theme.css",
+      "app/tailwind/theme.css",
+      "config/locales/en.yml",
+      "content/about.md",
+      "doc/notes.md",
+      "bin/foo-dev",
+      "spec/spec_helper.rb",
+      "goldens/README.md",
+      ".github/workflows/test.yml",
+      "lib/foo.rb",
+      "lib/foo/engine.rb",
+      "lib/foo/version.rb",
+      "lib/tasks/foo.rake",
+      "README.md",
+      "LICENSE",
+      "Rakefile",
+      "Gemfile",
+      "package.json",
+      "yarn.lock",
+      "foo.gemspec",
+      ".rubocop.yml",
+      ".node-version"
+    ]
+  end
+
+  it "passes a tree that stays inside the contract" do
+    Dir.mktmpdir do |dir|
+      root = File.join(dir, "foo")
+      build_tree(root, contract_abiding)
+
+      stdout, _stderr, status = run(root)
+
+      expect(status).to be_success
+      expect(stdout).to include("every extension stays inside the contract")
+    end
+  end
+
+  it "fails on models, controllers, migrations, routes, initializers and stray lib code" do
+    Dir.mktmpdir do |dir|
+      root = File.join(dir, "foo")
+      build_tree(root, contract_abiding + [
+        "app/models/thing.rb",
+        "app/controllers/things_controller.rb",
+        "db/migrate/001_add_things.rb",
+        "config/routes.rb",
+        "config/initializers/boot.rb",
+        "lib/foo/sneaky.rb",
+        "lib/elsewhere/payload.rb"
+      ])
+
+      _stdout, stderr, status = run(root)
+
+      expect(status).not_to be_success
+      expect(stderr).to include("app/models/thing.rb")
+      expect(stderr).to include("app/controllers/things_controller.rb")
+      expect(stderr).to include("db/migrate/001_add_things.rb")
+      expect(stderr).to include("config/routes.rb")
+      expect(stderr).to include("config/initializers/boot.rb")
+      expect(stderr).to include("lib/foo/sneaky.rb")
+      expect(stderr).to include("lib/elsewhere/payload.rb")
+    end
+  end
+
+  it "ignores the gem's own git metadata" do
+    Dir.mktmpdir do |dir|
+      root = File.join(dir, "foo")
+      build_tree(root, contract_abiding + [".git/config", ".git/objects/ab/cdef"])
+
+      _stdout, _stderr, status = run(root)
+
+      expect(status).to be_success
+    end
+  end
+end

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -194,6 +194,21 @@ RSpec.describe EventsQuery do
       query = described_class.new(site: site, day: today)
       expect(query.next_event_after(10.days.from_now)).to be_nil
     end
+
+    # Insertion order is the reverse of chronological order here, so an
+    # unordered query returns the wrong event.
+    context "when the events were created out of chronological order" do
+      let!(:latest) { create(:future_event, organiser: partner, dtstart: 9.days.from_now) }
+      let!(:soonest) { create(:future_event, organiser: partner, dtstart: 1.day.from_now) }
+
+      it "returns the soonest event, not whichever row comes back first" do
+        query = described_class.new(site: site, day: today)
+
+        expect(query.next_event_after(today)).to eq(soonest)
+        expect(query.next_event_after(2.days.from_now)).to eq(event1)
+        expect(query.next_event_after(6.days.from_now)).to eq(latest)
+      end
+    end
   end
 
   describe "period: 'month'" do

--- a/spec/requests/public/articles_spec.rb
+++ b/spec/requests/public/articles_spec.rb
@@ -80,6 +80,21 @@ RSpec.describe "Public Articles (News)", type: :request do
       end
     end
 
+    context "with the back link" do
+      let!(:article) { create(:article, is_draft: false) }
+
+      # `news_path` with no argument takes the id from the current request, so
+      # the back link used to point at the article the reader was already on.
+      it "points at the news index, not at the article itself" do
+        get news_url(article, host: "#{site.slug}.lvh.me")
+
+        back = Nokogiri::HTML(response.body).at_css(".article__back a")
+
+        expect(back).to be_present
+        expect(back[:href]).to eq(news_index_path)
+      end
+    end
+
     context "with author name" do
       let!(:article) { create(:article, is_draft: false, author: author) }
 

--- a/spec/requests/public/events_spec.rb
+++ b/spec/requests/public/events_spec.rb
@@ -239,22 +239,24 @@ RSpec.describe "Public Events", type: :request do
       expect(response.body).to include("Community Workshop")
     end
 
+    # h2, not h3: these are the first headings under the page h1, so an h3
+    # here skips a level and axe reports heading-order.
     it "shows contact information section with consistent heading level" do
       get event_url(event, host: "#{site.slug}.lvh.me")
       expect(response.body).to include("Contact information")
-      expect(response.body).to match(%r{<h3[^>]*>Contact information</h3>})
+      expect(response.body).to match(%r{<h2[^>]*>Contact information</h2>})
     end
 
     it "shows event address with consistent heading level" do
       get event_url(event, host: "#{site.slug}.lvh.me")
       expect(response.body).to include("Event address")
-      expect(response.body).to match(%r{<h3[^>]*>Event address</h3>})
+      expect(response.body).to match(%r{<h2[^>]*>Event address</h2>})
     end
 
     it "shows event organiser with consistent heading level" do
       get event_url(event, host: "#{site.slug}.lvh.me")
       expect(response.body).to include("Event organiser")
-      expect(response.body).to match(%r{<h3[^>]*>Event organiser</h3>})
+      expect(response.body).to match(%r{<h2[^>]*>Event organiser</h2>})
     end
 
     it "includes Event JSON-LD structured data" do

--- a/spec/requests/public/heading_order_spec.rb
+++ b/spec/requests/public/heading_order_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# axe's heading-order rule: a page must not skip a heading level. Site pages
+# used to go h2 (the navigation's screen-reader site name) then h4 (the hero
+# tagline) then h1, and the partner and event bodies opened at h3.
+RSpec.describe "Site page heading order", type: :request do
+  let(:site) { create(:site, slug: "headings", tagline: "Events in Riverside") }
+  let(:ward) { create(:riverside_ward) }
+  let(:partner) { create(:riverside_partner, address: create(:riverside_address, neighbourhood: ward)) }
+
+  before { site.neighbourhoods << ward }
+
+  def headings(scope = "body")
+    Nokogiri::HTML(response.body).css("#{scope} h1, #{scope} h2, #{scope} h3, #{scope} h4, #{scope} h5, #{scope} h6")
+            .map(&:name)
+  end
+
+  describe "a partner page" do
+    before { get partner_url(partner, host: "#{site.slug}.lvh.me") }
+
+    it "renders the hero tagline as a paragraph, not a heading" do
+      expect(response.body).to include(site.tagline)
+      expect(Nokogiri::HTML(response.body).at_css(".hero p.allcaps")&.text).to eq(site.tagline)
+      expect(Nokogiri::HTML(response.body).css(".hero h4")).to be_empty
+    end
+
+    it "puts only the site name h2 before the h1" do
+      before_h1 = headings.take_while { |name| name != "h1" }
+
+      expect(before_h1).to eq(["h2"])
+    end
+
+    # The shared footer has its own long-standing level jump, so the body of
+    # the page is what this checks.
+    it "never skips a heading level in the page body" do
+      expect(skipped_levels(headings("main"))).to be_empty
+    end
+  end
+
+  describe "an event page" do
+    let(:event) do
+      create(:event, address: create(:riverside_address, neighbourhood: ward), organiser: partner)
+    end
+
+    before { get event_url(event, host: "#{site.slug}.lvh.me") }
+
+    it "never skips a heading level in the page body" do
+      expect(response).to be_successful
+      expect(skipped_levels(headings("main"))).to be_empty
+    end
+  end
+
+  # Every place the document jumps down by more than one level, as "h2 -> h4".
+  def skipped_levels(names)
+    levels = names.map { |name| name[1].to_i }
+    levels.each_cons(2).filter_map { |from, to| "h#{from} -> h#{to}" if to > from + 1 }
+  end
+end


### PR DESCRIPTION
- The hero tagline is a paragraph, not an h4, and the section headings on partner and event pages are h2, so site pages no longer skip heading levels (found by the theme repo's new axe spec). Core's own accessibility spec stays green; a request spec asserts no level is skipped inside main.
- doc/extensions.md gains a Trust section: an engine runs Ruby in-process with the app's privileges and is a code dependency reviewed like any gem; four rules and a pointer to #3489 for themes that cannot run code.
- bin/check-extension-tree fails the lint job if any extension gem ships files outside the contract (models, controllers, migrations, routes, initialisers, stray lib Ruby). Passes against the pinned Trans Dimension gem; specced against synthetic trees.
- Back to news links to the index, not the article itself; next_event_after returns the soonest event, not an arbitrary one.
- The contact_email admin hint says exactly where the address is shown.

795 examples green across components, helpers, queries, public requests, i18n keys and the guard spec; the accessibility system spec 11 green.