### PR TITLE
Fix importer rescue constant and tolerate missing Eventbrite venue

### DIFF
--- a/app/jobs/calendar_importer/calendar_importer_task.rb
+++ b/app/jobs/calendar_importer/calendar_importer_task.rb
@@ -74,7 +74,7 @@ class CalendarImporter::CalendarImporterTask
     active_event_uids << parsed_event.uid
 
     parsed_event.save_all_occurences
-  rescue CalendarImporter::EventResolver::Problem => e
+  rescue CalendarImporter::LocationResolver::Problem => e
     notices << e.message
   end
 

--- a/app/jobs/calendar_importer/events/eventbrite_event.rb
+++ b/app/jobs/calendar_importer/events/eventbrite_event.rb
@@ -22,8 +22,11 @@ module CalendarImporter::Events
       @event['url']
     end
 
+    # The venue only arrives via the `expand=venue` expansion. When Eventbrite
+    # omits it the key is absent entirely, and the SDK's `[]` raises rather
+    # than returning nil, so guard the lookup.
     def place
-      @place ||= @event['venue']
+      @place ||= @event.respond_to?(:venue) ? @event['venue'] : nil
     end
 
     def location

--- a/spec/jobs/calendar_importer/calendar_importer_task_spec.rb
+++ b/spec/jobs/calendar_importer/calendar_importer_task_spec.rb
@@ -175,6 +175,23 @@ RSpec.describe CalendarImporter::CalendarImporterTask do
         end.to raise_error(CalendarImporter::Exceptions::InvalidResponse, /Source responded with invalid JSON/)
       end
     end
+
+    it "records a location problem as a notice instead of failing the import" do
+      calendar = build(:calendar, strategy: "event")
+      importer_task = described_class.new(calendar, Time.zone.today, true)
+
+      parsed_event = instance_double(
+        CalendarImporter::EventResolver,
+        is_private?: false,
+        has_no_occurences?: false,
+        determine_online_location: nil
+      )
+      allow(parsed_event).to receive(:determine_location_for_strategy)
+        .and_raise(CalendarImporter::LocationResolver::Problem, "N/A")
+
+      expect { importer_task.send(:process_event, parsed_event) }.not_to raise_error
+      expect(importer_task.send(:notices)).to eq(["N/A"])
+    end
   end
 
   describe "generic iCal import" do

--- a/spec/jobs/calendar_importer/events/eventbrite_event_spec.rb
+++ b/spec/jobs/calendar_importer/events/eventbrite_event_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CalendarImporter::Events::EventbriteEvent do
+  subject(:event) { described_class.new(sdk_event) }
+
+  # Mirror production: the parser hands us SDK attribute objects, whose `[]`
+  # raises NoMethodError for keys that are absent from the payload.
+  let(:sdk_event) { EventbriteSDK::Resource::Attributes.new(payload) }
+
+  let(:base_payload) do
+    {
+      "id" => "123",
+      "name" => { "text" => "Queer Lit Social" },
+      "description" => { "html" => "<p>Books</p>" },
+      "url" => "https://www.eventbrite.co.uk/e/123",
+      "start" => { "utc" => "2026-10-01T18:00:00Z" },
+      "end" => { "utc" => "2026-10-01T20:00:00Z" },
+      "online_event" => false
+    }
+  end
+
+  context "when the venue expansion is present" do
+    let(:payload) do
+      base_payload.merge(
+        "venue" => {
+          "name" => "Refuge",
+          "address" => {
+            "address_1" => "Oxford Street",
+            "address_2" => "",
+            "city" => "Manchester",
+            "region" => "",
+            "postal_code" => "M60 7HA"
+          }
+        }
+      )
+    end
+
+    it "builds the location from the venue" do
+      expect(event.location).to eq("Refuge, Oxford Street, Manchester, M60 7HA")
+    end
+  end
+
+  context "when Eventbrite omits the venue key entirely" do
+    let(:payload) { base_payload }
+
+    it "treats the event as having no place" do
+      expect(event.place).to be_nil
+    end
+
+    it "returns no location instead of raising" do
+      expect { event.location }.not_to raise_error
+      expect(event.location).to be_nil
+    end
+  end
+
+  context "when the venue key is present but null" do
+    let(:payload) { base_payload.merge("venue" => nil) }
+
+    it "returns no location" do
+      expect(event.location).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Since 15:02 UTC on 7 Sep every Eventbrite calendar import has been failing with `NameError: uninitialized constant CalendarImporter::EventResolver::Problem` (AppSignal prod #353, staging #147).

Two bugs stacked:

1. `CalendarImporterTask#process_event` rescues `CalendarImporter::EventResolver::Problem`, but that class moved to `LocationResolver` when EventResolver was split (d5b92e15, March). Ruby resolves rescue constants lazily, so this only fires when an exception actually reaches the clause, and when it does the NameError replaces the real error.
2. The real error: Eventbrite has started returning events with no `venue` key at all. `EventbriteSDK::Resource::Attributes#[]` is `public_send(key)`, so a missing key raises `NoMethodError` instead of returning nil. Calendars 110 and 275 both hit this on prod.

## Fix

- Rescue `CalendarImporter::LocationResolver::Problem`, the class that actually exists.
- `EventbriteEvent#place` checks `respond_to?(:venue)` before reading it, so events without a venue import with no place rather than killing the whole calendar.

## Tests

- New `eventbrite_event_spec.rb` builds the event on a real `EventbriteSDK::Resource::Attributes` object. The "venue key absent" examples fail on `main` with the exact production error and pass here.
- New task spec proves a `LocationResolver::Problem` is recorded as a notice instead of raising.

```
24 examples, 0 failures
```
(`eventbrite_event_spec`, `calendar_importer_task_spec`, `event_resolver_strategy_spec`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
