### PR TITLE
Theme slots spec: core partners page now has its own list heading

### DIFF
--- a/spec/requests/extensions/theme_slots_spec.rb
+++ b/spec/requests/extensions/theme_slots_spec.rb
@@ -280,8 +280,11 @@ RSpec.describe "Theme slots", type: :request do
       expect(response.body).not_to include("hero__section")
       expect(response.body).to include(" 9 Nov")
 
+      # Core sites carry their own partners heading (the outline would skip a
+      # level without it); what must not leak is the fixture theme's wording.
       get "http://plain.lvh.me/partners"
-      expect(response.body).not_to include("list-heading")
+      expect(response.body).to include('class="list-heading">All partners</h2>')
+      expect(response.body).not_to include("Fixture partners list heading")
     end
 
     aggregate_failures "theme page" do


### PR DESCRIPTION
WP 4.8 gave core sites an "All partners" heading, so the one negative assertion that expected no list heading on a core partners page now checks the fixture theme's wording does not leak instead. 22 examples green.