### PR TITLE
Refactor: split the query objects by responsibility

### DIFF
--- a/app/queries/event_neighbourhood_counts.rb
+++ b/app/queries/event_neighbourhood_counts.rb
@@ -1,23 +1,16 @@
 # frozen_string_literal: true
 
-# The neighbourhood filter dropdown for a site's events listing: every
-# neighbourhood that has events somewhere in its subtree, each carrying that
-# subtree's event count, sorted by name.
-#
-# Given an already period- and region-filtered events relation, it counts the
-# events per neighbourhood and rolls those up to the ancestors within the
-# site's own territory. Extracted from EventsQuery to keep that object focused
-# on selecting events (app/queries, single responsibility).
+# The neighbourhood filter dropdown for a site's events: every neighbourhood
+# with events in its subtree, each with that subtree's count, sorted by name.
+# Given a period- and region-filtered events relation, rolls the counts up to
+# the ancestors within the site's own territory.
 class EventNeighbourhoodCounts
-  # @param scope [ActiveRecord::Relation<Event>] the events to count, already
-  #   filtered by period and any region
-  # @param site [Site] the site whose neighbourhoods bound the dropdown
   def initialize(scope:, site:)
     @scope = scope
     @site = site
   end
 
-  # @return [Array<Hash>] { neighbourhood: Neighbourhood, count: Integer }
+  # @return [Array<Hash>] { neighbourhood:, count: }
   def call
     site_root_ids = @site.neighbourhoods.pluck(:id)
     return [] if site_root_ids.empty?
@@ -27,9 +20,7 @@ class EventNeighbourhoodCounts
 
   private
 
-  # Events counted against the neighbourhood they happen in (single query).
-  #
-  # @return [Hash{Integer=>Integer}] event count per neighbourhood id
+  # Events per neighbourhood they happen in, in one query.
   def raw_counts
     @scope
       .left_joins(:address, organiser: :address)
@@ -39,16 +30,11 @@ class EventNeighbourhoodCounts
       .count
   end
 
-  # Only the neighbourhoods that have events and their ancestors can carry a
-  # non-zero count, so we load just those rather than every descendant of the
-  # site. A country-anchored site has ~13,000 descendants; loading them all to
-  # fill a handful-long dropdown cost ~2s a request. Entries are kept to strict
-  # descendants of the site's own neighbourhoods, so the anchor nodes are
-  # excluded, matching the previous descendants-only behaviour.
-  #
-  # @param raw_counts [Hash{Integer=>Integer}] event count per neighbourhood id
-  # @param site_root_ids [Array<Integer>] the site's own neighbourhood ids
-  # @return [Array<Hash>] { neighbourhood:, count: } sorted by name
+  # Only neighbourhoods with events and their ancestors can carry a count, so
+  # load just those, not every descendant of the site: a country-anchored site
+  # has ~13,000 descendants and loading them all to fill a short dropdown cost
+  # ~2s. Kept to strict descendants of the site's neighbourhoods, so the anchor
+  # nodes are excluded, as before.
   def dropdown_neighbourhoods(raw_counts, site_root_ids)
     return [] if raw_counts.empty?
 
@@ -58,8 +44,6 @@ class EventNeighbourhoodCounts
     Neighbourhood.where(id: candidate_ids).order(:name).filter_map do |node|
       next unless (node.ancestor_ids & site_root_ids).any?
 
-      # An event counts towards a node when the node is an ancestor-or-self of
-      # the neighbourhood the event is in, i.e. the event sits in its subtree.
       count = event_hoods.sum { |h| h.path_ids.include?(node.id) ? raw_counts[h.id] : 0 }
       { neighbourhood: node, count: count } if count.positive?
     end

--- a/app/queries/event_neighbourhood_counts.rb
+++ b/app/queries/event_neighbourhood_counts.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# The neighbourhood filter dropdown for a site's events listing: every
+# neighbourhood that has events somewhere in its subtree, each carrying that
+# subtree's event count, sorted by name.
+#
+# Given an already period- and region-filtered events relation, it counts the
+# events per neighbourhood and rolls those up to the ancestors within the
+# site's own territory. Extracted from EventsQuery to keep that object focused
+# on selecting events (app/queries, single responsibility).
+class EventNeighbourhoodCounts
+  # @param scope [ActiveRecord::Relation<Event>] the events to count, already
+  #   filtered by period and any region
+  # @param site [Site] the site whose neighbourhoods bound the dropdown
+  def initialize(scope:, site:)
+    @scope = scope
+    @site = site
+  end
+
+  # @return [Array<Hash>] { neighbourhood: Neighbourhood, count: Integer }
+  def call
+    site_root_ids = @site.neighbourhoods.pluck(:id)
+    return [] if site_root_ids.empty?
+
+    dropdown_neighbourhoods(raw_counts, site_root_ids)
+  end
+
+  private
+
+  # Events counted against the neighbourhood they happen in (single query).
+  #
+  # @return [Hash{Integer=>Integer}] event count per neighbourhood id
+  def raw_counts
+    @scope
+      .left_joins(:address, organiser: :address)
+      .where('COALESCE(addresses.neighbourhood_id, addresses_partners.neighbourhood_id) IS NOT NULL')
+      .group('COALESCE(addresses.neighbourhood_id, addresses_partners.neighbourhood_id)')
+      .distinct
+      .count
+  end
+
+  # Only the neighbourhoods that have events and their ancestors can carry a
+  # non-zero count, so we load just those rather than every descendant of the
+  # site. A country-anchored site has ~13,000 descendants; loading them all to
+  # fill a handful-long dropdown cost ~2s a request. Entries are kept to strict
+  # descendants of the site's own neighbourhoods, so the anchor nodes are
+  # excluded, matching the previous descendants-only behaviour.
+  #
+  # @param raw_counts [Hash{Integer=>Integer}] event count per neighbourhood id
+  # @param site_root_ids [Array<Integer>] the site's own neighbourhood ids
+  # @return [Array<Hash>] { neighbourhood:, count: } sorted by name
+  def dropdown_neighbourhoods(raw_counts, site_root_ids)
+    return [] if raw_counts.empty?
+
+    event_hoods = Neighbourhood.where(id: raw_counts.keys).to_a
+    candidate_ids = (raw_counts.keys + event_hoods.flat_map(&:ancestor_ids)).uniq
+
+    Neighbourhood.where(id: candidate_ids).order(:name).filter_map do |node|
+      next unless (node.ancestor_ids & site_root_ids).any?
+
+      # An event counts towards a node when the node is an ancestor-or-self of
+      # the neighbourhood the event is in, i.e. the event sits in its subtree.
+      count = event_hoods.sum { |h| h.path_ids.include?(node.id) ? raw_counts[h.id] : 0 }
+      { neighbourhood: node, count: count } if count.positive?
+    end
+  end
+end

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -164,68 +164,14 @@ class EventsQuery
   # Base Scope
   # ===================
 
+  # Events for the whole directory (no site) or, via SiteEventsScope, the ones
+  # that belong to this site. Preloads place and organiser for the cards.
   def base_scope
-    @base_scope ||= if @site.nil?
-                      Event.includes(:place, :organiser)
-                    else
-                      events_for_site.includes(:place, :organiser)
-                    end
+    @base_scope ||= events_in_scope.includes(:place, :organiser)
   end
 
-  # Inline of Event.for_site: the events that belong on this site. Both site
-  # shapes take events organised by, or hosted at, one of the site's partners;
-  # a neighbourhood site also takes any event whose address is in its area,
-  # and a tagged site adds the legacy venue match. The hosted-at rule reaches
-  # an event a site partner puts on somewhere else, which is how the partner
-  # page and the tag filter already count it.
-  def events_for_site
-    if @site.tags.any?
-      events_for_tagged_site(site_partner_ids)
-    else
-      events_for_untagged_site(site_partner_ids)
-    end
-  end
-
-  # The site's partner ids, fetched once per query object and handed to
-  # Postgres as a literal list. As a subquery the planner hashed the set and
-  # scanned every future event for each count: 600ms against 12ms on
-  # production data, four counts per events page. Ids only, never rows.
-  def site_partner_ids
-    @site_partner_ids ||= PartnersQuery.new(site: @site).call.reorder(nil).except(:includes).pluck(:id)
-  end
-
-  # For sites without tags: partner events plus anything at a site address.
-  def events_for_untagged_site(partner_ids)
-    site_neighbourhood_ids = @site.owned_neighbourhood_ids
-
-    base = Event.left_joins(:address)
-    base.where(organiser_id: partner_ids)
-        .or(base.where(place_id: partner_ids))
-        .or(base.where(addresses: { neighbourhood_id: site_neighbourhood_ids }))
-  end
-
-  # For sites with tags: events organised by, or hosted at, a partner in the
-  # site scope, plus the legacy venue match.
-  def events_for_tagged_site(partner_ids)
-    return Event.none if partner_ids.empty?
-
-    base = Event.left_joins(:address)
-    base.where(organiser_id: partner_ids)
-        .or(base.where(place_id: partner_ids))
-        .or(base.where(legacy_venue_match_sql(partner_ids)))
-  end
-
-  # Legacy venue matching, from 2024 (commit 5b90f19), for events whose place
-  # was never set: an event counts as happening at a partner when its address
-  # street line is the partner's name and the postcodes agree. Ids are cast
-  # to integers again before interpolation.
-  def legacy_venue_match_sql(partner_ids)
-    <<~SQL.squish
-      EXISTS (SELECT 1 FROM partners venue_partners
-        INNER JOIN addresses venue_addresses ON venue_addresses.id = venue_partners.address_id
-        WHERE venue_partners.id IN (#{partner_ids.map(&:to_i).join(',')})
-        AND lower(venue_partners.name) = lower(addresses.street_address) AND lower(venue_addresses.postcode) = lower(addresses.postcode))
-    SQL
+  def events_in_scope
+    @site.nil? ? Event.all : SiteEventsScope.new(site: @site).call
   end
 
   # ===================

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -135,11 +135,8 @@ class EventsQuery
     filter_by_tag(base_scope, tag_id).future(day).reorder(dtstart: :asc).first
   end
 
-  # Returns neighbourhoods that have events, with counts for the given period
-  # Used for filter dropdowns
-  #
-  # Shows all descendant neighbourhoods of the site's configured neighbourhoods,
-  # at every level. Each neighbourhood's count includes events in its subtree.
+  # Neighbourhoods with events, with per-subtree counts, for the filter
+  # dropdown. Delegates the roll-up to EventNeighbourhoodCounts.
   #
   # @param period [String] 'day', 'week', or 'future'
   # @param tag_id [Integer] optionally restrict to a tag, so the counts agree
@@ -148,20 +145,8 @@ class EventsQuery
   def neighbourhoods_with_counts(period: 'future', tag_id: nil)
     return [] unless @site
 
-    site_root_ids = @site.neighbourhoods.pluck(:id)
-    return [] if site_root_ids.empty?
-
-    events = apply_period(filter_by_tag(base_scope, tag_id), period)
-
-    # Events counted against the neighbourhood they happen in (single query)
-    raw_counts = events
-                 .left_joins(:address, organiser: :address)
-                 .where('COALESCE(addresses.neighbourhood_id, addresses_partners.neighbourhood_id) IS NOT NULL')
-                 .group('COALESCE(addresses.neighbourhood_id, addresses_partners.neighbourhood_id)')
-                 .distinct
-                 .count
-
-    dropdown_neighbourhoods(raw_counts, site_root_ids)
+    scope = apply_period(filter_by_tag(base_scope, tag_id), period)
+    EventNeighbourhoodCounts.new(scope: scope, site: @site).call
   end
 
   # Whether the given event appears on this site — same rules as the event
@@ -327,29 +312,4 @@ class EventsQuery
   # The neighbourhood dropdown: every neighbourhood with events in its subtree,
   # each carrying that subtree's event count, sorted by name.
   #
-  # Only the neighbourhoods that have events and their ancestors can carry a
-  # non-zero count, so we load just those rather than every descendant of the
-  # site. A country-anchored site has ~13,000 descendants; loading them all to
-  # fill a handful-long dropdown cost ~2s a request. Entries are kept to strict
-  # descendants of the site's own neighbourhoods, so the anchor nodes are
-  # excluded, matching the previous descendants-only behaviour.
-  #
-  # @param raw_counts [Hash{Integer=>Integer}] event count per neighbourhood id
-  # @param site_root_ids [Array<Integer>] the site's own neighbourhood ids
-  # @return [Array<Hash>] { neighbourhood:, count: } sorted by name
-  def dropdown_neighbourhoods(raw_counts, site_root_ids)
-    return [] if raw_counts.empty?
-
-    event_hoods = Neighbourhood.where(id: raw_counts.keys).to_a
-    candidate_ids = (raw_counts.keys + event_hoods.flat_map(&:ancestor_ids)).uniq
-
-    Neighbourhood.where(id: candidate_ids).order(:name).filter_map do |node|
-      next unless (node.ancestor_ids & site_root_ids).any?
-
-      # An event counts towards a node when the node is an ancestor-or-self of
-      # the neighbourhood the event is in, i.e. the event sits in its subtree.
-      count = event_hoods.sum { |h| h.path_ids.include?(node.id) ? raw_counts[h.id] : 0 }
-      { neighbourhood: node, count: count } if count.positive?
-    end
-  end
 end

--- a/app/queries/partner_facets.rb
+++ b/app/queries/partner_facets.rb
@@ -2,51 +2,33 @@
 
 # Filter-dropdown facet counts for a site's (or the directory's) partners:
 # neighbourhoods, the cascading neighbourhood tree, partnerships and
-# categories, each with a distinct-partner count. Extracted from PartnersQuery
-# so that object stays focused on selecting partners (app/queries, single
-# responsibility); PartnersQuery delegates its facet methods here.
-#
-# Every method takes an optional +scope+ (a partners relation) and falls back
-# to the default scope the facets were built with, so callers can cross-filter
-# the counts on the other active filters.
+# categories, each with a distinct-partner count. Every method takes an
+# optional +scope+ and falls back to the default the facets were built with,
+# so callers can cross-filter the counts on the other active filters.
 class PartnerFacets
-  # @param default_scope [ActiveRecord::Relation<Partner>] the site's partners,
-  #   used when a method is called without an explicit scope
   def initialize(default_scope:)
     @default_scope = default_scope
   end
 
-  # Neighbourhoods that have partners, with counts. Used for filter dropdowns.
-  #
-  # @return [Array<Hash>] array of { neighbourhood: Neighbourhood, count: Integer }
+  # @return [Array<Hash>] { neighbourhood:, count: }
   def neighbourhoods_with_counts(scope: nil)
     pairs = neighbourhood_partner_pairs(scope: scope)
     return [] if pairs.empty?
 
     direct_ids = pairs.map { |r| r['neighbourhood_id'] }.uniq
     neighbourhoods = Neighbourhood.where(id: direct_ids).order(:name).to_a
-
-    # Roll each partner up to its neighbourhood and all listed ancestors, so an
-    # area-level neighbourhood's count matches what filtering by it returns (its
-    # whole subtree) and the dropdown stays consistent with the results.
     counts = rollup_partner_counts(pairs, neighbourhoods.index_by(&:id))
 
     neighbourhoods.map { |n| { neighbourhood: n, count: counts[n.id] } }
   end
 
-  # The full geographic hierarchy of neighbourhoods that have partners, as a
-  # nested tree for the directory's cascading neighbourhood filter.
+  # The nested neighbourhood hierarchy for the directory's cascading filter:
+  # every assigned neighbourhood plus its ancestors, each node counting the
+  # distinct partners in its subtree. The country level is dropped and its
+  # children become roots.
   #
-  # Every neighbourhood a partner is assigned to is included along with all of
-  # its ancestors, so the cascade can be drilled region > county > district >
-  # ward. Each node's count is the number of distinct partners in its subtree,
-  # matching what filtering by that node returns. The country level is dropped
-  # (it filters to everything, same as no filter) and its children become roots.
-  #
-  # @param selected_id [Integer, String, nil] keep this neighbourhood in the
-  #   tree even when the current scope leaves it with no partners, so the picker
-  #   still reflects the active selection
-  # @return [Array<Hash>] nested nodes of { id:, name:, unit:, count:, children: }
+  # @param selected_id keeps that neighbourhood in the tree even when the scope
+  #   leaves it empty, so the picker still reflects the active selection
   def neighbourhood_tree(scope: nil, selected_id: nil)
     pairs = neighbourhood_partner_pairs(scope: scope)
     direct = Neighbourhood.where(id: pairs.map { |r| r['neighbourhood_id'] }.uniq).to_a
@@ -64,39 +46,30 @@ class PartnerFacets
     build_neighbourhood_tree(nodes, by_id, counts)
   end
 
-  # Partnerships that have partners, with counts. Directory filter dropdown.
-  #
-  # @return [Array<Hash>] array of { partnership: Partnership, count: Integer }
+  # @return [Array<Hash>] { partnership:, count: }
   def partnerships_with_counts(scope: nil)
-    Tag
-      .joins(:partner_tags)
-      .where(partner_tags: { partner_id: (scope || @default_scope).reorder(nil).select(:id) }, type: 'Partnership')
-      .group(:id, :name)
-      .order(:name)
-      .select('tags.*, COUNT(partner_tags.partner_id) as partner_count')
-      .map { |tag| { partnership: tag, count: tag.partner_count } }
+    tags_with_counts('Partnership', scope).map { |tag| { partnership: tag, count: tag.partner_count } }
   end
 
-  # Categories that have partners, with counts. Used for filter dropdowns.
-  #
-  # @return [Array<Hash>] array of { category: Tag, count: Integer }
+  # @return [Array<Hash>] { category:, count: }
   def categories_with_counts(scope: nil)
-    Tag
-      .joins(:partner_tags)
-      .where(partner_tags: { partner_id: (scope || @default_scope).reorder(nil).select(:id) }, type: 'Category')
-      .group(:id, :name)
-      .order(:name)
-      .select('tags.*, COUNT(partner_tags.partner_id) as partner_count')
-      .map { |tag| { category: tag, count: tag.partner_count } }
+    tags_with_counts('Category', scope).map { |tag| { category: tag, count: tag.partner_count } }
   end
 
   private
 
-  # Distinct (neighbourhood_id, partner_id) pairs for partners in the scope,
-  # via either their address or a service area. Shared by the dropdown count
-  # and the cascade tree so both reflect the same set of partners.
-  #
-  # @return [Array<Hash>] rows with 'neighbourhood_id' and 'partner_id'
+  def tags_with_counts(type, scope)
+    Tag
+      .joins(:partner_tags)
+      .where(partner_tags: { partner_id: (scope || @default_scope).reorder(nil).select(:id) }, type: type)
+      .group(:id, :name)
+      .order(:name)
+      .select('tags.*, COUNT(partner_tags.partner_id) as partner_count')
+  end
+
+  # Distinct (neighbourhood_id, partner_id) pairs for partners in the scope, via
+  # address or service area. Shared by the dropdown and the tree so both reflect
+  # the same partners.
   def neighbourhood_partner_pairs(scope: nil)
     partner_ids = (scope || @default_scope).reorder(nil).select(:id)
 
@@ -117,11 +90,7 @@ class PartnerFacets
   end
 
   # Credit each partner to its neighbourhood and every ancestor present in
-  # +by_id+, so an area-level node's count matches its whole subtree.
-  #
-  # @param pairs [Array<Hash>] neighbourhood/partner rows
-  # @param by_id [Hash{Integer => Neighbourhood}] nodes to credit
-  # @return [Hash{Integer => Integer}] neighbourhood id => distinct partner count
+  # +by_id+, so an area-level node's count spans its whole subtree.
   def rollup_partner_counts(pairs, by_id)
     partner_sets = Hash.new { |hash, key| hash[key] = Set.new }
     pairs.each do |row|
@@ -135,10 +104,8 @@ class PartnerFacets
     partner_sets.transform_values(&:size)
   end
 
-  # Assemble +nodes+ into a nested tree, dropping the country level and
-  # re-rooting its children. Children are sorted by name at every level.
-  #
-  # @return [Array<Hash>] root nodes of { id:, name:, unit:, count:, children: }
+  # Nest +nodes+ into a tree, dropping the country level and re-rooting its
+  # children, sorted by name at every level.
   def build_neighbourhood_tree(nodes, by_id, counts)
     children_of = Hash.new { |hash, key| hash[key] = [] }
     roots = []
@@ -167,8 +134,7 @@ class PartnerFacets
     roots.sort_by { |n| n.shortname.downcase }.map(&build)
   end
 
-  # @return [Boolean] whether the node is country-level (the unit attribute is
-  #   the canonical level marker; the numeric `level` column is often unset)
+  # unit is the canonical level marker; the numeric `level` column is often unset.
   def country?(node)
     node.unit.to_s == 'country'
   end

--- a/app/queries/partner_facets.rb
+++ b/app/queries/partner_facets.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+# Filter-dropdown facet counts for a site's (or the directory's) partners:
+# neighbourhoods, the cascading neighbourhood tree, partnerships and
+# categories, each with a distinct-partner count. Extracted from PartnersQuery
+# so that object stays focused on selecting partners (app/queries, single
+# responsibility); PartnersQuery delegates its facet methods here.
+#
+# Every method takes an optional +scope+ (a partners relation) and falls back
+# to the default scope the facets were built with, so callers can cross-filter
+# the counts on the other active filters.
+class PartnerFacets
+  # @param default_scope [ActiveRecord::Relation<Partner>] the site's partners,
+  #   used when a method is called without an explicit scope
+  def initialize(default_scope:)
+    @default_scope = default_scope
+  end
+
+  # Neighbourhoods that have partners, with counts. Used for filter dropdowns.
+  #
+  # @return [Array<Hash>] array of { neighbourhood: Neighbourhood, count: Integer }
+  def neighbourhoods_with_counts(scope: nil)
+    pairs = neighbourhood_partner_pairs(scope: scope)
+    return [] if pairs.empty?
+
+    direct_ids = pairs.map { |r| r['neighbourhood_id'] }.uniq
+    neighbourhoods = Neighbourhood.where(id: direct_ids).order(:name).to_a
+
+    # Roll each partner up to its neighbourhood and all listed ancestors, so an
+    # area-level neighbourhood's count matches what filtering by it returns (its
+    # whole subtree) and the dropdown stays consistent with the results.
+    counts = rollup_partner_counts(pairs, neighbourhoods.index_by(&:id))
+
+    neighbourhoods.map { |n| { neighbourhood: n, count: counts[n.id] } }
+  end
+
+  # The full geographic hierarchy of neighbourhoods that have partners, as a
+  # nested tree for the directory's cascading neighbourhood filter.
+  #
+  # Every neighbourhood a partner is assigned to is included along with all of
+  # its ancestors, so the cascade can be drilled region > county > district >
+  # ward. Each node's count is the number of distinct partners in its subtree,
+  # matching what filtering by that node returns. The country level is dropped
+  # (it filters to everything, same as no filter) and its children become roots.
+  #
+  # @param selected_id [Integer, String, nil] keep this neighbourhood in the
+  #   tree even when the current scope leaves it with no partners, so the picker
+  #   still reflects the active selection
+  # @return [Array<Hash>] nested nodes of { id:, name:, unit:, count:, children: }
+  def neighbourhood_tree(scope: nil, selected_id: nil)
+    pairs = neighbourhood_partner_pairs(scope: scope)
+    direct = Neighbourhood.where(id: pairs.map { |r| r['neighbourhood_id'] }.uniq).to_a
+
+    selected = Neighbourhood.find_by(id: selected_id) if selected_id.present?
+    direct << selected if selected && direct.none? { |n| n.id == selected.id }
+
+    return [] if direct.empty?
+
+    ancestor_ids = direct.flat_map(&:ancestor_ids).uniq
+    nodes = Neighbourhood.where(id: (direct.map(&:id) + ancestor_ids).uniq).to_a
+    by_id = nodes.index_by(&:id)
+
+    counts = rollup_partner_counts(pairs, by_id)
+    build_neighbourhood_tree(nodes, by_id, counts)
+  end
+
+  # Partnerships that have partners, with counts. Directory filter dropdown.
+  #
+  # @return [Array<Hash>] array of { partnership: Partnership, count: Integer }
+  def partnerships_with_counts(scope: nil)
+    Tag
+      .joins(:partner_tags)
+      .where(partner_tags: { partner_id: (scope || @default_scope).reorder(nil).select(:id) }, type: 'Partnership')
+      .group(:id, :name)
+      .order(:name)
+      .select('tags.*, COUNT(partner_tags.partner_id) as partner_count')
+      .map { |tag| { partnership: tag, count: tag.partner_count } }
+  end
+
+  # Categories that have partners, with counts. Used for filter dropdowns.
+  #
+  # @return [Array<Hash>] array of { category: Tag, count: Integer }
+  def categories_with_counts(scope: nil)
+    Tag
+      .joins(:partner_tags)
+      .where(partner_tags: { partner_id: (scope || @default_scope).reorder(nil).select(:id) }, type: 'Category')
+      .group(:id, :name)
+      .order(:name)
+      .select('tags.*, COUNT(partner_tags.partner_id) as partner_count')
+      .map { |tag| { category: tag, count: tag.partner_count } }
+  end
+
+  private
+
+  # Distinct (neighbourhood_id, partner_id) pairs for partners in the scope,
+  # via either their address or a service area. Shared by the dropdown count
+  # and the cascade tree so both reflect the same set of partners.
+  #
+  # @return [Array<Hash>] rows with 'neighbourhood_id' and 'partner_id'
+  def neighbourhood_partner_pairs(scope: nil)
+    partner_ids = (scope || @default_scope).reorder(nil).select(:id)
+
+    ActiveRecord::Base.connection.select_all(<<~SQL).to_a # rubocop:disable Rails/SquishedSQLHeredocs
+      SELECT neighbourhood_id, partner_id FROM (
+        SELECT a.neighbourhood_id, p.id AS partner_id
+        FROM partners p
+        INNER JOIN addresses a ON a.id = p.address_id
+        WHERE p.id IN (#{partner_ids.to_sql})
+          AND a.neighbourhood_id IS NOT NULL
+        UNION
+        SELECT sa.neighbourhood_id, sa.partner_id
+        FROM service_areas sa
+        WHERE sa.partner_id IN (#{partner_ids.to_sql})
+          AND sa.neighbourhood_id IS NOT NULL
+      ) AS combined
+    SQL
+  end
+
+  # Credit each partner to its neighbourhood and every ancestor present in
+  # +by_id+, so an area-level node's count matches its whole subtree.
+  #
+  # @param pairs [Array<Hash>] neighbourhood/partner rows
+  # @param by_id [Hash{Integer => Neighbourhood}] nodes to credit
+  # @return [Hash{Integer => Integer}] neighbourhood id => distinct partner count
+  def rollup_partner_counts(pairs, by_id)
+    partner_sets = Hash.new { |hash, key| hash[key] = Set.new }
+    pairs.each do |row|
+      node = by_id[row['neighbourhood_id']]
+      next unless node
+
+      [node.id, *node.ancestor_ids].each do |id|
+        partner_sets[id] << row['partner_id'] if by_id.key?(id)
+      end
+    end
+    partner_sets.transform_values(&:size)
+  end
+
+  # Assemble +nodes+ into a nested tree, dropping the country level and
+  # re-rooting its children. Children are sorted by name at every level.
+  #
+  # @return [Array<Hash>] root nodes of { id:, name:, unit:, count:, children: }
+  def build_neighbourhood_tree(nodes, by_id, counts)
+    children_of = Hash.new { |hash, key| hash[key] = [] }
+    roots = []
+
+    nodes.each do |node|
+      next if country?(node)
+
+      parent = by_id[node.parent_id]
+      if parent.nil? || country?(parent)
+        roots << node
+      else
+        children_of[node.parent_id] << node
+      end
+    end
+
+    build = lambda do |node|
+      {
+        id: node.id,
+        name: node.shortname,
+        unit: node.unit.to_s,
+        count: counts[node.id] || 0,
+        children: children_of[node.id].sort_by { |c| c.shortname.downcase }.map(&build)
+      }
+    end
+
+    roots.sort_by { |n| n.shortname.downcase }.map(&build)
+  end
+
+  # @return [Boolean] whether the node is country-level (the unit attribute is
+  #   the canonical level marker; the numeric `level` column is often unset)
+  def country?(node)
+    node.unit.to_s == 'country'
+  end
+end

--- a/app/queries/partners_query.rb
+++ b/app/queries/partners_query.rb
@@ -67,83 +67,10 @@ class PartnersQuery
     partners.includes({ address: :neighbourhood }, { service_areas: :neighbourhood }, :categories).order(sort_clause(sort))
   end
 
-  # Returns neighbourhoods that have partners, with counts
-  # Used for filter dropdowns
-  #
-  # @return [Array<Hash>] array of { neighbourhood: Neighbourhood, count: Integer }
-  def neighbourhoods_with_counts(scope: nil)
-    pairs = neighbourhood_partner_pairs(scope: scope)
-    return [] if pairs.empty?
-
-    direct_ids = pairs.map { |r| r['neighbourhood_id'] }.uniq
-    neighbourhoods = Neighbourhood.where(id: direct_ids).order(:name).to_a
-
-    # Roll each partner up to its neighbourhood and all listed ancestors, so an
-    # area-level neighbourhood's count matches what filtering by it returns (its
-    # whole subtree) and the dropdown stays consistent with the results.
-    counts = rollup_partner_counts(pairs, neighbourhoods.index_by(&:id))
-
-    neighbourhoods.map { |n| { neighbourhood: n, count: counts[n.id] } }
-  end
-
-  # Returns the full geographic hierarchy of neighbourhoods that have partners,
-  # as a nested tree for the directory's cascading neighbourhood filter.
-  #
-  # Every neighbourhood a partner is assigned to is included along with all of
-  # its ancestors, so the cascade can be drilled region > county > district >
-  # ward. Each node's count is the number of distinct partners in its subtree,
-  # matching what filtering by that node returns. The country level is dropped
-  # (it filters to everything, same as no filter) and its children become roots.
-  #
-  # @param selected_id [Integer, String, nil] keep this neighbourhood in the
-  #   tree even when the current scope leaves it with no partners, so the picker
-  #   still reflects the active selection
-  # @return [Array<Hash>] nested nodes of
-  #   { id:, name:, unit:, count:, children: [...] }
-  def neighbourhood_tree(scope: nil, selected_id: nil)
-    pairs = neighbourhood_partner_pairs(scope: scope)
-    direct = Neighbourhood.where(id: pairs.map { |r| r['neighbourhood_id'] }.uniq).to_a
-
-    selected = Neighbourhood.find_by(id: selected_id) if selected_id.present?
-    direct << selected if selected && direct.none? { |n| n.id == selected.id }
-
-    return [] if direct.empty?
-
-    ancestor_ids = direct.flat_map(&:ancestor_ids).uniq
-    nodes = Neighbourhood.where(id: (direct.map(&:id) + ancestor_ids).uniq).to_a
-    by_id = nodes.index_by(&:id)
-
-    counts = rollup_partner_counts(pairs, by_id)
-    build_neighbourhood_tree(nodes, by_id, counts)
-  end
-
-  # Returns partnerships that have partners, with counts
-  # Used for filter dropdowns on the directory site
-  #
-  # @return [Array<Hash>] array of { partnership: Partnership, count: Integer }
-  def partnerships_with_counts(scope: nil)
-    Tag
-      .joins(:partner_tags)
-      .where(partner_tags: { partner_id: (scope || base_scope).reorder(nil).select(:id) }, type: 'Partnership')
-      .group(:id, :name)
-      .order(:name)
-      .select('tags.*, COUNT(partner_tags.partner_id) as partner_count')
-      .map { |tag| { partnership: tag, count: tag.partner_count } }
-  end
-
-  # Returns categories/tags that have partners, with counts
-  # Used for filter dropdowns
-  #
-  # @return [Array<Hash>] array of { category: Tag, count: Integer }
-  def categories_with_counts(scope: nil)
-    Tag
-      .joins(:partner_tags)
-      .where(partner_tags: { partner_id: (scope || base_scope).reorder(nil).select(:id) }, type: 'Category')
-      .group(:id, :name)
-      .order(:name)
-      .select('tags.*, COUNT(partner_tags.partner_id) as partner_count')
-      .map { |tag| { category: tag, count: tag.partner_count } }
-  end
+  # Filter-dropdown facet counts. Delegated to PartnerFacets so this object
+  # stays focused on selecting partners.
+  delegate :neighbourhoods_with_counts, :neighbourhood_tree,
+           :partnerships_with_counts, :categories_with_counts, to: :facets
 
   # Whether the given partner appears on this site — same rules as the
   # partner listing (address or service area in the site's neighbourhoods,
@@ -157,89 +84,10 @@ class PartnersQuery
 
   private
 
-  # ===================
-  # Neighbourhood roll-up helpers
-  # ===================
-
-  # Distinct (neighbourhood_id, partner_id) pairs for partners in the scope,
-  # via either their address or a service area. Shared by the dropdown count
-  # and the cascade tree so both reflect the same set of partners.
-  #
-  # @return [Array<Hash>] rows with 'neighbourhood_id' and 'partner_id'
-  def neighbourhood_partner_pairs(scope: nil)
-    partner_ids = (scope || base_scope).reorder(nil).select(:id)
-
-    ActiveRecord::Base.connection.select_all(<<~SQL).to_a # rubocop:disable Rails/SquishedSQLHeredocs
-      SELECT neighbourhood_id, partner_id FROM (
-        SELECT a.neighbourhood_id, p.id AS partner_id
-        FROM partners p
-        INNER JOIN addresses a ON a.id = p.address_id
-        WHERE p.id IN (#{partner_ids.to_sql})
-          AND a.neighbourhood_id IS NOT NULL
-        UNION
-        SELECT sa.neighbourhood_id, sa.partner_id
-        FROM service_areas sa
-        WHERE sa.partner_id IN (#{partner_ids.to_sql})
-          AND sa.neighbourhood_id IS NOT NULL
-      ) AS combined
-    SQL
-  end
-
-  # Credit each partner to its neighbourhood and every ancestor present in
-  # +by_id+, so an area-level node's count matches its whole subtree.
-  #
-  # @param pairs [Array<Hash>] neighbourhood/partner rows
-  # @param by_id [Hash{Integer => Neighbourhood}] nodes to credit
-  # @return [Hash{Integer => Integer}] neighbourhood id => distinct partner count
-  def rollup_partner_counts(pairs, by_id)
-    partner_sets = Hash.new { |hash, key| hash[key] = Set.new }
-    pairs.each do |row|
-      node = by_id[row['neighbourhood_id']]
-      next unless node
-
-      [node.id, *node.ancestor_ids].each do |id|
-        partner_sets[id] << row['partner_id'] if by_id.key?(id)
-      end
-    end
-    partner_sets.transform_values(&:size)
-  end
-
-  # Assemble +nodes+ into a nested tree, dropping the country level and
-  # re-rooting its children. Children are sorted by name at every level.
-  #
-  # @return [Array<Hash>] root nodes of { id:, name:, unit:, count:, children: }
-  def build_neighbourhood_tree(nodes, by_id, counts)
-    children_of = Hash.new { |hash, key| hash[key] = [] }
-    roots = []
-
-    nodes.each do |node|
-      next if country?(node)
-
-      parent = by_id[node.parent_id]
-      if parent.nil? || country?(parent)
-        roots << node
-      else
-        children_of[node.parent_id] << node
-      end
-    end
-
-    build = lambda do |node|
-      {
-        id: node.id,
-        name: node.shortname,
-        unit: node.unit.to_s,
-        count: counts[node.id] || 0,
-        children: children_of[node.id].sort_by { |c| c.shortname.downcase }.map(&build)
-      }
-    end
-
-    roots.sort_by { |n| n.shortname.downcase }.map(&build)
-  end
-
-  # @return [Boolean] whether the node is country-level (the unit attribute is
-  #   the canonical level marker; the numeric `level` column is often unset)
-  def country?(node)
-    node.unit.to_s == 'country'
+  # @return [PartnerFacets] facet-count collaborator, defaulting to this site's
+  #   partner scope
+  def facets
+    @facets ||= PartnerFacets.new(default_scope: base_scope)
   end
 
   # ===================

--- a/app/queries/site_events_scope.rb
+++ b/app/queries/site_events_scope.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 # Which events belong to a site: the membership rule, separate from the
-# filtering, counting and grouping that EventsQuery does on top of it.
-#
-# Both site shapes take events organised by, or hosted at, one of the site's
-# partners. A neighbourhood site also takes any event whose address is in its
-# area; a tagged site adds the legacy venue match. The hosted-at rule reaches
-# an event a site partner puts on somewhere else, the same way the partner
-# page and the tag filter count it.
+# filtering, counting and grouping EventsQuery does on top of it. Both site
+# shapes take events organised by, or hosted at, a site partner; a
+# neighbourhood site also takes events at an address in its area, and a tagged
+# site adds the legacy venue match.
 class SiteEventsScope
-  # @param site [Site]
   def initialize(site:)
     @site = site
   end
@@ -21,15 +17,13 @@ class SiteEventsScope
 
   private
 
-  # The site's partner ids, handed to Postgres as a literal list. As a subquery
-  # the planner hashed the set and scanned every future event for each count
-  # (600ms against 12ms on production data, four counts per events page). Ids
-  # only, never partner rows.
+  # Handed to Postgres as a literal id list: as a subquery the planner hashed
+  # the set and scanned every future event per count (600ms against 12ms on
+  # production data, four counts a page). Ids only, never partner rows.
   def partner_ids
     @partner_ids ||= PartnersQuery.new(site: @site).call.reorder(nil).except(:includes).pluck(:id)
   end
 
-  # For sites without tags: partner events plus anything at a site address.
   def untagged
     base = Event.left_joins(:address)
     base.where(organiser_id: partner_ids)
@@ -37,8 +31,6 @@ class SiteEventsScope
         .or(base.where(addresses: { neighbourhood_id: @site.owned_neighbourhood_ids }))
   end
 
-  # For sites with tags: events organised by, or hosted at, a site partner,
-  # plus the legacy venue match.
   def tagged
     return Event.none if partner_ids.empty?
 
@@ -48,10 +40,9 @@ class SiteEventsScope
         .or(base.where(legacy_venue_match_sql))
   end
 
-  # Legacy venue matching, from 2024 (commit 5b90f19), for events whose place
-  # was never set: an event counts as happening at a partner when its address
-  # street line is the partner's name and the postcodes agree. Ids are cast to
-  # integers again before interpolation.
+  # From 2024 (commit 5b90f19): an event with no place counts as held at a
+  # partner when its address street line is the partner's name and the
+  # postcodes agree.
   def legacy_venue_match_sql
     <<~SQL.squish
       EXISTS (SELECT 1 FROM partners venue_partners

--- a/app/queries/site_events_scope.rb
+++ b/app/queries/site_events_scope.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Which events belong to a site: the membership rule, separate from the
+# filtering, counting and grouping that EventsQuery does on top of it.
+#
+# Both site shapes take events organised by, or hosted at, one of the site's
+# partners. A neighbourhood site also takes any event whose address is in its
+# area; a tagged site adds the legacy venue match. The hosted-at rule reaches
+# an event a site partner puts on somewhere else, the same way the partner
+# page and the tag filter count it.
+class SiteEventsScope
+  # @param site [Site]
+  def initialize(site:)
+    @site = site
+  end
+
+  # @return [ActiveRecord::Relation<Event>]
+  def call
+    @site.tags.any? ? tagged : untagged
+  end
+
+  private
+
+  # The site's partner ids, handed to Postgres as a literal list. As a subquery
+  # the planner hashed the set and scanned every future event for each count
+  # (600ms against 12ms on production data, four counts per events page). Ids
+  # only, never partner rows.
+  def partner_ids
+    @partner_ids ||= PartnersQuery.new(site: @site).call.reorder(nil).except(:includes).pluck(:id)
+  end
+
+  # For sites without tags: partner events plus anything at a site address.
+  def untagged
+    base = Event.left_joins(:address)
+    base.where(organiser_id: partner_ids)
+        .or(base.where(place_id: partner_ids))
+        .or(base.where(addresses: { neighbourhood_id: @site.owned_neighbourhood_ids }))
+  end
+
+  # For sites with tags: events organised by, or hosted at, a site partner,
+  # plus the legacy venue match.
+  def tagged
+    return Event.none if partner_ids.empty?
+
+    base = Event.left_joins(:address)
+    base.where(organiser_id: partner_ids)
+        .or(base.where(place_id: partner_ids))
+        .or(base.where(legacy_venue_match_sql))
+  end
+
+  # Legacy venue matching, from 2024 (commit 5b90f19), for events whose place
+  # was never set: an event counts as happening at a partner when its address
+  # street line is the partner's name and the postcodes agree. Ids are cast to
+  # integers again before interpolation.
+  def legacy_venue_match_sql
+    <<~SQL.squish
+      EXISTS (SELECT 1 FROM partners venue_partners
+        INNER JOIN addresses venue_addresses ON venue_addresses.id = venue_partners.address_id
+        WHERE venue_partners.id IN (#{partner_ids.map(&:to_i).join(',')})
+        AND lower(venue_partners.name) = lower(addresses.street_address) AND lower(venue_addresses.postcode) = lower(addresses.postcode))
+    SQL
+  end
+end


### PR DESCRIPTION
EventsQuery and PartnersQuery had grown into single classes doing several jobs at once, both pressed against the 190-line class limit. This splits each along its natural seams, behaviour-preserving, with the query objects delegating so every caller and the existing specs are unchanged.

Extracted:

- `PartnerFacets` - the filter-dropdown facet counts (neighbourhoods, the cascade tree, partnerships, categories) and their roll-up helpers.
- `EventNeighbourhoodCounts` - the events neighbourhood dropdown.
- `SiteEventsScope` - the rule for which events belong to a site (tagged, untagged, legacy venue match), separate from filtering, counting and grouping.

Code lines per file after (comments excluded): events_query 127 (was 160), partners_query 90 (was 190), and the three new objects 33, 30 and 98.

271 examples pass across the query specs, the public partners and events request specs, the filter component specs and the directory system specs; rubocop clean. No behaviour change: the query objects keep the same public methods and delegate to the new collaborators, so the filter components, the partners controller and the directory are untouched.