### PR TITLE
Bump placecal-theme-transdimension to v0.3.15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'strong_migrations'           # Catch unsafe migrations before they reach pr
 # release a new version of an extension.
 group :extensions do
   gem 'placecal-theme-mossley', github: 'geeksforsocialchange/placecal-theme-mossley', tag: 'v0.1.4'
-  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.3.14'
+  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.3.15'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/geeksforsocialchange/placecal-theme-transdimension.git
-  revision: dbb933996b7bea4e7386e233fdc09a8df6b9a075
-  tag: v0.3.14
+  revision: 24ad592c109c926c3369394b1c1098b3a27159b4
+  tag: v0.3.15
   specs:
-    placecal-theme-transdimension (0.3.14)
+    placecal-theme-transdimension (0.3.15)
       rails (>= 8.0)
 
 GEM


### PR DESCRIPTION
The homepage region filter now updates in place through a turbo frame instead of a Drive visit that repaints the whole page (theme PR #8). Deploys to staging on merge.