### PR TITLE
Vendor a judge-arch review skill and restate layer rules as negative examples

### DIFF
--- a/bin/setup-ai
+++ b/bin/setup-ai
@@ -26,6 +26,7 @@ link "$SRC/better-stimulus/agent.md"        "$ROOT/.claude/agents/better-stimulu
 
 # Skills (whole directory, scripts co-located)
 link "$SRC/rails-hotwire-driver"            "$ROOT/.claude/skills/rails-hotwire-driver"
+link "$SRC/judge-arch"                      "$ROOT/.claude/skills/judge-arch"
 
 # Hooks: register the RuboCop auto-correct PostToolUse hook in the local
 # .claude/settings.json (merged idempotently; settings.local.json is untouched).
@@ -52,6 +53,7 @@ AI tooling installed successfully!
 What you get (see doc/ai/plugins/README.md):
   - better-stimulus       agent  — StimulusJS best practices
   - rails-hotwire-driver  skill  — drive the running dev server to verify changes
+  - judge-arch            skill  — fresh-context architectural review of a change
   - rubocop-autocorrect   hook   — auto-fixes RuboCop after every Ruby edit
 
 Context for assistants stays in:
@@ -64,5 +66,6 @@ this script if the links go stale.
 To remove later:
   rm -f .claude/agents/better-stimulus.md
   rm -f .claude/skills/rails-hotwire-driver
+  rm -f .claude/skills/judge-arch
   # and delete the rubocop-autocorrect PostToolUse entry from .claude/settings.json
 EOF

--- a/doc/ai/plugins/README.md
+++ b/doc/ai/plugins/README.md
@@ -13,10 +13,11 @@ stale.
 
 ## What's here
 
-| Plugin                 | Type  | What it does                                                                                                                                                                                           | When it triggers                                       |
-| ---------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
-| `rails-hotwire-driver` | skill | Drive the running dev server from the terminal — log in via Devise, submit forms (CSRF handled), inspect Turbo Streams, read `development.log` by request id. The runtime half of the **verify loop**. | Verifying a server-rendered change actually works      |
-| `better-stimulus`      | agent | Opinionated StimulusJS best practices (Values API, mixins, late binding, Turbo teardown), adapted to PlaceCal's native-JS / importmap / `controllers/mixins/` setup.                                   | Writing, reviewing, or debugging a Stimulus controller |
+| Plugin                 | Type  | What it does                                                                                                                                                                                                                                                                   | When it triggers                                         |
+| ---------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| `rails-hotwire-driver` | skill | Drive the running dev server from the terminal — log in via Devise, submit forms (CSRF handled), inspect Turbo Streams, read `development.log` by request id. The runtime half of the **verify loop**.                                                                         | Verifying a server-rendered change actually works        |
+| `judge-arch`           | skill | Fresh-context architectural review of a diff against the four questions (boundary placement, data ownership, dependency direction, error handling) and PlaceCal's own layer rules, with a grep-test for web concerns leaking into domain code. Findings only, PASS when clean. | Before calling a non-trivial change done or opening a PR |
+| `better-stimulus`      | agent | Opinionated StimulusJS best practices (Values API, mixins, late binding, Turbo teardown), adapted to PlaceCal's native-JS / importmap / `controllers/mixins/` setup.                                                                                                           | Writing, reviewing, or debugging a Stimulus controller   |
 
 ## Provenance
 
@@ -33,6 +34,17 @@ we already have. Notably we skipped `rails-security-auditor` because Brakeman
 cover that ground, and `rails-simplifier` because its safe rules duplicate
 `/code-review` + `/simplify` while its opinionated refactors fight a mature
 codebase.
+
+`judge-arch` is adapted from Tech Fleet's
+[enterprise-software-AI-skills](https://github.com/techfleetworks/enterprise-software-AI-skills)
+(MIT). We took the review rubric and the fresh-context stance and rewrote the
+examples for Rails/Phlex; the mechanical gate script and its React/Supabase
+presets were left out because Brakeman, RuboCop, `strong_migrations` and the
+skill's grep-test already cover PlaceCal's layer rules. The rest of that
+collection (OWASP, test pyramid, ADRs, release safety, SRE, compliance, WCAG,
+browser support, usability) restates things PlaceCal already enforces
+specifically, so it was not adopted; the vendoring PR maps each one to where
+we already do it.
 
 ## Install
 

--- a/doc/ai/plugins/judge-arch/SKILL.md
+++ b/doc/ai/plugins/judge-arch/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: judge-arch
+description: >
+  Architectural review of a change, run in a fresh context. Use before
+  calling any non-trivial PlaceCal change done, before opening a PR, or when
+  asked to review a diff or branch for structural drift. Checks the change
+  against the four questions (boundary placement, data ownership, dependency
+  direction, error handling) and PlaceCal's own layer rules, with a grep-test
+  for web or view concerns leaking into models, queries, services and jobs.
+  Findings only: it never edits code, and it returns PASS when nothing is
+  wrong rather than inventing problems.
+---
+
+# judge-arch: the architectural judge
+
+You are a skeptical senior Rails engineer reviewing a change you did **not** write. Your
+job is to catch silent structural drift: the decisions that got made without anyone
+asking. Bad structure does not announce itself the way a bug does. The specs stay green
+and the feature works. This review is what makes it visible.
+
+`/code-review` hunts for correctness bugs and `/simplify` for cleanups. This skill covers
+the third thing: is the change in the right place, in the right shape.
+
+## Prime directives
+
+- **Ask for problems, not approval.** Do not open with what is good. An empty report is a
+  valid, good result. Do not manufacture findings to look thorough.
+- **Findings, not fixes.** Report what is wrong and the smallest fix. Do not edit code
+  during the review. The human decides what to act on.
+- **Where, not line noise.** Name the area a problem lives in (a controller, a model, a
+  component), not exhaustive file:line lists. Read like a colleague, not a linter.
+
+## 1. Scope the target
+
+1. If an area, path or flow was named (`judge-arch app/queries`), review that.
+2. Otherwise review the current change set: `git diff origin/main...HEAD` (fall back to
+   the working tree if there is no diff).
+
+Never review the whole repository unless explicitly asked. State in one line what you
+scoped to.
+
+## 2. Load PlaceCal's rules
+
+These are the standard. Read the ones the change touches:
+
+- `doc/adr/` for any decision the change is near (partners and places, the partner
+  decomposition, the admin redesign, the test-suite migration).
+- `doc/ai/prompts/` for the layer the change lives in (`controllers.md`, `views.md`,
+  `models.md`, `services.md`, `jobs.md`, `graphql.md`, `stimulus.md`, `tests.md`).
+- `doc/ai/context.md` and `AGENTS.md` for the always-on rules.
+- `doc/extensions.md` if the change touches a site theme or an extension engine.
+
+## 3. Review in a fresh context (required)
+
+Do not judge from the conversation that produced the code. That context makes you
+lenient and blind to what a newcomer would hit. Run the review as a **separate agent
+with no prior knowledge of the change**: give it the scoped diff, the rules above, and
+the rubric below, and have it return the findings in the output format.
+
+## 4. The rubric: the four questions
+
+For the scoped change, check each. The examples are PlaceCal's own layers.
+
+1. **Boundary placement.** Business rules (site scoping, visibility, date windows,
+   neighbourhood resolution) belong in `app/queries/`, `app/models/` or `app/services/`.
+   Red flags: a `where` chain or a visibility check written inline in a controller
+   action or a Phlex `view_template`; a workflow trapped in one controller so the
+   GraphQL resolver or the next controller must copy it.
+   ```ruby
+   # ❌ never: site scoping rebuilt in the controller
+   @partners = Partner.joins(:address).where(addresses: { neighbourhood_id: @site.neighbourhood_ids })
+   # ✅ always: the query object owns the rule, every caller gets the same answer
+   @partners = PartnersQuery.new(site: current_site).call
+   ```
+2. **Data ownership.** One writer per fact. Red flags: a value written in two places;
+   a denormalised count or cached label stored next to its source rows with no single
+   updater; a model writing into another model's table instead of through its
+   interface; an importer and an admin form both "fixing up" the same column.
+3. **Dependency direction.** Domain code must not know about the web. Models, query
+   objects, services and jobs must not reference `params`, `request`, `session`,
+   `cookies`, `current_user`, `view_context`, `helpers.`, or build HTML. Rendering
+   belongs in `app/components/` and `app/views/`; request context enters through
+   `Current` and through arguments.
+   ```ruby
+   # ❌ never: a model building markup
+   %(<span class='opening_times--day'>#{d}</span>).html_safe
+   # ✅ always: the model returns data, a component renders it
+   { day: d, opens: o, closes: c }   # then Components::OpeningTimes(times)
+   ```
+   **Run the grep-test** (section 5) as concrete evidence.
+4. **Error handling.** Every `rescue` must recover, retry, or report. Red flags: a
+   bare `rescue` returning `nil`, `[]` or `false` so the caller cannot tell "no data"
+   from "broken"; an importer swallowing a parse error without logging or a
+   `CalendarImporter::Exceptions` subclass; a new exception type nothing upstream
+   catches.
+   ```ruby
+   # ❌ never: parse failure indistinguishable from empty
+   rescue JSON::ParserError
+     []
+   # ✅ always: report it, then decide
+   rescue JSON::ParserError => e
+     Rails.logger.warn("Partner #{id} opening_times unparseable: #{e.message}")
+     []
+   ```
+
+Also flag **over-engineering** (an abstraction for a single caller; a change nobody
+asked for; a new service object wrapping one ActiveRecord call) and
+**under-engineering** (logic in the wrong layer; a duplicated block; a patch on a
+patch; absent error handling). Those are the two directions of drift.
+
+## 5. The grep-test (dependency direction, mechanical)
+
+Run this over the change and report any hit outside a known boundary as a
+dependency-direction violation with its location:
+
+```bash
+git diff origin/main...HEAD --name-only -- app/models app/queries app/services app/jobs \
+  | xargs grep -nE 'params\[|request\.|session\[|cookies|current_user|view_context|helpers\.|html_safe|content_tag|tag\.' 2>/dev/null
+```
+
+Known, accepted boundaries (not findings): `Site.find_by_request` reads `request.host`
+because site resolution _is_ the boundary; `Current` holds request-scoped state on
+purpose. Anything else is a finding.
+
+## 6. The "does it matter now?" test
+
+The critic always finds something. Before reporting a finding answer **"what breaks
+later if I ignore this?"** If you have a concrete answer (two totals will disagree; the
+GraphQL resolver must copy this; this cannot be unit-tested without a request), keep
+it. If the honest answer is "nothing, it is a speculative nicety", drop it. Precision
+over volume.
+
+## Output format
+
+Lead with the verdict line, then one block per violation, most severe first:
+
+```
+Architecture review: <PASS | N violation(s)>. Scoped to: <what>.
+
+### <the rule that was broken, stated as the title>
+**Where:** <area of the app: controller / model / component / query>
+**What breaks if ignored:** <the concrete future failure>
+**Smallest fix:** <the least invasive change that satisfies the rule>
+```
+
+End with a plain checklist of the fixes and nothing else. No summary paragraph, no
+encouragement. If clean: `Architecture review: PASS. Scoped to: <what>. No violations.`
+
+## Provenance
+
+The four questions, the fresh-context critic stance, and the findings-only output are
+adapted from Tech Fleet's `judge-arch` skill in
+[techfleetworks/enterprise-software-AI-skills](https://github.com/techfleetworks/enterprise-software-AI-skills)
+(MIT), itself adapted from the certificates.dev / Tech Fleet workshop "Who's Designing
+Your System? You, or Your Agent?". The mechanical gate script and React/Supabase
+presets from upstream were not vendored: PlaceCal's layer rules are checked by the
+grep-test above plus Brakeman, RuboCop and `strong_migrations` in CI.

--- a/doc/ai/prompts/controllers.md
+++ b/doc/ai/prompts/controllers.md
@@ -130,7 +130,43 @@ end
 - Use constraints for advanced routing
 - Keep routes RESTful
 
-Remember: Controllers should be thin coordinators. Business logic belongs in models or service objects.
+## Rules that must hold
+
+### No business rules in an action
+
+```ruby
+# ❌ never: the site-scoping rule lives in this one action, so the GraphQL
+# resolver and the next controller must copy it
+def index
+  @events = Event.joins(:address)
+                 .where(addresses: { neighbourhood_id: current_site.neighbourhood_ids })
+                 .where('dtstart >= ?', Time.current)
+end
+
+# ✅ always: the query object owns the rule; every caller gets the same answer
+def index
+  @events = EventsQuery.new(site: current_site).call(period: :future)
+end
+```
+
+Controllers coordinate: resolve the site, authorise, call the owning query or
+service, render. A `where` chain, a visibility check, or a date window written
+inline in an action is a violation.
+
+### Every action is authorised
+
+```ruby
+# ❌ never: relies on a before_action existing somewhere
+def destroy
+  @partner.destroy
+end
+
+# ✅ always: the policy is named at the point of use
+def destroy
+  authorize @partner
+  @partner.destroy
+end
+```
 
 ## MCP-Enhanced Capabilities
 

--- a/doc/ai/prompts/models.md
+++ b/doc/ai/prompts/models.md
@@ -115,4 +115,47 @@ Use MCP tools to:
 - Check association options and their performance implications
 - Reference database-specific features (PostgreSQL, MySQL, etc.)
 
-Remember: Focus on data integrity, performance, and following Rails conventions.
+## Rules that must hold
+
+### A model never builds HTML or reads the request
+
+```ruby
+# ❌ never: markup assembled in a model method
+def opening_times_html
+  %(<span class='opening_times--day'>#{day}</span>).html_safe
+end
+
+# ✅ always: the model returns data; a component in app/components/ renders it
+def opening_times
+  parsed.map { |t| { day: t['dayOfWeek'], opens: t['opens'], closes: t['closes'] } }
+end
+```
+
+`params`, `request`, `session`, `current_user`, `view_context`, `helpers.` and
+`html_safe` do not appear under `app/models/`. The one accepted boundary is
+`Site.find_by_request`, which exists to turn a request into a `Site`. Request
+scoped state enters through `Current` or through method arguments.
+
+### A rescue never hides a failure
+
+```ruby
+# ❌ never: the caller cannot tell "no opening times" from "corrupt JSON"
+rescue JSON::ParserError
+  []
+
+# ✅ always: report, then return the safe value
+rescue JSON::ParserError => e
+  Rails.logger.warn("Partner #{id} opening_times unparseable: #{e.message}")
+  []
+```
+
+### `safety_assured` needs a stated reason
+
+```ruby
+# ❌ never
+safety_assured { remove_column :partners, :legacy_slug }
+
+# ✅ always: the reason sits next to the bypass so the reviewer can check it
+# legacy_slug has been in ignored_columns since PR #3258, two deploys ago
+safety_assured { remove_column :partners, :legacy_slug }
+```

--- a/doc/ai/prompts/views.md
+++ b/doc/ai/prompts/views.md
@@ -211,6 +211,55 @@ end
 - Keyboard navigation and visible focus states
 - Sufficient colour contrast (WCAG AA — the suite has `axe-core-rspec` coverage)
 
-Remember: views are clean, typed, semantic Phlex focused on presentation.
-Business logic belongs in models, query objects (`app/queries/`), or services —
-not in views.
+## Rules that must hold
+
+Stated as forbidden/allowed pairs from this codebase, because "keep views thin"
+matches nothing.
+
+### No business rules in a view or component
+
+```ruby
+# ❌ never: site scoping or visibility rebuilt inside view_template
+def view_template
+  partners = Partner.joins(:address).where(addresses: { neighbourhood_id: site.neighbourhood_ids })
+  partners.each { |p| PartnerCard(p) }
+end
+
+# ✅ always: the query object owns the rule; the view receives the result as a prop
+prop :partners, ActiveRecord::Relation, reader: :private   # from PartnersQuery.new(site:).call
+def view_template
+  partners.each { |p| PartnerCard(p) }
+end
+```
+
+Business logic belongs in models, query objects (`app/queries/`), or services.
+A `where`, a date window, or a permission check inside `app/views/` or
+`app/components/` is a violation.
+
+### No user-facing string literals
+
+```ruby
+# ❌ never
+h2 { 'Upcoming events' }
+button { 'Clear filters' }
+
+# ✅ always
+h2 { t('directory.partners.show.upcoming_events') }
+button { t('admin.actions.clear_filters') }
+```
+
+### `safe()` is only ever the last expression in a block
+
+```ruby
+# ❌ never: the SafeValue is silently discarded
+div do
+  safe(SVG_ICON)
+  span { label }
+end
+
+# ✅ always: raw() writes to the buffer wherever it sits
+div do
+  raw safe(SVG_ICON)
+  span { label }
+end
+```


### PR DESCRIPTION
We're starting work with Tech Fleet, who maintain [enterprise-software-AI-skills](https://github.com/techfleetworks/enterprise-software-AI-skills): thirteen vendor-neutral Claude Code skills encoding senior engineering standards. This PR is the result of reading all of it against what PlaceCal already does. Two things were worth taking; the rest we already enforce in a more specific form, mapped below.

@mdenner1234 tagging you so you can see where each skill landed and where we already had the equivalent. Corrections welcome.

## What this PR adds

- **`doc/ai/plugins/judge-arch/`**: a fresh-context architectural review skill adapted from upstream `judge-arch`. Same four questions (boundary placement, data ownership, dependency direction, error handling), same findings-only stance, same "PASS when clean" rule. Examples rewritten for Rails and Phlex, rules loaded from `doc/adr/` and `doc/ai/prompts/`, and the grep-test tuned to our layers (`params`, `request`, `html_safe` etc. under `app/models`, `app/queries`, `app/services`, `app/jobs`). The upstream mechanical gate script and its React/Supabase presets were not vendored. Registered in `bin/setup-ai` and the plugins README.
- **Layer rules restated as negative examples** (the `arch-encode` idea: a principle like "keep controllers thin" matches nothing, a forbidden/allowed code pair does). The closing rules in `views.md`, `controllers.md` and `models.md` are now concrete pairs drawn from this codebase, including one real one: `Partner#opening_times` building HTML in a model.

## Where PlaceCal already covers each upstream skill

| Upstream skill | PlaceCal equivalent |
|---|---|
| `enterprise-architecture-standards` | Rails-specific layer rules per file in `doc/ai/prompts/`, the query-object pattern in `app/queries/`, and decisions such as `doc/adr/0014-decompose-the-partner-model.md` |
| `architectural-decision-records` | `doc/adr/`, 14 records since 0001, written for decisions big enough to need one rather than for every change |
| `owasp-secure-coding-bdd` | Brakeman gating CI in `test-and-deploy.yml`, Pundit policies in `app/policies/`, Devise, GraphQL `max_depth 10` / `max_complexity 1500` in `place_cal_schema.rb`, Renovate for dependencies |
| `comprehensive-test-strategy` | CI matrix of RSpec unit, RSpec system, Cucumber admin and Cucumber public suites; VCR for HTTP; the no-`sleep` rule in `tests.md`; flaky tests tracked as issues, not dismissed (#3341) |
| `release-deployment-safety` | `strong_migrations` runs on every `db:migrate` including the Kamal deploy (`models.md` documents the policy); a full staging environment; Release Drafter |
| `sre-operational-readiness` | AppSignal for errors, performance, logs and triggers |
| `compliance-data-lifecycle` | Partly. Privacy and terms pages are in the axe sweep; retention and audit logging are not written down as a standard |
| `judge-arch` | Vendored here |
| `arch-encode` | The negative-example rewrites here; per-layer scoping is done by having one prompt file per layer rather than nested `AGENTS.md` |
| `verifiable-quality-gates` | Not covered. Our custom gates (the RuboCop PostToolUse hook, `update-robots.yml`) have no test proving they can fail. This is the one upstream idea with a real gap behind it |
| `universal-accessibility-wcag` | `axe-core-rspec`: 11 directory pages with colour contrast enforced (`spec/system/directory/accessibility_spec.rb`), 9 core-theme site pages (`spec/system/sites/accessibility_spec.rb`, contrast skipped pending a palette fix), ~20 admin pages. The manual criteria axe can't see (keyboard, focus, meaningful text) are called out in `views.md` |
| `universal-browser-device-support` | Partly. No `browserslist`; the importmap/CDN notes in `context.md` cover the one Safari issue we've hit |
| `usability-ux-universal-design` | `doc/adr/0003` (UX reanalysis), `0010` (admin redesign), `0012` (design system) |

## Why not adopt the collection wholesale

The skills trigger on "EVERY feature" and would load ADR writing, threat modelling, SLO definition and a WCAG pass onto routine changes in a three-person Rails monolith. The specific versions above cost nothing per change and are enforced by CI rather than prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
