### PR TITLE
Site#show_neighbourhoods?: cheap children check, not the 13k-id subtree

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -234,17 +234,21 @@ class Site < ApplicationRecord
   end
 
   # @return [Boolean] whether neighbourhood badges should be shown
+  # Whether the site spans more than one neighbourhood, asked once per partner
+  # card. It needs a yes/no, not the id list: building the whole subtree (~13,000
+  # rows for a country-anchored site) just to call .many? cost ~100ms. A site
+  # spans more than one neighbourhood when it has more than one, or its single
+  # one has any descendant.
   def show_neighbourhoods?
-    owned_neighbourhood_ids.many?
+    return @show_neighbourhoods if defined?(@show_neighbourhoods)
+
+    hoods = neighbourhoods.limit(2).to_a
+    @show_neighbourhoods = hoods.many? || hoods.first&.has_children? || false
   end
 
   # @return [String] "near" for multi-neighbourhood sites, "in" otherwise
   def join_word
-    if owned_neighbourhoods.many?
-      'near'
-    else
-      'in'
-    end
+    show_neighbourhoods? ? 'near' : 'in'
   end
 
   # @return [EventsQuery]

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -163,6 +163,38 @@ RSpec.describe Site, type: :model do
     end
   end
 
+  describe "#show_neighbourhoods? and #join_word" do
+    let(:district) { create(:millbrook_district) }
+    let(:ward) { create(:riverside_ward, parent: district) }
+
+    it "is false for a site with a single leaf neighbourhood" do
+      site = create(:site, neighbourhoods: [ward])
+      expect(site.show_neighbourhoods?).to be(false)
+      expect(site.join_word).to eq("in")
+    end
+
+    it "is true for a site whose single neighbourhood has descendants" do
+      ward
+      site = create(:site, neighbourhoods: [district])
+      expect(site.show_neighbourhoods?).to be(true)
+      expect(site.join_word).to eq("near")
+    end
+
+    it "is true for a site with more than one neighbourhood" do
+      site = create(:site, neighbourhoods: [ward, create(:oldtown_ward)])
+      expect(site.show_neighbourhoods?).to be(true)
+    end
+
+    it "does not build the whole neighbourhood id list" do
+      site = create(:site, neighbourhoods: [district])
+      allow(site).to receive(:owned_neighbourhood_ids).and_call_original
+
+      site.show_neighbourhoods?
+
+      expect(site).not_to have_received(:owned_neighbourhood_ids)
+    end
+  end
+
   describe "#owned_neighbourhood_ids" do
     let(:site) { create(:site) }
     let(:ward) { create(:riverside_ward) }


### PR DESCRIPTION
Profiling the partners page after the earlier fixes, the last big chunk was `Site#show_neighbourhoods?`, called once per partner card. It answered "does the site span more than one neighbourhood?" by building the site's entire neighbourhood id subtree (~13,000 rows for a country-anchored site) and calling `.many?`. Memoisation meant it built once per request, but that one build was ~100ms on the staging clone.

It does not need the id list, only a yes/no. A site spans more than one neighbourhood when it has more than one, or its single one has descendants. That is two cheap queries (load at most two of the site's neighbourhoods, check `has_children?`), ~1 to 2ms warm, memoised. Verified on staging: the same boolean, ~100ms down to a couple of ms.

`join_word` asked the same question by rebuilding the same subtree, so it now reuses `show_neighbourhoods?`, which deduplicates it and makes it cheap too.

New specs pin the behaviour across the leaf, single-parent and multi-neighbourhood cases (none existed before) and assert it no longer builds the id list. 134 examples pass across the site model, the partner preview component, the public partners request spec and the directory system specs; rubocop clean. Part of the perf audit #3519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)