### PR TITLE
Raise Kamal container memory caps

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -9,12 +9,12 @@ image: geeksforsocialchange/placecal
 servers:
   web:
     options:
-      memory: 512m
+      memory: 1g
   job_worker:
     cmd: bin/rails jobs:work
     proxy: false
     options:
-      memory: 512m
+      memory: 768m
 
 proxy:
   ssl:
@@ -81,7 +81,7 @@ accessories:
     directories:
       - data:/var/lib/postgresql
     options:
-      memory: 512m
+      memory: 1g
 
 asset_path: /rails/public/assets
 


### PR DESCRIPTION
## Problem

The recurring `ActiveRecord::ConnectionNotEstablished` / `ActiveRecord::ConnectionFailed` incidents in AppSignal (prod #254, #296, #299, #310, #334, #351, #352; staging #223 to #228) are not app bugs. They are Postgres being OOM-killed by the 512m container cgroup and going into crash recovery for ~30s.

Verified via `journalctl` on both hosts, 31 Aug to 7 Sep:

| Container | OOM kills (prod) |
|---|---|
| placecal-web | 22 |
| placecal-db | 7 |
| placecal-job_worker | 2 |

Prod web is at ~457MB of 512MB three hours after a reboot, so it keeps happening. Staging postgres was killed the same way at 18:53 on 7 Sep.

## Change

| Role | Before | After |
|---|---|---|
| web | 512m | 1g |
| job_worker | 512m | 768m |
| db accessory | 512m | 1g |

Prod has 7.7GB RAM with ~5GB unused. Staging has 3.8GB and no swap; 1g + 768m + 1g plus alloy (~250MB) and kamal-proxy (~90MB) fits.

## Deploy note

The web and worker limits apply on the next normal deploy. The db accessory is not recreated by `kamal deploy`, so after this merges it needs:

```
kamal accessory reboot db -d staging
kamal accessory reboot db -d production
```

Each is a brief DB outage while the container is recreated (data is on the `data` volume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
