### PR TITLE
WP 4.12: hosted events on neighbourhood sites, footer headings at h2

### DIFF
--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -20,8 +20,11 @@
 		border-color: var(--base-secondary);
 	}
 
-	h5 {
-		margin-top: 0;
+	// The footer headings are h2s so the document outline never jumps a level,
+	// but they keep the h5 look they had: the small class sets the size and
+	// line height, allcaps the weight, and this restores the h5 margin.
+	&__heading {
+		margin: 0 0 1.67em;
 	}
 
 	&__inner {

--- a/app/components/footer.rb
+++ b/app/components/footer.rb
@@ -45,7 +45,7 @@ class Components::Footer < Components::Base
 
   def render_nav
     div(class: 'footer__item footer__nav') do
-      h5(class: 'allcaps small', id: 'footer-nav-heading') { t('footer.site_navigation') }
+      h2(class: 'footer__heading allcaps small', id: 'footer-nav-heading') { t('footer.site_navigation') }
       # Named, so a screen reader's landmark menu distinguishes this nav from
       # the header's rather than listing "navigation" twice.
       nav(role: 'navigation', aria_labelledby: 'footer-nav-heading') do
@@ -85,7 +85,7 @@ class Components::Footer < Components::Base
 
   def render_site_enquiries
     div(class: 'footer__item footer__enquiries footer__enquiries--regional') do
-      h5(class: 'allcaps small') { t('footer.site_enquiries', site: @site.name) }
+      h2(class: 'footer__heading allcaps small') { t('footer.site_enquiries', site: @site.name) }
       p { @site.site_admin.full_name }
       p { render_site_contact_info }
     end
@@ -104,7 +104,7 @@ class Components::Footer < Components::Base
 
   def render_general_enquiries
     div(class: 'footer__item footer__enquiries footer__enquiries--general') do
-      h5(class: 'allcaps small') { t('footer.general_enquiries') }
+      h2(class: 'footer__heading allcaps small') { t('footer.general_enquiries') }
       p { t('footer.get_in_touch') }
       p do
         strong { t('footer.email_label') }
@@ -117,7 +117,7 @@ class Components::Footer < Components::Base
   def render_site_supporters
     hr(class: 'footer__item footer__hr')
     div(class: 'footer__item footer__supporters') do
-      h5(class: 'allcaps small') { t('footer.site_supporters', site: @site.name) }
+      h2(class: 'footer__heading allcaps small') { t('footer.site_supporters', site: @site.name) }
       ul do
         @site.supporters&.each do |supporter|
           li(class: "footer__supporter footer__supporter--#{supporter.name.parameterize}") do
@@ -133,7 +133,7 @@ class Components::Footer < Components::Base
 
     global_supporters = view_context.instance_variable_get(:@global_supporters)
     div(class: 'footer__item footer__supporters') do
-      h5(class: 'allcaps small') { t('footer.global_supporters') }
+      h2(class: 'footer__heading allcaps small') { t('footer.global_supporters') }
       ul do
         global_supporters&.each do |supporter|
           li(class: "footer__supporter footer__supporter--#{supporter.name.parameterize}") do

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -194,9 +194,12 @@ class EventsQuery
                     end
   end
 
-  # Inline of Event.for_site - finds events belonging to partners in this site
-  # When site has tags: only events from tagged partners (no address fallback)
-  # When site has no tags: events from site partners OR events with address in site neighbourhoods
+  # Inline of Event.for_site: the events that belong on this site. Both site
+  # shapes take events organised by, or hosted at, one of the site's partners;
+  # a neighbourhood site also takes any event whose address is in its area,
+  # and a tagged site adds the legacy venue match. The hosted-at rule reaches
+  # an event a site partner puts on somewhere else, which is how the partner
+  # page and the tag filter already count it.
   def events_for_site
     partners_scope = PartnersQuery.new(site: @site).call.reorder(nil)
 
@@ -214,6 +217,7 @@ class EventsQuery
 
     base = Event.left_joins(:address)
     base.where(organiser_id: partner_subquery)
+        .or(base.where(place_id: partner_subquery))
         .or(base.where(addresses: { neighbourhood_id: site_neighbourhood_ids }))
   end
 

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -773,6 +773,31 @@ RSpec.describe EventsQuery do
     end
   end
 
+  describe "site scoping for a neighbourhood site" do
+    let(:neighbourhood_site) { create(:site, slug: "neighbourhood-site") }
+    let(:ward) { create(:riverside_ward) }
+    let(:other_ward) { create(:cliffside_ward) }
+    let(:site_partner) { create(:partner, name: "Site Partner", address: create(:riverside_address, neighbourhood: ward)) }
+    let(:outside_partner) { create(:partner, name: "Outside Partner", address: create(:cliffside_address, neighbourhood: other_ward)) }
+
+    before do
+      neighbourhood_site.neighbourhoods << ward
+      create(:future_event, organiser: site_partner, summary: "Organised Here")
+      create(:future_event, organiser: outside_partner, address: create(:cliffside_address, neighbourhood: other_ward), summary: "Outside")
+    end
+
+    # The same rule as a tagged site: an event a site partner hosts belongs on
+    # the site even when the event's own address is outside its area.
+    it "includes events hosted at a site partner as well as organised by one" do
+      create(:future_event, organiser: outside_partner, place: site_partner,
+                            address: create(:cliffside_address, neighbourhood: other_ward), summary: "Hosted Here")
+
+      result = described_class.new(site: neighbourhood_site, day: today).call(period: "future")
+
+      expect(result.values.flatten.map(&:summary)).to contain_exactly("Organised Here", "Hosted Here")
+    end
+  end
+
   describe "site scoping for a tag-only site" do
     let(:tag_only_site) { create(:site, slug: "tag-only-site") }
     let(:ward) { create(:riverside_ward) }

--- a/spec/requests/public/heading_order_spec.rb
+++ b/spec/requests/public/heading_order_spec.rb
@@ -40,10 +40,17 @@ RSpec.describe "Site page heading order", type: :request do
       expect(before_h1).to eq(["h2"])
     end
 
-    # The shared footer has its own long-standing level jump, so the body of
-    # the page is what this checks.
-    it "never skips a heading level in the page body" do
-      expect(skipped_levels(headings("main"))).to be_empty
+    it "never skips a heading level anywhere on the page" do
+      expect(skipped_levels(headings)).to be_empty
+    end
+
+    # The footer's section headings used to be h5s straight after the page
+    # body, a level jump on every site; they are h2s that keep the h5 look.
+    it "puts the footer's section headings at h2" do
+      footer_headings = document.css("footer h1, footer h2, footer h3, footer h4, footer h5, footer h6")
+
+      expect(footer_headings.map(&:name).uniq).to eq(["h2"])
+      expect(footer_headings.map { |h| h["class"] }).to all(include("footer__heading"))
     end
   end
 
@@ -56,7 +63,7 @@ RSpec.describe "Site page heading order", type: :request do
 
     it "never skips a heading level in the page body" do
       expect(response).to be_successful
-      expect(skipped_levels(headings("main"))).to be_empty
+      expect(skipped_levels(headings)).to be_empty
     end
   end
 
@@ -93,7 +100,7 @@ RSpec.describe "Site page heading order", type: :request do
         end
 
         it "never skips a heading level in the page body" do
-          expect(skipped_levels(headings("main"))).to be_empty
+          expect(skipped_levels(headings)).to be_empty
         end
 
         it "names every navigation landmark" do
@@ -116,7 +123,7 @@ RSpec.describe "Site page heading order", type: :request do
       end
 
       it "never skips a heading level in the page body" do
-        expect(skipped_levels(headings("main"))).to be_empty
+        expect(skipped_levels(headings)).to be_empty
       end
     end
   end


### PR DESCRIPTION
Two of the round-four judgement calls, decided with Kim.

- Events hosted at a site partner belong on the site for both site shapes. Tagged sites already had the rule; neighbourhood sites now match, so an event a site partner hosts somewhere outside the site's area is listed the way the partner page and the tag filter already count it. Spec fails without the change.
- The footer's section headings are h2s rather than h5s, so no site's outline jumps a level after the page body. They keep the h5 look: measured on a core site before and after at 14.4px, weight 800, line height 21.6px, bottom margin 24.048px. The heading-order spec now checks the whole page rather than stopping at main, plus a footer example.

118 examples across the touched specs green; rubocop clean. The Mossley theme's footer selector follows in its next release.