### PR TITLE
Fix slow site pages: pass the site's partner ids to the events query as a literal list

### DIFF
--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -201,53 +201,51 @@ class EventsQuery
   # an event a site partner puts on somewhere else, which is how the partner
   # page and the tag filter already count it.
   def events_for_site
-    partners_scope = PartnersQuery.new(site: @site).call.reorder(nil)
-
     if @site.tags.any?
-      events_for_tagged_site(partners_scope)
+      events_for_tagged_site(site_partner_ids)
     else
-      events_for_untagged_site(partners_scope)
+      events_for_untagged_site(site_partner_ids)
     end
   end
 
-  # For sites without tags: use subquery instead of materializing partners
-  def events_for_untagged_site(partners_scope)
+  # The site's partner ids, fetched once per query object and handed to
+  # Postgres as a literal list. As a subquery the planner hashed the set and
+  # scanned every future event for each count: 600ms against 12ms on
+  # production data, four counts per events page. Ids only, never rows.
+  def site_partner_ids
+    @site_partner_ids ||= PartnersQuery.new(site: @site).call.reorder(nil).except(:includes).pluck(:id)
+  end
+
+  # For sites without tags: partner events plus anything at a site address.
+  def events_for_untagged_site(partner_ids)
     site_neighbourhood_ids = @site.owned_neighbourhood_ids
-    partner_subquery = partners_scope.select(:id)
 
     base = Event.left_joins(:address)
-    base.where(organiser_id: partner_subquery)
-        .or(base.where(place_id: partner_subquery))
+    base.where(organiser_id: partner_ids)
+        .or(base.where(place_id: partner_ids))
         .or(base.where(addresses: { neighbourhood_id: site_neighbourhood_ids }))
   end
 
   # For sites with tags: events organised by, or hosted at, a partner in the
-  # site scope, plus the legacy venue match. The partner set stays in the
-  # database as a subquery, so a tag-only site does not load every partner
-  # row on every events request (#3368).
-  def events_for_tagged_site(partners_scope)
-    partner_subquery = partners_scope.select(:id)
+  # site scope, plus the legacy venue match.
+  def events_for_tagged_site(partner_ids)
+    return Event.none if partner_ids.empty?
+
     base = Event.left_joins(:address)
-    base.where(organiser_id: partner_subquery)
-        .or(base.where(place_id: partner_subquery))
-        .or(base.where(legacy_venue_match_sql(partners_scope)))
+    base.where(organiser_id: partner_ids)
+        .or(base.where(place_id: partner_ids))
+        .or(base.where(legacy_venue_match_sql(partner_ids)))
   end
 
   # Legacy venue matching, from 2024 (commit 5b90f19), for events whose place
   # was never set: an event counts as happening at a partner when its address
-  # street line is the partner's name and the postcodes agree.
-  #
-  # This one interpolates the partner scope as raw SQL, so it strips the
-  # preloads and the ordering first: with `includes` still on the relation, a
-  # future `where` referencing an included table would flip Rails into eager
-  # loading and emit a multi-column SELECT, which an IN (...) cannot take. A
-  # subquery wants neither preloads nor an ORDER BY anyway.
-  def legacy_venue_match_sql(partners_scope)
-    partner_subquery = partners_scope.except(:includes, :order).select(:id)
+  # street line is the partner's name and the postcodes agree. Ids are cast
+  # to integers again before interpolation.
+  def legacy_venue_match_sql(partner_ids)
     <<~SQL.squish
       EXISTS (SELECT 1 FROM partners venue_partners
         INNER JOIN addresses venue_addresses ON venue_addresses.id = venue_partners.address_id
-        WHERE venue_partners.id IN (#{partner_subquery.to_sql})
+        WHERE venue_partners.id IN (#{partner_ids.map(&:to_i).join(',')})
         AND lower(venue_partners.name) = lower(addresses.street_address) AND lower(venue_addresses.postcode) = lower(addresses.postcode))
     SQL
   end
@@ -276,7 +274,7 @@ class EventsQuery
   def filter_by_tag(events, tag_id)
     return events if tag_id.blank?
 
-    partner_ids = PartnerTag.where(tag_id: tag_id).select(:partner_id)
+    partner_ids = PartnerTag.where(tag_id: tag_id).pluck(:partner_id)
     events.where(organiser_id: partner_ids).or(events.where(place_id: partner_ids))
   end
 

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -847,18 +847,41 @@ RSpec.describe EventsQuery do
       expect(partner_set_queries).to be_empty
     end
 
-    # The legacy venue clause is raw SQL, so it interpolates the partner scope
-    # with to_sql. PartnersQuery#call carries includes; if a future where
-    # clause ever referenced an included table Rails would switch to eager
-    # loading and emit a multi-column SELECT, which an IN (...) cannot take.
-    it "interpolates a single-column partner subquery even from an eager-loading scope" do
-      scope = PartnersQuery.new(site: tag_only_site).call.references(:addresses)
-      expect(scope).to be_eager_loading
+    # The partner set reaches Postgres as a literal id list rather than a
+    # subquery: with a subquery the planner hashed the set and scanned every
+    # future event for each count (600ms against 12ms on production data).
+    it "passes the site's partner ids to the events query as a literal list" do
+      sql = described_class.new(site: tag_only_site, day: today).send(:base_scope).to_sql
 
-      sql = described_class.new(site: tag_only_site, day: today).send(:legacy_venue_match_sql, scope)
+      expect(sql).to include(%("events"."organiser_id" = #{tagged_partner.id}))
+      expect(sql).to include(%("events"."place_id" = #{tagged_partner.id}))
+      expect(sql).to include(%(venue_partners.id IN (#{tagged_partner.id})))
+      expect(sql).not_to include("IN (SELECT")
+    end
 
-      expect(sql).to include('IN (SELECT DISTINCT "partners"."id" FROM')
-      expect(sql).not_to include('"addresses"."id" AS')
+    it "fetches the partner ids once per query object" do
+      query = described_class.new(site: tag_only_site, day: today)
+      queries = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        queries << payload[:sql] unless payload[:cached]
+      end
+
+      begin
+        query.future_count
+        query.next_7_days_count
+        query.monthly_count
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(queries.count { |q| q.include?('FROM "partners"') }).to eq(1)
+    end
+
+    it "returns nothing for a tagged site with no partners" do
+      empty_site = create(:site, slug: "empty-tagged")
+      empty_site.tags << create(:partnership, name: "Nobody")
+
+      expect(described_class.new(site: empty_site, day: today).call(period: "future")).to be_empty
     end
   end
 end


### PR DESCRIPTION
On staging with a production clone the Trans Dimension events page took 3.6 to 5.7 seconds and the homepage 2 seconds. Profiling in-process showed the events scope's COUNT(*) running three times at about 520ms each plus the listing itself at 400ms, all on the same shape of query.

The cause is the round-three change that kept the site's partner set in SQL as subqueries: Postgres hashes each subquery and sequentially scans every future event, so the organiser and place indexes never get used. Measured on staging, the same count is 599ms as subqueries and 12ms with the partner ids passed as a literal list (31ms keeping the legacy venue match, which adds no events on the Trans Dimension data).

EventsQuery now plucks the site's partner ids once per query object and passes them literally, for tagged and neighbourhood sites alike; the legacy venue match takes the same list; the region filter plucks its partner ids the same way; a tagged site with no partners short-circuits to none. Ids only, never partner rows, which the existing spec still asserts. New specs pin the literal-list shape, the single partner fetch across the three counts, and the empty case.

Verified after deploy to staging by re-timing the same routes (figures in the PR conversation).
