### PR TITLE
Cache the filter facet counts, share the site query with the filter

### DIFF
--- a/app/components/event_filter.rb
+++ b/app/components/event_filter.rb
@@ -12,6 +12,9 @@ class Components::EventFilter < Components::Base
   prop :show_monthly, _Boolean, default: true
   prop :region_tags, Array, default: -> { [] }
   prop :selected_region, _Nilable(::Tag), default: nil
+  # The controller passes its query so the site event scope is not rebuilt just
+  # to count the neighbourhood dropdown.
+  prop :query, _Nilable(::EventsQuery), default: nil
 
   # Today, tomorrow and five more days (D22).
   DAY_STRIP_LENGTH = 7
@@ -235,19 +238,22 @@ class Components::EventFilter < Components::Base
     end
   end
 
-  def neighbourhoods
+  # Counting future events per neighbourhood for the dropdown was ~100ms a
+  # request. Cached with a short TTL, the same tolerance Site#news_article_count
+  # already accepts; keyed on the site, period and region so each view caches
+  # separately. On a hit the query and its base scope are skipped.
+  def neighbourhood_items
     return [] unless @site
 
-    @neighbourhoods ||= EventsQuery.new(site: @site).neighbourhoods_with_counts(period: @period, tag_id: @selected_region&.id)
-  end
-
-  def neighbourhood_items
-    neighbourhoods.map do |n|
-      { id: n[:neighbourhood].id, name: n[:neighbourhood].name, count: n[:count] }
+    @neighbourhood_items ||= Rails.cache.fetch(['event_facet_neighbourhoods', @site.id, @period, @selected_region&.id],
+                                               expires_in: 10.minutes) do
+      query = @query || EventsQuery.new(site: @site)
+      query.neighbourhoods_with_counts(period: @period, tag_id: @selected_region&.id)
+           .map { |n| { id: n[:neighbourhood].id, name: n[:neighbourhood].name, count: n[:count] } }
     end
   end
 
   def show_neighbourhood_filter?
-    neighbourhoods.length > 1
+    neighbourhood_items.length > 1
   end
 end

--- a/app/components/partner_filter.rb
+++ b/app/components/partner_filter.rb
@@ -8,11 +8,14 @@ class Components::PartnerFilter < Components::Base
   prop :selected_neighbourhood, _Nilable(String), default: nil
   prop :region_tags, Array, default: -> { [] }
   prop :selected_region, _Nilable(::Tag), default: nil
+  # The controller passes its own query so the site partner scope is built once
+  # for the listing and the facet counts, not once each.
+  prop :query, _Nilable(::PartnersQuery), default: nil
 
   def after_initialize
     @selected_category = @selected_category.to_i
     @selected_neighbourhood = @selected_neighbourhood.to_i
-    @query = PartnersQuery.new(site: @site)
+    @query ||= PartnersQuery.new(site: @site)
   end
 
   def view_template
@@ -77,20 +80,26 @@ class Components::PartnerFilter < Components::Base
     end
   end
 
-  def categories
-    @categories ||= @query.categories_with_counts(scope: filtered_scope(neighbourhood_id: selected_neighbourhood_id))
-  end
-
+  # Facet counts are recomputed at most every few minutes, the same tolerance
+  # the news-nav count already accepts (Site#news_article_count). Counting
+  # partners per category and neighbourhood was ~100ms a request; on a cache
+  # hit it is skipped along with the base-scope build it needed.
   def category_items
-    categories.map { |c| { id: c[:category].id, name: c[:category].name, count: c[:count] } }
+    @category_items ||= cached_facet(:categories, neighbourhood: selected_neighbourhood_id) do
+      @query.categories_with_counts(scope: filtered_scope(neighbourhood_id: selected_neighbourhood_id))
+            .map { |c| { id: c[:category].id, name: c[:category].name, count: c[:count] } }
+    end
   end
 
   def show_category_filter?
-    categories.length > 1
+    category_items.length > 1
   end
 
-  def neighbourhoods
-    @neighbourhoods ||= @query.neighbourhoods_with_counts(scope: filtered_scope(tag_id: selected_category_id))
+  # The site and the other active filters key the cache, so cross-filtered
+  # counts cache separately.
+  def cached_facet(facet, **filters, &)
+    key = ['partner_facets', facet, @site.id, @selected_region&.id, *filters.values]
+    Rails.cache.fetch(key, expires_in: 10.minutes, &)
   end
 
   def selected_category_id
@@ -113,11 +122,14 @@ class Components::PartnerFilter < Components::Base
   end
 
   def neighbourhood_items
-    neighbourhoods.map { |n| { id: n[:neighbourhood].id, name: n[:neighbourhood].name, count: n[:count] } }
+    @neighbourhood_items ||= cached_facet(:neighbourhoods, category: selected_category_id) do
+      @query.neighbourhoods_with_counts(scope: filtered_scope(tag_id: selected_category_id))
+            .map { |n| { id: n[:neighbourhood].id, name: n[:neighbourhood].name, count: n[:count] } }
+    end
   end
 
   def show_neighbourhood_filter?
-    neighbourhoods.length > 1
+    neighbourhood_items.length > 1
   end
 
   def any_filter_active?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -143,7 +143,8 @@ class EventsController < ApplicationController
             selected_neighbourhood: @selected_neighbourhood,
             next_date: @next_date, truncated: @truncated,
             show_monthly: @show_monthly,
-            region_tags: region_tags, selected_region: @region
+            region_tags: region_tags, selected_region: @region,
+            query: @query
           )
         end
       end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -189,7 +189,8 @@ class PartnersController < ApplicationController
       partners: @partners, site: @site,
       map: @map, selected_category: @selected_category,
       selected_neighbourhood: @selected_neighbourhood,
-      region_tags: region_tags, selected_region: @region
+      region_tags: region_tags, selected_region: @region,
+      query: query
     )
   end
 end

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -13,6 +13,7 @@ class Views::Events::Index < Views::Base
   prop :show_monthly, _Boolean, reader: :private, default: true
   prop :region_tags, Array, reader: :private, default: -> { [] }
   prop :selected_region, _Nilable(::Tag), reader: :private, default: nil
+  prop :query, _Nilable(::EventsQuery), reader: :private, default: nil
 
   def view_template
     content_for(:title) { t('events.index.page_title') }
@@ -53,7 +54,8 @@ class Views::Events::Index < Views::Base
               selected_neighbourhood: selected_neighbourhood,
               show_monthly: show_monthly,
               region_tags: region_tags,
-              selected_region: selected_region
+              selected_region: selected_region,
+              query: query
             )
           end
         end

--- a/app/views/partners/index.rb
+++ b/app/views/partners/index.rb
@@ -8,6 +8,7 @@ class Views::Partners::Index < Views::Base
   prop :selected_neighbourhood, _Nilable(String), reader: :private
   prop :region_tags, Array, reader: :private, default: -> { [] }
   prop :selected_region, _Nilable(::Tag), reader: :private, default: nil
+  prop :query, _Nilable(::PartnersQuery), reader: :private, default: nil
 
   def view_template
     content_for(:title) { t('partners.index.page_title') }
@@ -24,7 +25,8 @@ class Views::Partners::Index < Views::Base
             selected_category: selected_category,
             selected_neighbourhood: selected_neighbourhood,
             region_tags: region_tags,
-            selected_region: selected_region
+            selected_region: selected_region,
+            query: query
           )
         end
 

--- a/spec/components/partner_filter_component_spec.rb
+++ b/spec/components/partner_filter_component_spec.rb
@@ -16,6 +16,25 @@ RSpec.describe Components::PartnerFilter, type: :component do
       ]
     end
 
+    it "caches the neighbourhood facet counts, so a second render runs no facet query" do
+      cache = ActiveSupport::Cache::MemoryStore.new
+      allow(Rails).to receive(:cache).and_return(cache)
+
+      render_inline(described_class.new(site: site, selected_category: nil, selected_neighbourhood: nil))
+
+      facet_queries = 0
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        facet_queries += 1 if payload[:sql].include?("neighbourhood_id") && !payload[:cached]
+      end
+      begin
+        render_inline(described_class.new(site: site, selected_category: nil, selected_neighbourhood: nil))
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(facet_queries).to eq(0)
+    end
+
     it "shows neighbourhood filter when multiple neighbourhoods exist" do
       render_inline(described_class.new(
                       site: site,


### PR DESCRIPTION
Profiling the index pages after the earlier fixes showed the remaining cost is the filter dropdowns. On the Trans Dimension site the partners filter spent ~100ms counting partners per category and neighbourhood, plus a redundant ~35ms because the controller and the filter each built their own `PartnersQuery` (so the ancestry base scope ran twice); the events filter spent ~100ms counting future events per neighbourhood for its dropdown.

- The facet count arrays (plain id/name/count hashes) are now cached with a 10-minute TTL, the same tolerance the codebase already accepts for `Site#news_article_count`. The key carries the site plus the active filters, so cross-filtered counts cache separately. On a cache hit the counting query and the base-scope build it needed are both skipped.
- The filters take the controller's query as a prop instead of building their own, so the site partner/event scope is built once for the listing and the counts rather than once each. This helps the cache-miss path.

No behaviour change beyond the counts being at most a few minutes stale, matching the news-nav count. A spec renders the partner filter twice and asserts the second render runs no facet query. 162 examples pass across both filter component specs, the public partners and events request specs, and the directory system specs; rubocop clean.

Follow-up in the perf audit #3519. To verify: after deploy to staging, re-time /partners and /events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
