### PR TITLE
Memoise User neighbourhood subtree lookups

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,22 +154,26 @@ class User < ApplicationRecord
     role == :national_admin
   end
 
+  # Memoised: the policies and admin partner scoping call these repeatedly,
+  # sometimes per partner in a loop, and each build expands the user's
+  # neighbourhood subtrees (or the whole table for a national admin).
+  #
   # @return [Array<Neighbourhood>] all neighbourhoods in this user's subtrees
   def owned_neighbourhoods
-    if national_admin?
-      Neighbourhood.all.to_a
-    else
-      neighbourhoods.collect(&:subtree).flatten
-    end
+    @owned_neighbourhoods ||= if national_admin?
+                                Neighbourhood.all.to_a
+                              else
+                                neighbourhoods.collect(&:subtree).flatten
+                              end
   end
 
   # @return [Array<Integer>] all neighbourhood IDs in this user's subtrees
   def owned_neighbourhood_ids
-    if national_admin?
-      Neighbourhood.pluck(:id)
-    else
-      owned_neighbourhoods.collect(&:id)
-    end
+    @owned_neighbourhood_ids ||= if national_admin?
+                                   Neighbourhood.pluck(:id)
+                                 else
+                                   owned_neighbourhoods.collect(&:id)
+                                 end
   end
 
   # @param partner_id [Integer]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -255,6 +255,22 @@ RSpec.describe User, type: :model do
       expect(owned.count).to be > 1
       expect(owned).to include(ward)
     end
+
+    it "memoises the subtree so it is not rebuilt per caller" do
+      user.owned_neighbourhood_ids
+
+      queries = 0
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        queries += 1 unless payload[:cached] || payload[:name] == "SCHEMA"
+      end
+      begin
+        3.times { user.owned_neighbourhood_ids }
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(queries).to eq(0)
+    end
   end
 
   describe "#can_view_neighbourhood_by_id?" do


### PR DESCRIPTION
Same fix as the site one, admin side. `User#owned_neighbourhood_ids` and `#owned_neighbourhoods` rebuild the user's neighbourhood subtrees (or the whole neighbourhoods table for a national admin) on every call, and the policies and `admin/partners_controller` call them repeatedly, sometimes once per partner in a loop. Both are now memoised on the instance, which is request-scoped. A spec asserts repeat calls issue no query.

Found while auditing the performance pattern behind the Trans Dimension slow pages (see the perf-audit issue). 129 examples pass across the user model and the partner, user and article policy specs; rubocop clean.