### PR TITLE
Fix slow events page: build the neighbourhood dropdown without loading the whole subtree

### DIFF
--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -148,12 +148,12 @@ class EventsQuery
   def neighbourhoods_with_counts(period: 'future', tag_id: nil)
     return [] unless @site
 
-    all_descendants = @site.neighbourhoods.flat_map { |n| n.descendants.to_a }
-    return [] if all_descendants.empty?
+    site_root_ids = @site.neighbourhoods.pluck(:id)
+    return [] if site_root_ids.empty?
 
     events = apply_period(filter_by_tag(base_scope, tag_id), period)
 
-    # Count events per leaf neighbourhood (single query)
+    # Events counted against the neighbourhood they happen in (single query)
     raw_counts = events
                  .left_joins(:address, organiser: :address)
                  .where('COALESCE(addresses.neighbourhood_id, addresses_partners.neighbourhood_id) IS NOT NULL')
@@ -161,14 +161,7 @@ class EventsQuery
                  .distinct
                  .count
 
-    # Build parent→children map from ancestry data already in memory,
-    # then compute subtree counts without extra DB queries
-    subtree_counts = subtree_counts_from_ancestry(all_descendants, raw_counts)
-
-    all_descendants
-      .select { |n| (subtree_counts[n.id] || 0).positive? }
-      .sort_by(&:name)
-      .map { |n| { neighbourhood: n, count: subtree_counts[n.id] } }
+    dropdown_neighbourhoods(raw_counts, site_root_ids)
   end
 
   # Whether the given event appears on this site — same rules as the event
@@ -331,29 +324,32 @@ class EventsQuery
     end
   end
 
-  # Compute subtree event counts using in-memory ancestry data (no extra queries).
-  # Builds a parent→children map, then propagates leaf counts upward.
-  def subtree_counts_from_ancestry(descendants, raw_counts)
-    ids = descendants.to_set(&:id)
-    children_map = Hash.new { |h, k| h[k] = [] }
-    roots = []
+  # The neighbourhood dropdown: every neighbourhood with events in its subtree,
+  # each carrying that subtree's event count, sorted by name.
+  #
+  # Only the neighbourhoods that have events and their ancestors can carry a
+  # non-zero count, so we load just those rather than every descendant of the
+  # site. A country-anchored site has ~13,000 descendants; loading them all to
+  # fill a handful-long dropdown cost ~2s a request. Entries are kept to strict
+  # descendants of the site's own neighbourhoods, so the anchor nodes are
+  # excluded, matching the previous descendants-only behaviour.
+  #
+  # @param raw_counts [Hash{Integer=>Integer}] event count per neighbourhood id
+  # @param site_root_ids [Array<Integer>] the site's own neighbourhood ids
+  # @return [Array<Hash>] { neighbourhood:, count: } sorted by name
+  def dropdown_neighbourhoods(raw_counts, site_root_ids)
+    return [] if raw_counts.empty?
 
-    descendants.each do |n|
-      if n.parent_id && ids.include?(n.parent_id)
-        children_map[n.parent_id] << n.id
-      else
-        roots << n.id
-      end
-    end
+    event_hoods = Neighbourhood.where(id: raw_counts.keys).to_a
+    candidate_ids = (raw_counts.keys + event_hoods.flat_map(&:ancestor_ids)).uniq
 
-    counts = {}
-    # Post-order traversal: compute children first, then sum into parent
-    compute = lambda do |id|
-      own = raw_counts[id] || 0
-      child_sum = children_map[id].sum { |cid| compute.call(cid) }
-      counts[id] = own + child_sum
+    Neighbourhood.where(id: candidate_ids).order(:name).filter_map do |node|
+      next unless (node.ancestor_ids & site_root_ids).any?
+
+      # An event counts towards a node when the node is an ancestor-or-self of
+      # the neighbourhood the event is in, i.e. the event sits in its subtree.
+      count = event_hoods.sum { |h| h.path_ids.include?(node.id) ? raw_counts[h.id] : 0 }
+      { neighbourhood: node, count: count } if count.positive?
     end
-    roots.each { |id| compute.call(id) }
-    counts
   end
 end

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -549,6 +549,34 @@ RSpec.describe EventsQuery do
         expect(result).to be_empty
       end
     end
+
+    # The dropdown lists only neighbourhoods with events and their ancestors, so
+    # it must not load every descendant of the site's territory. A site anchored
+    # to a district with many empty wards but events in one ward returns just
+    # that ward, having loaded a bounded set of neighbourhood rows, not the lot.
+    context "when the site's territory is large but few neighbourhoods have events" do
+      let(:district) { site.primary_neighbourhood }
+      let(:active_ward) { create(:neighbourhood, name: "Active Ward", unit: "ward", parent: district) }
+      let(:address) { create(:address, neighbourhood: active_ward) }
+      let(:partner) do
+        p = create(:partner, address: address)
+        p.service_areas << create(:service_area, neighbourhood: active_ward)
+        p
+      end
+
+      before do
+        create_list(:neighbourhood, 15, unit: "ward", parent: district)
+        create_list(:future_event, 2, organiser: partner, address: address)
+      end
+
+      it "returns only the event-bearing ward, not the empty siblings" do
+        query = described_class.new(site: site, day: today)
+        result = query.neighbourhoods_with_counts(period: "future")
+
+        expect(result.map { |r| r[:neighbourhood].id }).to contain_exactly(active_ward.id)
+        expect(result.first[:count]).to eq(2)
+      end
+    end
   end
 
   describe "#call with neighbourhood_id filter" do


### PR DESCRIPTION
Third of the Trans Dimension performance fixes, after #3511 (events counts) and #3512 (partners scope). Those two left the events page still around 2s, and profiling on staging showed why: a single EventFilter render took 1009ms, and the query behind it, EventsQuery#neighbourhoods_with_counts, took 2076ms on its own.

The cause is the same root as the other two. The method did:

    all_descendants = @site.neighbourhoods.flat_map { |n| n.descendants.to_a }

which for a site anchored to the four UK country neighbourhoods loads ~13,000 Neighbourhood objects into Ruby, builds a tree over them, and walks it, all to populate a dropdown that only ever lists the handful of neighbourhoods that actually have events. The partners page's equivalent never did this (298ms), which is why only events was pathological.

It now loads only the neighbourhoods that have events plus their ancestors, keeps them to strict descendants of the site's own neighbourhoods (excluding the anchor nodes, matching the old behaviour), and sums each subtree count directly from the event neighbourhoods' ancestry paths. The old post-order traversal helper is gone. Same dropdown entries, same counts: the existing county/district/ward and leaf-level specs pass unchanged, plus a new spec that empty sibling neighbourhoods are not listed.

194 examples across queries, the events request spec, the filter component spec and the directory system specs pass; rubocop clean.

To verify: after deploy to staging, re-time /events on the Trans Dimension site (figures to follow in the conversation).