### PR TITLE
Hooks: enforce no em/en dashes and no Claude co-author trailer

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,15 @@
+msg_file="$1"
+
+# House style, enforced with Ruby (BSD grep has no -P for \x escapes):
+#   - no em/en dashes in the message
+#   - no 'Co-Authored-By: Claude' trailer (not used in this repo)
+ruby -e '
+  msg = File.read(ARGV[0], encoding: "UTF-8")
+  if msg.match?(/[\u2013\u2014\u2015]/)
+    warn "commit-msg: em or en dash in the message. Use full stops, commas, parentheses or colons."
+    exit 1
+  elsif msg.match?(/^\s*Co-Authored-By:\s*Claude/i)
+    warn "commit-msg: drop the Co-Authored-By: Claude trailer; it is not used in this repo."
+    exit 1
+  end
+' "$msg_file"

--- a/bin/setup-ai
+++ b/bin/setup-ai
@@ -4,7 +4,7 @@ set -euo pipefail
 # Install PlaceCal's AI assistant tooling into the local, gitignored .claude/
 # directory: symlink the vendored plugins (an agent + a skill) from their tracked
 # source of truth in doc/ai/plugins/, and register the RuboCop auto-correct
-# PostToolUse hook in .claude/settings.json. Idempotent — safe to re-run.
+# PostToolUse hook in .claude/settings.json. Idempotent - safe to re-run.
 #
 # The plugins are documented in doc/ai/plugins/README.md; the hook in
 # doc/ai/hooks/.
@@ -27,36 +27,41 @@ link "$SRC/better-stimulus/agent.md"        "$ROOT/.claude/agents/better-stimulu
 # Skills (whole directory, scripts co-located)
 link "$SRC/rails-hotwire-driver"            "$ROOT/.claude/skills/rails-hotwire-driver"
 
-# Hooks: register the RuboCop auto-correct PostToolUse hook in the local
-# .claude/settings.json (merged idempotently; settings.local.json is untouched).
-HOOK="$ROOT/doc/ai/hooks/rubocop-autocorrect.sh"
+# Hooks: register the PostToolUse hooks in the local .claude/settings.json
+# (merged idempotently; settings.local.json is untouched).
 SETTINGS="$ROOT/.claude/settings.json"
 ruby -rjson -e '
-  settings_path, hook = ARGV
+  settings_path, *hooks_to_add = ARGV
   settings = File.exist?(settings_path) ? JSON.parse(File.read(settings_path)) : {}
   hooks = (settings["hooks"] ||= {})
   post  = (hooks["PostToolUse"] ||= [])
-  already = post.any? { |e| Array(e["hooks"]).any? { |h| h["command"] == hook } }
-  unless already
+  changed = false
+  hooks_to_add.each do |hook|
+    already = post.any? { |e| Array(e["hooks"]).any? { |h| h["command"] == hook } }
+    next if already
+
     post << { "matcher" => "Write|Edit|MultiEdit",
               "hooks" => [{ "type" => "command", "command" => hook }] }
-    File.write(settings_path, JSON.pretty_generate(settings) + "\n")
+    changed = true
   end
-' "$SETTINGS" "$HOOK"
+  File.write(settings_path, JSON.pretty_generate(settings) + "\n") if changed
+' "$SETTINGS" "$ROOT/doc/ai/hooks/rubocop-autocorrect.sh" "$ROOT/doc/ai/hooks/no-em-dash.sh"
 echo "  hook   rubocop-autocorrect -> .claude/settings.json (PostToolUse)"
+echo "  hook   no-em-dash          -> .claude/settings.json (PostToolUse)"
 
 cat <<'EOF'
 
 AI tooling installed successfully!
 
 What you get (see doc/ai/plugins/README.md):
-  - better-stimulus       agent  — StimulusJS best practices
-  - rails-hotwire-driver  skill  — drive the running dev server to verify changes
-  - rubocop-autocorrect   hook   — auto-fixes RuboCop after every Ruby edit
+  - better-stimulus       agent  - StimulusJS best practices
+  - rails-hotwire-driver  skill  - drive the running dev server to verify changes
+  - rubocop-autocorrect   hook   - auto-fixes RuboCop after every Ruby edit
+  - no-em-dash            hook   - flags em/en dashes in edited files
 
 Context for assistants stays in:
-  - AGENTS.md / doc/ai/context.md  — project conventions
-  - doc/ai/prompts/                — per-domain guidance
+  - AGENTS.md / doc/ai/context.md  - project conventions
+  - doc/ai/prompts/                - per-domain guidance
 
 Edit the plugins in doc/ai/plugins/ (the symlinks point back there); re-run
 this script if the links go stale.

--- a/doc/ai/hooks/no-em-dash.sh
+++ b/doc/ai/hooks/no-em-dash.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Claude Code PostToolUse hook - flag em and en dashes in files the agent just
+# edited, so it strips them before moving on.
+#
+# Why: the house style bans em/en dashes in prose, comments and copy (they read
+# as an AI tell). The model forgets. A hook makes it deterministic. Installed
+# into .claude/settings.json by bin/setup-ai.
+#
+# Protocol: reads the hook payload as JSON on stdin. Exit 0 = clean or not
+# applicable. Exit 2 = dashes found; stderr is fed back to the agent as an
+# instruction to remove them.
+
+set -uo pipefail
+
+payload="$(cat)"
+
+file="$(printf '%s' "$payload" \
+  | ruby -rjson -e 'print(JSON.parse(STDIN.read).dig("tool_input", "file_path").to_s)' 2>/dev/null || true)"
+
+[ -n "$file" ] && [ -f "$file" ] || exit 0
+
+# Text and source files only; skip vendored and generated trees where a dash
+# may be legitimate data we do not own.
+case "$file" in
+  */vendor/* | */node_modules/* | */public/assets/* | */app/assets/builds/*) exit 0 ;;
+esac
+case "$file" in
+  *.rb | *.rake | *.ru | *.gemspec | *Gemfile | *Rakefile | *.erb | *.haml | \
+  *.md | *.markdown | *.yml | *.yaml | *.js | *.ts | *.css | *.scss | *.json | *.txt) : ;;
+  *) exit 0 ;;
+esac
+
+# Report every line carrying an em dash (U+2014), en dash (U+2013) or
+# horizontal bar (U+2015). Ruby, not grep: BSD grep has no -P for \x escapes.
+hits="$(ruby -e '
+  file = ARGV[0]
+  File.foreach(file, encoding: "UTF-8").with_index(1) do |line, n|
+    puts "#{n}:#{line}" if line.match?(/[\u2013\u2014\u2015]/)
+  end
+' "$file" 2>/dev/null || true)"
+
+[ -z "$hits" ] && exit 0
+
+{
+  echo "Em or en dashes found in ${file}. The house style bans them: replace with"
+  echo "full stops, commas, parentheses or colons, then continue."
+  echo
+  printf '%s\n' "$hits"
+} >&2
+exit 2


### PR DESCRIPTION
Converts two house-style rules from guidelines the model keeps forgetting into deterministic hooks, following the existing rubocop-autocorrect pattern.

- `doc/ai/hooks/no-em-dash.sh`: a Claude Code PostToolUse hook (Write/Edit/MultiEdit) that flags em, en and horizontal-bar dashes in the edited file and feeds the offending lines back so they get removed. Skips vendored and generated trees, text and source extensions only.
- `.husky/commit-msg`: rejects a commit message containing those dashes or a `Co-Authored-By: Claude` trailer. The only such trailers in the last 200 commits were added this session by mistake; the repo convention is no AI co-author line.
- `bin/setup-ai` registers the new PostToolUse hook alongside rubocop-autocorrect, idempotently.

Both detectors use Ruby with `\u` escapes and UTF-8 reads, because BSD grep has no `-P` and a `ruby -e` script is otherwise parsed as US-ASCII. Tested each hook against clean, dashed and co-author inputs. The stray em dashes already in `bin/setup-ai`'s own output are cleaned up here too.