### PR TITLE
Release drafter: hide internal work packages from the notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,7 +24,9 @@ categories:
 # Anything not matched by the categories above still shows under this heading.
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 change-title-escapes: '\<*_&'
-exclude-labels: [duplicate, "won't fix"]
+# `internal` marks work packages merged into a feature branch first: the
+# feature PR that lands them on main is the release note, not each package.
+exclude-labels: [duplicate, "won't fix", internal]
 
 version-resolver:
   major:
@@ -36,6 +38,9 @@ version-resolver:
   default: patch
 
 autolabeler:
+  - label: internal
+    title: ["/^WP \\d/i"]
+    branch: ["/^wp\\//i"]
   - label: enhancement
     title: ["/^feat/i", "/^feature/i", "/^add/i"]
     branch: ["/^feat/i", "/^feature/i", "/^add/i"]


### PR DESCRIPTION
The v0.29.0 draft lists all 58 work-package PRs that were merged into feature/td-extension before #3436 landed, because Release Drafter walks every PR reachable from main. Those PRs now carry an `internal` label, which this config excludes, and an autolabeler rule applies it to `WP n.n:` titles and `wp/` branches in future. #3436 is labelled enhancement, #3488 fix and #3487 maintenance, so the draft reads as three categorised entries plus renovate.