### PR TITLE
Fix slow partners page: match the neighbourhood subtree by subquery, not a 13k-id list

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -195,6 +195,22 @@ class Site < ApplicationRecord
       .flatten
   end
 
+  # The site's neighbourhoods and every descendant, as a relation rather than
+  # an array of ids. Meant to be embedded as a subquery: a site anchored to a
+  # large area (a whole country's subtree is 13,000-odd rows) otherwise
+  # serialises a five-figure id list into every partner query, which cost
+  # ~440ms and 180KB of SQL per request. As a subquery Postgres resolves the
+  # subtree from the ancestry path itself. See PartnersQuery#in_site_neighbourhoods_sql.
+  #
+  # @return [ActiveRecord::Relation<Neighbourhood>] empty when the site has none
+  def owned_neighbourhoods_subtree
+    nodes = neighbourhoods.select(:id, :ancestry).to_a
+    return Neighbourhood.none if nodes.empty?
+
+    nodes.map { |node| Neighbourhood.subtree_of(node) }
+         .reduce { |relation, subtree| relation.or(subtree) }
+  end
+
   # Whether a site shows News in its nav is derived from this count (#3368 D6),
   # so every page of every site runs it. Memoised per instance for the request
   # and cached across requests for ten minutes.

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -260,11 +260,11 @@ class PartnersQuery
   # has no partners.
   def build_base_scope
     return Partner.visible if @site.nil?
-    return Partner.none if site_neighbourhood_ids.empty? && site_tag_ids.empty?
+    return Partner.none if !site_has_neighbourhoods? && site_tag_ids.empty?
 
     scope = Partner.visible
     scope = scope.joins(:tags).where(tags: { id: site_tag_ids }) if site_tag_ids.any?
-    scope = scope.left_joins(:address, :service_areas).where(in_site_neighbourhoods_sql) if site_neighbourhood_ids.any?
+    scope = scope.left_joins(:address, :service_areas).where(in_site_neighbourhoods_sql) if site_has_neighbourhoods?
     scope.distinct
   end
 
@@ -278,23 +278,13 @@ class PartnersQuery
   # neighbourhood (e.g. "Manchester" the district) includes partners living
   # in its wards, not just those assigned to the area node itself.
   def filter_by_neighbourhood(partners, neighbourhood_id)
-    ids = neighbourhood_subtree_ids(neighbourhood_id)
-    return partners.none if ids.empty?
+    node = Neighbourhood.find_by(id: neighbourhood_id)
+    return partners.none unless node
 
     partners
       .left_joins(:address, :service_areas)
-      .where(
-        'addresses.neighbourhood_id IN (:ids) OR service_areas.neighbourhood_id IN (:ids)',
-        ids: ids
-      )
+      .where(in_neighbourhood_subtree_sql(Neighbourhood.subtree_of(node)))
       .distinct
-  end
-
-  # @return [Array<Integer>] the neighbourhood id plus all descendant ids, or
-  #   [] when the id is blank/unknown — so an invalid filter matches nothing
-  #   rather than raising on a non-integer value passed to an integer column.
-  def neighbourhood_subtree_ids(neighbourhood_id)
-    Neighbourhood.find_by(id: neighbourhood_id)&.subtree_ids || []
   end
 
   def filter_by_tag(partners, tag_id)
@@ -325,14 +315,25 @@ class PartnersQuery
   # ===================
 
   def in_site_neighbourhoods_sql
-    [
-      'addresses.neighbourhood_id IN (:ids) OR service_areas.neighbourhood_id IN (:ids)',
-      { ids: site_neighbourhood_ids }
-    ]
+    in_neighbourhood_subtree_sql(@site.owned_neighbourhoods_subtree)
   end
 
-  def site_neighbourhood_ids
-    @site_neighbourhood_ids ||= @site.owned_neighbourhood_ids
+  # Match a partner whose address or service area sits anywhere in +subtree+,
+  # embedding it as a subquery so the subtree stays in the database rather than
+  # arriving as a literal id list. +subtree+ is a Neighbourhood relation built
+  # from trusted records (site or dropdown selection), never user input.
+  #
+  # @param subtree [ActiveRecord::Relation<Neighbourhood>]
+  # @return [String] a WHERE fragment
+  def in_neighbourhood_subtree_sql(subtree)
+    ids = subtree.select(:id).to_sql
+    "addresses.neighbourhood_id IN (#{ids}) OR service_areas.neighbourhood_id IN (#{ids})"
+  end
+
+  def site_has_neighbourhoods?
+    return @site_has_neighbourhoods if defined?(@site_has_neighbourhoods)
+
+    @site_has_neighbourhoods = @site.neighbourhoods.exists?
   end
 
   def site_tag_ids

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -447,4 +447,31 @@ RSpec.describe Site, type: :model do
       expect(other.news_article_count).to eq(0)
     end
   end
+
+  describe "#owned_neighbourhoods_subtree" do
+    let(:site) { create(:site) }
+    let(:district) { create(:millbrook_district) }
+    let(:ward) { create(:riverside_ward, parent: district) }
+
+    it "is empty for a site with no neighbourhoods" do
+      expect(site.owned_neighbourhoods_subtree).to be_empty
+    end
+
+    it "returns the site's neighbourhoods and their descendants" do
+      ward
+      site.neighbourhoods << district
+
+      ids = site.owned_neighbourhoods_subtree.pluck(:id)
+
+      expect(ids).to include(district.id, ward.id)
+    end
+
+    it "matches owned_neighbourhood_ids without materialising the id list" do
+      ward
+      site.neighbourhoods << district
+
+      expect(site.owned_neighbourhoods_subtree.pluck(:id).sort).to eq(site.owned_neighbourhood_ids.sort)
+      expect(site.owned_neighbourhoods_subtree.to_sql).to include('"neighbourhoods"."ancestry" LIKE')
+    end
+  end
 end

--- a/spec/queries/partners_query_spec.rb
+++ b/spec/queries/partners_query_spec.rb
@@ -93,6 +93,33 @@ RSpec.describe PartnersQuery do
       end
     end
 
+    context "when the site is anchored to a large area" do
+      let(:district) { create(:millbrook_district) }
+      let(:ward) { create(:riverside_ward, parent: district) }
+      let!(:partner_in_ward) do
+        create(:partner, address: create(:address, neighbourhood: ward))
+      end
+      let(:area_site) { create(:site) }
+
+      before { area_site.neighbourhoods << district }
+
+      # The subtree reaches Postgres as a subquery, never a literal id list: a
+      # country-anchored site otherwise serialised ~13,000 ids into 180KB of
+      # SQL on every request. See Site#owned_neighbourhoods_subtree.
+      it "matches the neighbourhood subtree with a subquery, not an id list" do
+        sql = described_class.new(site: area_site).call.to_sql
+
+        expect(sql).to include('IN (SELECT "neighbourhoods"."id" FROM "neighbourhoods"')
+        expect(sql).to match(%r{"neighbourhoods"\."ancestry" LIKE '[\d/]+/%'})
+      end
+
+      it "still returns partners in the area's descendants" do
+        results = described_class.new(site: area_site).call
+
+        expect(results).to include(partner_in_ward)
+      end
+    end
+
     context "with an unknown or invalid neighbourhood filter" do
       before do
         address = create(:address, neighbourhood: neighbourhood)


### PR DESCRIPTION
Follow-up to the events fix (#3511). On staging with a production clone the Trans Dimension partners page took ~1.9s warm and the site scope alone ~570ms.

The cause: the site is anchored to the four UK country neighbourhoods, and `Site#owned_neighbourhood_ids` expands them to every descendant, 13,017 ids, which `PartnersQuery` serialised into an `addresses.neighbourhood_id IN (...)` list. That is a 181KB SQL string built in Ruby and re-parsed by Postgres on every partners and events request. The check task actually wants a *single* country neighbourhood, whose UK subtree is the same size, so this is not a data problem: any nationally-anchored site hits it.

`Site#owned_neighbourhoods_subtree` now returns the subtree as a Neighbourhood relation (built from the ancestry path via the gem's `subtree_of`), and the partners scope embeds it as a subquery for both the site scope and the neighbourhood-filter dropdown. Same joins, same semantics: verified on staging that it returns the identical 13,017-id set and the identical 108 partners. The SQL drops from 181KB to ~260 bytes and the base scope from 242ms to 89ms in-process; Postgres resolves the subtree with a 9ms scan of the small neighbourhoods table.

`owned_neighbourhood_ids` stays for the array callers (article, calendar, the events untagged path); only the partners hot path moved to the subquery. New specs pin the subquery shape (no id list) and that the subtree still matches `owned_neighbourhood_ids`. 282 examples across queries, site, article, partners/events requests and the directory system specs pass; rubocop clean.

To verify: after deploy to staging, re-time /partners and /events on the Trans Dimension site (figures to follow in the conversation).