### PR TITLE
Bump theme pins: transdimension v0.3.14, mossley v0.1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,8 +73,8 @@ gem 'strong_migrations'           # Catch unsafe migrations before they reach pr
 # prebuilt, so the Dockerfile needs no extra build step. Bump the tag to
 # release a new version of an extension.
 group :extensions do
-  gem 'placecal-theme-mossley', github: 'geeksforsocialchange/placecal-theme-mossley', tag: 'v0.1.3'
-  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.3.13'
+  gem 'placecal-theme-mossley', github: 'geeksforsocialchange/placecal-theme-mossley', tag: 'v0.1.4'
+  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.3.14'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/geeksforsocialchange/placecal-theme-mossley.git
-  revision: 3d514ecb9b5e5d6a4a01984bfefa6ccb5f93b808
-  tag: v0.1.3
+  revision: a4d5eee37d7bfadb0838277c870436a87da4bc46
+  tag: v0.1.4
   specs:
-    placecal-theme-mossley (0.1.3)
+    placecal-theme-mossley (0.1.4)
       rails (>= 8.0)
 
 GIT
   remote: https://github.com/geeksforsocialchange/placecal-theme-transdimension.git
-  revision: 8d7c1e01f33b638031201ccf0cb91f919f5ac987
-  tag: v0.3.13
+  revision: dbb933996b7bea4e7386e233fdc09a8df6b9a075
+  tag: v0.3.14
   specs:
-    placecal-theme-transdimension (0.3.13)
+    placecal-theme-transdimension (0.3.14)
       rails (>= 8.0)
 
 GEM


### PR DESCRIPTION
TD drops its heading-order skip now core's byline and footer headings are fixed. Mossley follows the footer h2 selector, ships the artwork NOTICE and its own axe sweep. Both merged and tagged on their repos; pins bumped with the rake task.