### PR TITLE
Tree guard: name an explicit root after its gemspec

### DIFF
--- a/bin/check-extension-tree
+++ b/bin/check-extension-tree
@@ -144,14 +144,22 @@ def allowed?(path, allowed_lib)
   false
 end
 
-# Explicit roots on the command line, named after their directory.
+# Explicit roots on the command line, named after their gemspec. The directory
+# name is no guide: the extension workflow checks the gem out as `theme`, and
+# `lib/<gem>.rb` is one of the few lib files the contract allows, so a name
+# taken from the directory would flag every extension's own entry file.
 def roots_from_argv(argv)
   argv.map do |arg|
     root = Pathname.new(arg).expand_path
     abort "check-extension-tree: #{arg} is not a directory" unless root.directory?
 
-    [root.basename.to_s, root]
+    [gem_name_for(root), root]
   end
+end
+
+def gem_name_for(root)
+  gemspec = root.glob('*.gemspec').first
+  gemspec ? gemspec.basename('.gemspec').to_s : root.basename.to_s
 end
 
 failures = {}

--- a/spec/lib/check_extension_tree_spec.rb
+++ b/spec/lib/check_extension_tree_spec.rb
@@ -77,6 +77,23 @@ RSpec.describe "bin/check-extension-tree" do
     end
   end
 
+  # CI checks the gem out under a directory called `theme`, so the name has to
+  # come from the gemspec or the gem's own entry file counts as stray lib code.
+  it "names an explicit root after its gemspec, not its directory" do
+    Dir.mktmpdir do |dir|
+      root = File.join(dir, "theme")
+      # The real shape: gem placecal-theme-foo, module foo, so the entry file
+      # is only allowed once the guard knows the gem's name.
+      build_tree(root, contract_abiding - ["foo.gemspec", "lib/foo.rb"] +
+                       ["placecal-theme-foo.gemspec", "lib/placecal-theme-foo.rb"])
+
+      stdout, stderr, status = run(root)
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("placecal-theme-foo: #{contract_abiding.length} files checked")
+    end
+  end
+
   it "fails on models, controllers, migrations, routes, initializers and stray lib code" do
     Dir.mktmpdir do |dir|
       root = File.join(dir, "foo")


### PR DESCRIPTION
The guard step added to extension-test.yml in #3498 checks the gem out as `theme`, so the guard named it after the directory and flagged `lib/placecal-theme-transdimension.rb` as stray lib code; both theme repos went red against the updated workflow. Explicit roots are now named after their gemspec, falling back to the directory. Spec example mirrors the real gem shape and fails without the fix. Both theme checkouts pass the guard locally.