### PR TITLE
WP 4.8: round-four view, accessibility and i18n fixes

### DIFF
--- a/app/assets/stylesheets/base/typography.scss
+++ b/app/assets/stylesheets/base/typography.scss
@@ -40,18 +40,6 @@ h1.sans {
 	letter-spacing: $title-letter-spacing;
 }
 
-// Section headings on the partner and event show pages. They are h2 because
-// they are the first headings under the page h1 and an h3 there skips a level,
-// but they are drawn at the size they had as h3s: browser default h3 metrics,
-// restated so the promotion is only a change of outline, not of look. Scoped
-// to these two blocks so the managed-place headings, which have always been
-// h2s at h2 size, are left alone.
-.g--partner h2.h4,
-.event__fullinfo h2.h4 {
-	font-size: 1.17em;
-	margin-block: 1em;
-}
-
 .title-strip {
 	background-color: $base-rules;
 	background-color: var(--base-rules);

--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -58,9 +58,12 @@ class Components::EventFilter < Components::Base
 
   def render_date_picker_fields
     date_field_tag(:date, @pointer, class: 'filters__date-input', data: { date_picker_target: 'input', action: 'change->date-picker#submit' })
-    hidden_field_tag(:period, @period, data: { date_picker_target: 'period' })
-    hidden_field_tag(:sort, @sort, data: { date_picker_target: 'sort' })
-    hidden_field_tag(:repeating, @repeating, data: { date_picker_target: 'repeating' })
+    # id: nil throughout: the neighbourhood and sort filters carry the same
+    # three fields, so the default ids appeared twice on /events (axe
+    # duplicate-id). The date picker reaches them by Stimulus target.
+    hidden_field_tag(:period, @period, id: nil, data: { date_picker_target: 'period' })
+    hidden_field_tag(:sort, @sort, id: nil, data: { date_picker_target: 'sort' })
+    hidden_field_tag(:repeating, @repeating, id: nil, data: { date_picker_target: 'repeating' })
     hidden_field_tag(:region, @selected_region.slug, id: nil) if @selected_region
   end
 

--- a/app/components/footer.rb
+++ b/app/components/footer.rb
@@ -45,8 +45,10 @@ class Components::Footer < Components::Base
 
   def render_nav
     div(class: 'footer__item footer__nav') do
-      h5(class: 'allcaps small') { t('footer.site_navigation') }
-      nav(role: 'navigation') do
+      h5(class: 'allcaps small', id: 'footer-nav-heading') { t('footer.site_navigation') }
+      # Named, so a screen reader's landmark menu distinguishes this nav from
+      # the header's rather than listing "navigation" twice.
+      nav(role: 'navigation', aria_labelledby: 'footer-nav-heading') do
         ul do
           nav_links.each do |label, path|
             li { active_link_to(label, path) }

--- a/app/components/hero.rb
+++ b/app/components/hero.rb
@@ -20,10 +20,12 @@ class Components::Hero < Components::Base
     div(class: 'hero') do
       div(class: 'container-public') do
         p(class: 'hero__section') { @section } if @section.present?
-        if @subtitle
+        if @subtitle.present?
           # The tagline is a strapline, not a section title. It used to be an h4
           # sitting between the navigation's h2 site name and the page h1, which
           # skipped a heading level and failed axe's heading-order rule.
+          # `present?`, not truthiness: Site#tagline is nullable and an empty
+          # string would otherwise render a bare paragraph and a divider.
           p(class: 'allcaps') { @subtitle }
           div(role: 'presentation', class: 'hero__divider')
         end

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -81,7 +81,10 @@ class Components::Navigation < Components::Base
       end
     else
       h2(class: 'sr-only') { @site&.name }
-      p(class: 'sr-only') { 'The Community Calendar' }
+      # Blank in core, so most sites announce just their name; a theme may
+      # give itself a strapline through theme_overrides.
+      strapline = t('navigation.site.strapline')
+      p(class: 'sr-only') { strapline } if strapline.present?
     end
   end
 

--- a/app/components/navigation.rb
+++ b/app/components/navigation.rb
@@ -89,7 +89,8 @@ class Components::Navigation < Components::Base
   end
 
   def render_menu
-    nav(class: menu_nav_classes, data: { mobile_menu_target: 'menu' }) do
+    nav(id: 'site-menu', class: menu_nav_classes, aria_label: t('navigation.primary'),
+        data: { mobile_menu_target: 'menu' }) do
       ul(class: 'contents') do
         @navigation.each do |link_text, link_path|
           li(class: menu_li_classes) { active_link_to(link_text, link_path, data: { turbolinks: false }, base_css_class: menu_link_classes, active_css_class: menu_active_classes) }
@@ -193,13 +194,16 @@ class Components::Navigation < Components::Base
             'pt-4 gap-0.5  lg:row-start-1 lg:col-start-2 lg:col-span-1',
             'md:flex-row md:gap-8 md:pt-3 md:pb-4 md:mt-6',
             'md:max-lg:[&:is(.is-hidden)]:py-0 md:max-lg:[&:is(.is-hidden)]:mt-4.5 md:max-lg:bg-home-background',
-            'max-lg:[&:is(.is-hidden)]:h-0',
+            # invisible alongside h-0 so the collapsed menu's links leave the
+            # tab order instead of being reachable but off-screen.
+            'max-lg:[&:is(.is-hidden)]:h-0 max-lg:[&:is(.is-hidden)]:invisible',
             'lg:justify-end lg:items-baseline lg:mx-0 lg:mt-1.5 lg:py-0'
           ]
         else
           [
             '-mx-6 gap-1 mt-4',
             'max-md:pb-1 max-md:bg-tertiary max-md:[&:is(.is-hidden)]:h-0 max-md:[&:is(.is-hidden)]:pb-0',
+            'max-md:[&:is(.is-hidden)]:invisible',
             'md:-mx-6',
             'md:max-lg:px-2 md:max-lg:bg-foreground',
             'lg:row-start-1 lg:col-start-2 lg:col-span-1 lg:gap-8 lg:m-0'
@@ -225,7 +229,8 @@ class Components::Navigation < Components::Base
                  ['md:hidden']
                end)
            ], aria_label: t('navigation.menu'),
-           data: { action: 'click->mobile-menu#toggle', turbo: 'false' }) do
+           aria_expanded: 'false', aria_controls: 'site-menu',
+           data: { mobile_menu_target: 'toggle', action: 'click->mobile-menu#toggle', turbo: 'false' }) do
       # The accessible name is always there; the visible label beside the icon
       # is what a theme opts into.
       span(class: 'text-base font-semibold header__toggle-label') { t('navigation.menu') } if show_menu_label?

--- a/app/javascript/controllers/mobile_menu_controller.js
+++ b/app/javascript/controllers/mobile_menu_controller.js
@@ -1,11 +1,20 @@
 import { Controller } from "@hotwired/stimulus";
 
 // Mobile Menu Controller - Toggle mobile navigation menu
-// Used by the public site navigation component
+// Used by the public site navigation component.
+//
+// The button is a disclosure: it owns the menu through aria-controls and must
+// report its state, so aria-expanded is flipped alongside the class. The
+// collapsed menu also carries `visibility: hidden` from its own utilities, so
+// its links leave the tab order rather than being reachable off-screen.
 export default class extends Controller {
-	static targets = ["menu"];
+	static targets = ["menu", "toggle"];
 
 	toggle() {
-		this.menuTarget.classList.toggle("is-hidden");
+		const expanded = this.menuTarget.classList.toggle("is-hidden") === false;
+
+		if (this.hasToggleTarget) {
+			this.toggleTarget.setAttribute("aria-expanded", String(expanded));
+		}
 	}
 }

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -84,7 +84,7 @@ class Views::Events::Index < Views::Base
   def render_meta_section
     Meta('/hello/world') do |component|
       component.with_link do
-        link_to "Subscribe to #{site.name} with iCal", events_url(protocol: :webcal, format: :ics)
+        link_to t('events.index.subscribe_ical', name: site.name), events_url(protocol: :webcal, format: :ics)
       end
     end
   end

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -262,6 +262,9 @@ class Views::Events::Show < Views::Base
     end
   end
 
+  # h2, not h3: these are the first headings under the page h1, and Tailwind's
+  # preflight flattens every heading to the inherited size with no margin, so
+  # the promotion changes the outline and not the look.
   def render_contact_info
     div(class: 'gi gi__1-3') do
       if event.organiser

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -265,7 +265,7 @@ class Views::Events::Show < Views::Base
   def render_contact_info
     div(class: 'gi gi__1-3') do
       if event.organiser
-        h2(class: 'h4 udl') { 'Contact information' }
+        h2(class: 'h4 udl') { t('events.show.contact_heading') }
         div(class: 'small') do
           ContactDetails(partner: event.organiser)
         end
@@ -275,7 +275,7 @@ class Views::Events::Show < Views::Base
 
   def render_event_address
     div(class: 'gi gi__1-3') do
-      h2(class: 'h4 udl') { 'Event address' }
+      h2(class: 'h4 udl') { t('events.show.address_heading') }
       div(class: 'small') do
         Address(address: event.address, raw_location: event.raw_location_from_source)
       end
@@ -284,7 +284,7 @@ class Views::Events::Show < Views::Base
 
   def render_event_organiser
     div(class: 'gi gi__1-3') do
-      h2(class: 'h4 udl') { 'Event organiser' }
+      h2(class: 'h4 udl') { t('events.show.organiser_heading') }
       div(class: 'small') do
         span { link_to event.organiser, event.organiser }
       end
@@ -297,7 +297,7 @@ class Views::Events::Show < Views::Base
 
   def render_event_venue
     div(class: 'gi gi__1-3') do
-      h2(class: 'h4 udl') { 'Venue' }
+      h2(class: 'h4 udl') { t('events.show.venue_heading') }
       div(class: 'small') do
         span { link_to event.place, event.place }
       end
@@ -310,10 +310,11 @@ class Views::Events::Show < Views::Base
         contact = event.calendar&.contact_information
         if contact
           div(class: 'contact_information') do
-            plain 'Problem with this listing? '
+            plain t('events.show.problem_prompt')
             mail_to contact[0],
-                    'Let us know.',
-                    subject: "I think there's a problem with PlaceCal event http://placecal.org#{event_path(event)}",
+                    t('events.show.problem_link'),
+                    subject: t('events.show.problem_subject',
+                               url: "http://placecal.org#{event_path(event)}"),
                     cc: 'support@placecal.org'
           end
         end

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -196,10 +196,24 @@ class Views::Layouts::Application < Phlex::HTML
 
   def compute_title
     return 'PlaceCal | The Community Calendar' if current_page?(root_url) && site.nil?
-    return "#{content_for(:title)} | #{site.name}" if content_for?(:title) && site&.name
-    return "#{content_for(:title)} | PlaceCal" if content_for?(:title)
+
+    page_title = captured_title
+    return "#{page_title} | #{site.name}" if page_title && site&.name
+    return "#{page_title} | PlaceCal" if page_title
 
     site&.name || 'PlaceCal | The Community Calendar'
+  end
+
+  # `content_for(:title)` comes back as an already-escaped SafeBuffer, because
+  # the block was captured through Phlex. Interpolating it into a plain String
+  # drops the safe flag and the <title> element then escapes it a second time,
+  # so "Children's Storytime" reaches the browser tab as "Children&#39;s".
+  # Unescape the captured buffer first and let the single escape happen on the
+  # way out, in both <title> and og:title.
+  def captured_title
+    return nil unless content_for?(:title)
+
+    CGI.unescapeHTML(content_for(:title).to_s)
   end
 
   def devise_page?

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -168,7 +168,7 @@ class Views::Layouts::Application < Phlex::HTML
       meta(property: 'og:image:height', content: '630')
     else
       meta(property: 'og:image', content: image_url('og/wide.png'))
-      meta(property: 'og:image:alt', content: 'PlaceCal logo')
+      meta(property: 'og:image:alt', content: t('og_image.alt.directory'))
       meta(property: 'og:image:width', content: '1920')
       meta(property: 'og:image:height', content: '1080')
     end
@@ -195,13 +195,13 @@ class Views::Layouts::Application < Phlex::HTML
   end
 
   def compute_title
-    return 'PlaceCal | The Community Calendar' if current_page?(root_url) && site.nil?
+    return t('site.title_default') if current_page?(root_url) && site.nil?
 
     page_title = captured_title
     return "#{page_title} | #{site.name}" if page_title && site&.name
     return "#{page_title} | PlaceCal" if page_title
 
-    site&.name || 'PlaceCal | The Community Calendar'
+    site&.name || t('site.title_default')
   end
 
   # `content_for(:title)` comes back as an already-escaped SafeBuffer, because

--- a/app/views/news/show.rb
+++ b/app/views/news/show.rb
@@ -34,7 +34,9 @@ class Views::News::Show < Views::Base
 
       div(class: 'gi gi__4-5 article__main') do
         if article.author&.full_name.present?
-          h3(class: 'article__author') do
+          # A byline, not a section heading: as an h3 straight after the
+          # hero h1 it failed axe's heading-order rule on every article.
+          p(class: 'article__author') do
             plain t('news.show.by')
             em { article.author.full_name }
           end

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -64,7 +64,7 @@ class Views::Partners::Show < Views::Base
 
   def render_accessibility_details(summary_class: nil)
     details(id: 'accessibility-info') do
-      summary(class: summary_class) { 'Accessibility information' }
+      summary(class: summary_class) { t('partners.show.accessibility_heading') }
       div(class: 'mt-2 text-sm text-foreground') do
         raw safe(partner.accessibility_info_html.to_s)
       end
@@ -105,11 +105,11 @@ class Views::Partners::Show < Views::Base
   end
 
   def render_contact_and_address
-    h2(class: 'udl udl--fw allcaps h4') { 'Get in touch' }
+    h2(class: 'udl udl--fw allcaps h4') { t('partners.show.contact_heading') }
     ContactDetails(partner: partner)
 
-    h2(class: 'udl udl--fw allcaps h4') { 'Address' }
-    p { "We operate in #{partner_service_area_text(partner)}." } if partner.has_service_areas?
+    h2(class: 'udl udl--fw allcaps h4') { t('partners.show.address_heading') }
+    p { raw(t('partners.show.service_area_html', areas: partner_service_area_text(partner))) } if partner.has_service_areas?
 
     Address(address: partner.address)
 
@@ -117,10 +117,13 @@ class Views::Partners::Show < Views::Base
 
     return unless partner.managees.any?
 
+    # view_context.link_to, not the registered output helper: the helper
+    # writes straight to the buffer, so building the list as an interpolation
+    # argument would emit the links ahead of the sentence that contains them.
+    places = safe_join(partner.managees.map { |place| view_context.link_to(place.name, place) }, ', ')
+
     p(class: 'small') do
-      plain "#{partner.name} manage "
-      raw safe_join(partner.managees.map { |place| link_to place.name, place }, ', ')
-      plain '.'
+      raw(t('partners.show.managed_by_html', name: partner.name, places: places))
     end
   end
 
@@ -131,7 +134,7 @@ class Views::Partners::Show < Views::Base
       img(
         src: partner.image.standard.url,
         srcset: "#{partner.image.standard.url} 1x, #{partner.image.retina.url} 2x",
-        alt: "Image for #{partner.name}",
+        alt: t('partners.show.image_alt', name: partner.name),
         class: 'map--single'
       )
     end
@@ -142,7 +145,7 @@ class Views::Partners::Show < Views::Base
     return unless times.any?
 
     br
-    h2(class: 'udl udl--fw allcaps h4') { 'Opening times' }
+    h2(class: 'udl udl--fw allcaps h4') { t('partners.show.opening_times_heading') }
     ul(class: 'opening_times reset') do
       times.each do |slot|
         li { slot }
@@ -160,11 +163,11 @@ class Views::Partners::Show < Views::Base
           raw safe(place.summary_html.to_s) if place.summary_html.present?
         end
         div(class: 'gi gi__1-2') do
-          h2(class: 'udl udl--fw allcaps h4') { 'Address' }
+          h2(class: 'udl udl--fw allcaps h4') { t('partners.show.address_heading') }
           div(class: 'small') do
             Address(address: place.address)
           end
-          h2(class: 'udl udl--fw allcaps h4') { 'Contact' }
+          h2(class: 'udl udl--fw allcaps h4') { t('partners.show.place_contact_heading') }
           div(class: 'small') do
             ContactDetails(
               partner: partner,
@@ -239,7 +242,8 @@ class Views::Partners::Show < Views::Base
   def render_meta_section
     Meta("/partners/#{partner.id}") do |component|
       component.with_link do
-        link_to "Subscribe to #{partner}'s events with iCal", partner_url(partner, protocol: :webcal, format: :ics)
+        link_to t('partners.show.subscribe_ical', name: partner.name),
+                partner_url(partner, protocol: :webcal, format: :ics)
         if events.any?
           whitespace
           link_to t('events.csv_export.link'), partner_url(partner, format: :csv)

--- a/app/views/partners/show.rb
+++ b/app/views/partners/show.rb
@@ -104,6 +104,10 @@ class Views::Partners::Show < Views::Base
     end
   end
 
+  # These section headings are h2 rather than h3: they are the first headings
+  # under the page h1 and an h3 there skips a level. The look is unchanged,
+  # because Tailwind's preflight already flattens every heading to the
+  # inherited size with no margin, so an h2 and an h3 here draw identically.
   def render_contact_and_address
     h2(class: 'udl udl--fw allcaps h4') { t('partners.show.contact_heading') }
     ContactDetails(partner: partner)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,10 @@ en:
   meta:
     description: "%{site} is a community events calendar where you can find out everything that's happening, all in one place."
 
+  site:
+    # <title> for the nationwide directory, which has no Site record to name
+    title_default: "PlaceCal | The Community Calendar"
+
   colophon:
     year: "© 2019-%{year}"
     copyright: "GFSC Community Interest Company"
@@ -52,6 +56,7 @@ en:
       partnerships: "Partnerships"
       events: "Events"
       join: "Join us"
+    primary: "Main navigation"
     site:
       home: "Home"
       events: "Events"
@@ -61,6 +66,9 @@ en:
       privacy: "Privacy"
       terms: "Terms"
       log_in: "Log in"
+      # Screen-reader-only line under the site name. Blank in core so a themed
+      # site is not told it is "The Community Calendar"; a theme may set its own.
+      strapline: ""
 
   footer:
     site_navigation: "Site Navigation"
@@ -434,6 +442,18 @@ en:
   partners:
     show:
       section: ""
+      accessibility_heading: "Accessibility information"
+      contact_heading: "Get in touch"
+      address_heading: "Address"
+      opening_times_heading: "Opening times"
+      # Headings in a managed place's block, which repeats the partner's own
+      place_contact_heading: "Contact"
+      # %{areas} is the rendered list of service areas, already escaped
+      service_area_html: "We operate in %{areas}."
+      # %{places} is the rendered list of links to the places this partner runs
+      managed_by_html: "%{name} manage %{places}."
+      image_alt: "Image for %{name}"
+      subscribe_ical: "Subscribe to %{name}'s events with iCal"
       # Empty states for the partner page's event list, one per period
       no_events_day: "No events this day."
       no_events_week: "No events this week."
@@ -490,6 +510,7 @@ en:
       title: "Events & activities"
       standfirst: ""
       list_heading: ""
+      subscribe_ical: "Subscribe to %{name} with iCal"
     card:
       # strftime patterns for the event list date; themes may override
       date_format: "%e %b"
@@ -516,6 +537,14 @@ en:
     show:
       # Section name above the event page title, blank in core
       section: ""
+      contact_heading: "Contact information"
+      address_heading: "Event address"
+      organiser_heading: "Event organiser"
+      venue_heading: "Venue"
+      # Prompt and link inviting a reader to report a bad listing
+      problem_prompt: "Problem with this listing? "
+      problem_link: "Let us know."
+      problem_subject: "I think there's a problem with PlaceCal event %{url}"
     csv_export:
       link: "Download events as CSV"
       # Column headers for the events CSV (app/services/events_csv.rb).
@@ -571,6 +600,7 @@ en:
       partner: "Details for the partner %{name} on PlaceCal"
       partnership: "Details for the partnership %{name} on PlaceCal"
       site: "%{name}, powered by PlaceCal"
+      directory: "PlaceCal logo"
 
   # ===========================================================================
   # ENUMERIZE (Calendar types)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,8 +13,6 @@ en:
       label: Green
     blue:
       label: Blue
-    custom:
-      label: Custom (legacy, per-site stylesheet)
   # ===========================================================================
   # SITE METADATA
   # ===========================================================================
@@ -72,15 +70,6 @@ en:
 
   footer:
     site_navigation: "Site Navigation"
-    site_enquiries: "%{site} Enquiries"
-    general_enquiries: "General Enquiries"
-    get_in_touch: "Get in touch!"
-    # Abbreviated labels before a phone number and an email address
-    phone_label: "T:"
-    email_label: "E:"
-    site_supporters: " PlaceCal %{site} Supporters"
-    global_supporters: "PlaceCal Supporters"
-    build: "Build: "
     site_enquiries: "%{site} Enquiries"
     general_enquiries: "General Enquiries"
     get_in_touch: "Get in touch!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -464,7 +464,9 @@ en:
       title: "Our Partners"
       standfirst: ""
       standfirst_detail: ""
-      list_heading: ""
+      # Real text, not blank: it is the h2 between the hero h1 and the h3 of
+      # each partner card, and without it the page skips a heading level.
+      list_heading: "All partners"
   news:
     show:
       section: ""
@@ -509,6 +511,8 @@ en:
       page_title: "Events"
       title: "Events & activities"
       standfirst: ""
+      # Blank by design: the event list opens with an h2 per day, so there is
+      # no heading level to bridge here and a theme may still add one.
       list_heading: ""
       subscribe_ical: "Subscribe to %{name} with iCal"
     card:

--- a/spec/requests/public/heading_order_spec.rb
+++ b/spec/requests/public/heading_order_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 # axe's heading-order rule: a page must not skip a heading level. Site pages
 # used to go h2 (the navigation's screen-reader site name) then h4 (the hero
 # tagline) then h1, and the partner and event bodies opened at h3.
+#
+# Two neighbouring axe rules ride along here, because they are cheap to assert
+# from the same documents: landmark-unique (every nav landmark needs an
+# accessible name) and duplicate-id.
 RSpec.describe "Site page heading order", type: :request do
   let(:site) { create(:site, slug: "headings", tagline: "Events in Riverside") }
   let(:ward) { create(:riverside_ward) }
@@ -12,8 +16,12 @@ RSpec.describe "Site page heading order", type: :request do
 
   before { site.neighbourhoods << ward }
 
+  def document
+    Nokogiri::HTML(response.body)
+  end
+
   def headings(scope = "body")
-    Nokogiri::HTML(response.body).css("#{scope} h1, #{scope} h2, #{scope} h3, #{scope} h4, #{scope} h5, #{scope} h6")
+    document.css("#{scope} h1, #{scope} h2, #{scope} h3, #{scope} h4, #{scope} h5, #{scope} h6")
             .map(&:name)
   end
 
@@ -22,8 +30,8 @@ RSpec.describe "Site page heading order", type: :request do
 
     it "renders the hero tagline as a paragraph, not a heading" do
       expect(response.body).to include(site.tagline)
-      expect(Nokogiri::HTML(response.body).at_css(".hero p.allcaps")&.text).to eq(site.tagline)
-      expect(Nokogiri::HTML(response.body).css(".hero h4")).to be_empty
+      expect(document.at_css(".hero p.allcaps")&.text).to eq(site.tagline)
+      expect(document.css(".hero h4")).to be_empty
     end
 
     it "puts only the site name h2 before the h1" do
@@ -52,9 +60,103 @@ RSpec.describe "Site page heading order", type: :request do
     end
   end
 
+  # The listing pages and the homepage, which the show pages above do not
+  # reach: each has its own hero and its own first body heading.
+  describe "the listing pages and the homepage" do
+    # Two child neighbourhoods with events of their own, so /events renders the
+    # neighbourhood filter alongside the date picker: those two forms carry the
+    # same period/sort/repeating fields and used to collide on their ids.
+    let(:north) { create(:neighbourhood, name: "Riverside North", unit: "ward", parent: ward) }
+    let(:south) { create(:neighbourhood, name: "Riverside South", unit: "ward", parent: ward) }
+    let!(:event) do
+      create(:event, address: create(:riverside_address, neighbourhood: north), organiser: partner,
+                     dtstart: 1.day.from_now)
+    end
+    let!(:southern_event) do
+      create(:event, address: create(:riverside_address, neighbourhood: south),
+                     organiser: create(:partner, address: create(:riverside_address, neighbourhood: south)),
+                     dtstart: 1.day.from_now)
+    end
+    let!(:article) { create(:article, is_draft: false) }
+
+    {
+      "the homepage" => "/",
+      "the partners index" => "/partners",
+      "the events index" => "/events",
+      "the news index" => "/news"
+    }.each do |name, path|
+      context "on #{name}" do
+        before { get "http://#{site.slug}.lvh.me#{path}" }
+
+        it "responds successfully" do
+          expect(response).to be_successful
+        end
+
+        it "never skips a heading level in the page body" do
+          expect(skipped_levels(headings("main"))).to be_empty
+        end
+
+        it "names every navigation landmark" do
+          expect(unnamed_navs).to be_empty
+        end
+
+        it "uses every id at most once" do
+          expect(duplicate_ids).to be_empty
+        end
+      end
+    end
+
+    context "on an article page" do
+      before { get news_url(article, host: "#{site.slug}.lvh.me") }
+
+      it "renders the byline as a paragraph, not a heading" do
+        expect(response).to be_successful
+        expect(document.at_css("p.article__author")).to be_present
+        expect(document.at_css("h3.article__author")).to be_nil
+      end
+
+      it "never skips a heading level in the page body" do
+        expect(skipped_levels(headings("main"))).to be_empty
+      end
+    end
+  end
+
+  describe "the mobile menu disclosure" do
+    before { get "http://#{site.slug}.lvh.me/" }
+
+    it "reports its state and names the menu it controls" do
+      toggle = document.at_css(".header__toggle")
+
+      expect(toggle["aria-expanded"]).to eq("false")
+      expect(document.at_css("##{toggle['aria-controls']}")).to be_present
+    end
+  end
+
   # Every place the document jumps down by more than one level, as "h2 -> h4".
   def skipped_levels(names)
     levels = names.map { |name| name[1].to_i }
     levels.each_cons(2).filter_map { |from, to| "h#{from} -> h#{to}" if to > from + 1 }
+  end
+
+  # A nav landmark has an accessible name from aria-label, or from the element
+  # aria-labelledby points at. Anything else shows up as a bare "navigation"
+  # in a screen reader's landmark menu.
+  def unnamed_navs
+    doc = document
+    unnamed = doc.css("nav").reject do |nav|
+      nav["aria-label"].present? ||
+        (nav["aria-labelledby"].present? && doc.at_css("##{nav['aria-labelledby']}").present?)
+    end
+
+    unnamed.map { |nav| nav["class"] }
+  end
+
+  # Ids inside inlined SVGs are excluded: two Sketch exports on the same page
+  # collide on names like "Fill-11", none of them referenced by a url(#…), and
+  # fixing that means re-exporting the artwork rather than changing markup.
+  def duplicate_ids
+    ids = document.css("[id]").reject { |node| node.ancestors("svg").any? }.map { |node| node["id"] }
+
+    ids.tally.select { |_id, count| count > 1 }.keys
   end
 end

--- a/spec/requests/public/page_title_spec.rb
+++ b/spec/requests/public/page_title_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# `content_for(:title)` is captured through Phlex and comes back escaped, so
+# composing the <title> out of it used to escape a second time and put the
+# literal text "Children&#39;s Storytime" in the browser tab and the SERP.
+RSpec.describe "Public page titles", type: :request do
+  let(:site) { create(:site, slug: "titles") }
+  let(:ward) { create(:riverside_ward) }
+  let(:address) { create(:address, neighbourhood: ward) }
+  let(:partner) { create(:partner, address: address) }
+  let(:event) do
+    create(:event, organiser: partner, address: address, summary: "Children's Storytime", dtstart: 1.day.from_now)
+  end
+
+  before do
+    site.neighbourhoods << ward
+    get event_url(event, host: "#{site.slug}.lvh.me")
+  end
+
+  def title_tag
+    response.body[%r{<title>.*?</title>}m]
+  end
+
+  it "escapes an apostrophe in the title exactly once" do
+    expect(title_tag).to include("&#39;")
+    expect(title_tag).not_to include("&amp;#39;")
+  end
+
+  it "reads back as the original summary once unescaped" do
+    expect(CGI.unescapeHTML(title_tag.sub("<title>", "").sub("</title>", ""))).to start_with("Children's Storytime")
+  end
+
+  # Phlex escapes attributes on its own terms, so og:title carries a bare
+  # apostrophe. What matters is that it says the same thing as <title>.
+  it "agrees with og:title" do
+    og_title = CGI.unescapeHTML(response.body[/<meta property="og:title" content="([^"]*)"/, 1])
+
+    expect(og_title).to start_with("Children's Storytime")
+    expect(og_title).not_to include("&#39;")
+  end
+end


### PR DESCRIPTION
Round-four review fixes, core views half.

- Page title composed from the unescaped captured title so apostrophes escape once in both the title element and og:title; request spec covers it.
- Remaining public-view literals moved to locale keys (partner and event show headings, iCal links, the problem-report mail, og image alt, directory title, primary nav label, a blank strapline core sites leave empty).
- Accessibility: partners index gets a real list heading so the outline no longer skips a level; article byline is a paragraph, not an h3; header and footer navs are named landmarks; duplicate hidden-field ids on /events dropped; menu toggle reports aria-expanded and the collapsed menu leaves the tab order. Heading-order spec extended to every public page with landmark, duplicate-id and disclosure assertions (23 examples, each verified load-bearing by reverting its fix).
- The typography rule added with the h3 to h2 promotion is dropped: Tailwind preflight already flattens heading sizes.
- Locale housekeeping: duplicated footer block collapsed, dead custom theme label removed.

Site-wide visible change to flag: every core site's /partners page now shows an "All partners" heading between the hero and the list (TD already had it).

rubocop clean; components, helpers, public request and i18n specs: 710 examples, 0 failures.