### PR TITLE
WP 4.13: axe sweep over a core-themed site

### DIFF
--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -57,7 +57,10 @@ class Components::EventFilter < Components::Base
   end
 
   def render_date_picker_fields
-    date_field_tag(:date, @pointer, class: 'filters__date-input', data: { date_picker_target: 'input', action: 'change->date-picker#submit' })
+    # The field has no visible label: the Go to date button opens it. The
+    # aria-label gives it the same name for assistive tech (axe: label).
+    date_field_tag(:date, @pointer, class: 'filters__date-input', aria: { label: t('filters.go_to_date') },
+                                    data: { date_picker_target: 'input', action: 'change->date-picker#submit' })
     # id: nil throughout: the neighbourhood and sort filters carry the same
     # three fields, so the default ids appeared twice on /events (axe
     # duplicate-id). The date picker reaches them by Stimulus target.

--- a/app/components/footer.rb
+++ b/app/components/footer.rb
@@ -36,9 +36,9 @@ class Components::Footer < Components::Base
   def render_logo
     div(class: 'footer__item footer__logo') do
       if @site&.footer_logo.present?
-        image_tag(@site.footer_logo.url) if @site.footer_logo.url
+        image_tag(@site.footer_logo.url, alt: @site.name) if @site.footer_logo.url
       else
-        image_tag('logo-footer.svg')
+        image_tag('logo-footer.svg', alt: t('footer.logo_alt'))
       end
     end
   end
@@ -121,7 +121,7 @@ class Components::Footer < Components::Base
       ul do
         @site.supporters&.each do |supporter|
           li(class: "footer__supporter footer__supporter--#{supporter.name.parameterize}") do
-            link_to(supporter.url) { image_tag(supporter.logo.url) }
+            link_to(supporter.url) { image_tag(supporter.logo.url, alt: supporter.name) }
           end
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,8 @@ en:
       strapline: ""
 
   footer:
+    # Alt text for the PlaceCal logo in the footer of sites without their own
+    logo_alt: "PlaceCal"
     site_navigation: "Site Navigation"
     site_enquiries: "%{site} Enquiries"
     general_enquiries: "General Enquiries"

--- a/spec/system/sites/accessibility_spec.rb
+++ b/spec/system/sites/accessibility_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Every page a visitor to a core-themed site can reach, checked with axe-core
+# the way the directory is (spec/system/directory/accessibility_spec.rb). The
+# extension themes run the same sweep in their own repos; this is the one for
+# the markup and palette core ships.
+RSpec.describe "Site accessibility", :slow, type: :system do
+  # color-contrast is the one rule skipped, because what trips it is the core
+  # palette itself rather than markup: on the pink theme white text on the
+  # primary colour (#fffcf0 on #f19089, buttons and the partner card badge)
+  # measures 2.24:1 and the footer impressum (#998675 on #5b4e46) 2.29:1,
+  # against the 4.5:1 the rule wants. Changing that is a design decision for
+  # every core theme, not a spec fix. Everything structural is enforced.
+  PALETTE_RULES = [:"color-contrast"].freeze
+
+  let(:ward) { create(:riverside_ward) }
+  let(:site) { create(:site, slug: "riverside", theme: "pink", url: "https://riverside.lvh.me") }
+  let(:partner) { create(:partner, name: "Riverside Hub", address: create(:riverside_address, neighbourhood: ward)) }
+
+  let(:event) do
+    create(:event, summary: "Riverside Makers", organiser: partner,
+                   dtstart: 3.days.from_now, dtend: 3.days.from_now + 2.hours)
+  end
+
+  let(:article) do
+    create(:article, title: "Riverside Roundup", is_draft: false, published_at: 1.day.ago, partners: [partner])
+  end
+
+  before do
+    site.neighbourhoods << ward
+    event
+    article
+  end
+
+  # The site is resolved from the request host, so every visit goes to the
+  # site's host on Capybara's port rather than Capybara.app_host.
+  def visit_site(path)
+    visit "http://riverside.lvh.me:#{Capybara.current_session.server.port}#{path}"
+  end
+
+  {
+    "the homepage" => "/",
+    "the events listing" => "/events",
+    "the partners listing" => "/partners",
+    "the news listing" => "/news",
+    "the Get in touch page" => "/get-in-touch"
+  }.each do |description, path|
+    it "has no accessibility violations on #{description}" do
+      visit_site(path)
+
+      expect(page).to be_axe_clean.skipping(*PALETTE_RULES)
+    end
+  end
+
+  it "has no accessibility violations on a partner page" do
+    visit_site("/partners/#{partner.to_param}")
+
+    expect(page).to be_axe_clean.skipping(*PALETTE_RULES)
+  end
+
+  it "has no accessibility violations on an event page" do
+    visit_site("/events/#{event.to_param}")
+
+    expect(page).to be_axe_clean.skipping(*PALETTE_RULES)
+  end
+
+  it "has no accessibility violations on an article" do
+    visit_site("/news/#{article.to_param}")
+
+    expect(page).to be_axe_clean.skipping(*PALETTE_RULES)
+  end
+end


### PR DESCRIPTION
Adding the axe spec to the Mossley theme turned up two core problems on every site: the footer logo and supporter logos had no alt text, and the events date field had no accessible name. Both fixed (alt from the site or supporter name, a locale key for the PlaceCal logo, aria-label from the existing Go to date key).

New spec/system/sites/accessibility_spec.rb runs axe over every page of a pink-themed site, the same sweep the two theme repos run. It skips one rule, color-contrast, because the core palette itself trips it: white on the pink primary (buttons, partner badge) measures 2.24:1 and the footer impressum 2.29:1 against 4.5:1. That is a design decision for every core theme and is recorded in the spec rather than fixed here. 8 examples green with RUN_SLOW_TESTS; the spec fails on image-alt and label without the fixes.