### PR TITLE
Fix slow partners page: memoise the site neighbourhood subtree, trim the card

### DIFF
--- a/app/components/partner_preview.rb
+++ b/app/components/partner_preview.rb
@@ -7,7 +7,7 @@ class Components::PartnerPreview < Components::Base
   def view_template
     li(class: 'preview') do
       div(class: 'preview__header') do
-        h3 { link_to(@partner.name, @partner, data: { turbo_frame: '_top', turbo_action: 'replace' }) }
+        h3 { link_to(@partner.name, partner_path(@partner), data: { turbo_frame: '_top', turbo_action: 'replace' }) }
         if show_neighbourhood?
           css = "neighbourhood #{primary_neighbourhood? ? 'neighbourhood--primary' : 'neighbourhood--secondary'} preview__neighbourhood"
           div(class: css) { span { neighbourhood_name } }
@@ -16,7 +16,6 @@ class Components::PartnerPreview < Components::Base
 
       if @partner.description
         div(class: 'preview__details') do
-          comment { "Categories: #{@partner.categories.map(&:name).join(', ')}" }
           p { @partner.summary }
         end
       end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -182,17 +182,21 @@ class Site < ApplicationRecord
     slug.blank?
   end
 
+  # Memoised: for a site anchored to a large area this expands to thousands of
+  # rows, and it is read once per partner card (via show_neighbourhoods?), so
+  # rebuilding it each time cost ~500ms on a 108-partner page.
+  #
   # @return [Array<Neighbourhood>] all neighbourhoods in this site's subtrees
   def owned_neighbourhoods
-    neighbourhoods.map(&:subtree).flatten
+    @owned_neighbourhoods ||= neighbourhoods.map(&:subtree).flatten
   end
 
   # @return [Array<Integer>] all neighbourhood IDs in this site's subtrees
   def owned_neighbourhood_ids
-    neighbourhoods
-      .select(:id, :ancestry)
-      .map(&:subtree_ids)
-      .flatten
+    @owned_neighbourhood_ids ||= neighbourhoods
+                                 .select(:id, :ancestry)
+                                 .map(&:subtree_ids)
+                                 .flatten
   end
 
   # The site's neighbourhoods and every descendant, as a relation rather than

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -175,6 +175,22 @@ RSpec.describe Site, type: :model do
       ids = site.owned_neighbourhood_ids
       expect(ids).to include(ward.id)
     end
+
+    it "memoises the id list so it is not rebuilt per caller" do
+      site.owned_neighbourhood_ids
+
+      queries = 0
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        queries += 1 unless payload[:cached] || payload[:name] == "SCHEMA"
+      end
+      begin
+        3.times { site.owned_neighbourhood_ids }
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(queries).to eq(0)
+    end
   end
 
   describe "theming" do


### PR DESCRIPTION
Follow-up to the query fixes. After them the Trans Dimension partners page was still ~1.5s, and profiling on staging found the cause was not the queries (35 total) but the render: `Site#show_neighbourhoods?` calls `owned_neighbourhood_ids`, which rebuilds the site's full neighbourhood subtree (~13,000 ids for a country-anchored site) from scratch. `Components::PartnerPreview` calls it once per card, so 108 cards rebuilt it 108 times: ~500ms of the ~600ms render, measured at 4.7ms a call.

- `Site#owned_neighbourhood_ids` and `#owned_neighbourhoods` are now memoised. The site object is shared across all cards in a request, so the subtree is built once instead of per card. A new spec asserts repeat calls issue no query.
- `PartnerPreview` links via `partner_path(partner)` instead of passing the record, avoiding polymorphic URL generation per card (~60ms to ~2ms across the page).
- Dropped the `<!-- Categories: ... -->` HTML comment each card shipped to the browser, a leftover from the ViewComponent-to-Phlex migration.

Behaviour-preserving: 239 examples pass across the site model, the partner preview component, the public partners request spec and the query specs; rubocop clean. Pagination of the local partners index (the deeper win for very large sites) is deferred to #3516.

To verify: after deploy to staging, re-time /partners on the Trans Dimension site.