### PR TITLE
Fix Eventbrite venue NoMethodError on events without a venue

### DIFF
--- a/app/jobs/calendar_importer/events/eventbrite_event.rb
+++ b/app/jobs/calendar_importer/events/eventbrite_event.rb
@@ -22,11 +22,12 @@ module CalendarImporter::Events
       @event['url']
     end
 
-    # The venue only arrives via the `expand=venue` expansion. When Eventbrite
-    # omits it the key is absent entirely, and the SDK's `[]` raises rather
-    # than returning nil, so guard the lookup.
+    # The venue only arrives via the `expand=venue` expansion. The SDK defines
+    # `venue` as a relationship, so the resource always responds to it while
+    # `[]` raises for the absent key. Read the raw attribute hash instead, which
+    # simply lacks the key when Eventbrite omits the venue (e.g. online events).
     def place
-      @place ||= @event.respond_to?(:venue) ? @event['venue'] : nil
+      @place ||= @event.to_h['venue']
     end
 
     def location

--- a/spec/jobs/calendar_importer/events/eventbrite_event_spec.rb
+++ b/spec/jobs/calendar_importer/events/eventbrite_event_spec.rb
@@ -5,9 +5,11 @@ require "rails_helper"
 RSpec.describe CalendarImporter::Events::EventbriteEvent do
   subject(:event) { described_class.new(sdk_event) }
 
-  # Mirror production: the parser hands us SDK attribute objects, whose `[]`
-  # raises NoMethodError for keys that are absent from the payload.
-  let(:sdk_event) { EventbriteSDK::Resource::Attributes.new(payload) }
+  # Mirror production: the parser hands us EventbriteSDK::Event resources, not
+  # bare attribute objects. `venue` is a declared relationship, so the resource
+  # always responds to it, while `[]` raises NoMethodError for a venue that was
+  # never expanded into the payload. A bare Attributes double hides that.
+  let(:sdk_event) { EventbriteSDK::Event.new(payload) }
 
   let(:base_payload) do
     {


### PR DESCRIPTION
## What

AppSignal incident [#184](https://appsignal.com/geeks-for-social-change/sites/66c5191d2bf9601632322b31/exceptions/incidents/184) has been trickling since April: `CalendarImporterJob` raising `undefined method 'venue' for an instance of EventbriteSDK::Resource::Attributes` (36 recent occurrences on staging).

## Root cause

`EventbriteEvent#place` guarded the lookup with `@event.respond_to?(:venue)`. But the SDK declares `belongs_to :venue`, so an `EventbriteSDK::Event` resource **always** responds to `venue`. When Eventbrite omits the venue expansion (e.g. online events), `@event['venue']` reads the raw attribute hash, which has no `venue` key, and raises `NoMethodError`. The guard never actually guarded anything.

## Fix

Read the raw attribute hash via `to_h` instead, which simply lacks the key when the venue is absent (returning `nil`), rather than routing through the relationship-aware resource accessor.

## Test faithfulness

The existing spec built its double as a bare `EventbriteSDK::Resource::Attributes`, whose `respond_to?` honestly tracks key presence, so it never reproduced production (where the parser hands us `Event` resources). Switched the double to a real `EventbriteSDK::Event`; the old guard now fails the "omits venue" cases with the exact production error, and the fix makes all four pass.

Verified locally: `eventbrite_event_spec` + `eventbrite_parser_spec` green (15 examples), rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)