### PR TITLE
Seed the extension dev lockfile from core's Gemfile.lock

### DIFF
--- a/bin/extension-dev-gemfile
+++ b/bin/extension-dev-gemfile
@@ -101,5 +101,19 @@ core.join(GENERATED).write(<<~RUBY)
   end
 RUBY
 
+# Seed the generated Gemfile's lockfile from core's own, so Bundler resolves
+# only the path entries above and keeps every other gem at the version core
+# pins. Without a lockfile Bundler resolves the whole tree afresh, and a gem
+# that has cut a new major since core last locked (json 3.0 broke
+# Partner#opening_times_is_json_or_nil this way in the theme CI) lands in the
+# extension's test run but nowhere else. An existing lockfile is left alone:
+# it is a developer's own working state, and `bundle lock` keeps it current.
+lockfile = core.join("#{GENERATED}.lock")
+core_lock = core.join('Gemfile.lock')
+if !lockfile.file? && core_lock.file?
+  lockfile.write(core_lock.read)
+  puts "Seeded #{lockfile} from #{core_lock}"
+end
+
 puts "Wrote #{core.join(GENERATED)}"
 entries.each { |name, path| puts "  #{name} -> #{path}" }

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -318,7 +318,7 @@ PLACECAL_CORE_PATH=../PlaceCal \
   RAILS_ENV=test bundle exec rspec
 ```
 
-It takes `<gem>=<path>` pairs, and the paths are resolved as core sees them, from beside core's `Gemfile`. Every extension you do not name stays exactly as core pins it, so one boot still loads all of them: two engines registering two themes in one process is a property core has to keep working, and a dev Gemfile that dropped the sibling extension would hide a regression in it. The generated `Gemfile.extensions-dev` is local to the core checkout and gitignored there.
+It takes `<gem>=<path>` pairs, and the paths are resolved as core sees them, from beside core's `Gemfile`. Every extension you do not name stays exactly as core pins it, so one boot still loads all of them: two engines registering two themes in one process is a property core has to keep working, and a dev Gemfile that dropped the sibling extension would hide a regression in it. The generated `Gemfile.extensions-dev` is local to the core checkout and gitignored there. The generator also seeds `Gemfile.extensions-dev.lock` from core's `Gemfile.lock` when no lockfile exists yet, so Bundler resolves only the path entries and every other gem stays at the version core pins; a fresh resolution would otherwise pick up any new major release since core last locked, which is how `json` 3.0 broke an extension's CI without touching core's. A lockfile that already exists is left alone.
 
 ## Continuous integration
 

--- a/spec/lib/extension_dev_gemfile_spec.rb
+++ b/spec/lib/extension_dev_gemfile_spec.rb
@@ -155,6 +155,34 @@ RSpec.describe "bin/extension-dev-gemfile" do
     expect(resolved_gems).to have_key("added-later")
   end
 
+  describe "the lockfile" do
+    let(:lockfile) { File.join(core, "Gemfile.extensions-dev.lock") }
+
+    it "is seeded from core's Gemfile.lock when none exists, so only the path entries resolve afresh" do
+      File.write(File.join(core, "Gemfile.lock"), "GEM\n  specs:\n    json (2.21.2)\n")
+      _out, _err, status = run("placecal-theme-transdimension=../theme")
+
+      expect(status).to be_success
+      expect(File.read(lockfile)).to include("json (2.21.2)")
+    end
+
+    it "leaves an existing lockfile alone" do
+      File.write(File.join(core, "Gemfile.lock"), "GEM\n  specs:\n    json (2.21.2)\n")
+      File.write(lockfile, "# mine\n")
+      _out, _err, status = run("placecal-theme-transdimension=../theme")
+
+      expect(status).to be_success
+      expect(File.read(lockfile)).to eq("# mine\n")
+    end
+
+    it "writes nothing when core has no Gemfile.lock" do
+      _out, _err, status = run("placecal-theme-transdimension=../theme")
+
+      expect(status).to be_success
+      expect(File).not_to exist(lockfile)
+    end
+  end
+
   describe "when it cannot do what was asked" do
     it "refuses a gem core's Gemfile does not have" do
       _out, err, status = run("placecal-theme-nowhere=../nowhere")


### PR DESCRIPTION
`bin/extension-dev-gemfile` wrote `Gemfile.extensions-dev` but no lockfile, so in the reusable extension CI (a clean checkout) Bundler resolved the whole tree afresh. `json` 3.0.1 shipped since core last locked, satisfies core's constraints, and its `JSON.parse` change breaks `Partner#opening_times_is_json_or_nil` in every extension spec that builds a partner. Core's own CI stayed green on its pinned lockfile, so the failure only showed up on [placecal-theme-transdimension#9](https://github.com/geeksforsocialchange/placecal-theme-transdimension/pull/9).

The generator now copies core's `Gemfile.lock` to `Gemfile.extensions-dev.lock` when no lockfile exists, so Bundler re-resolves only the path entries and keeps every other gem at the version core pins. An existing lockfile is left alone. Verified locally: seeding, then `bundle lock` against the dev Gemfile, keeps `json` at 2.21.2 and re-resolves only the two path gems.

- `bin/extension-dev-gemfile`: seed the lockfile
- `spec/lib/extension_dev_gemfile_spec.rb`: three examples (seeded, existing lockfile untouched, no core lockfile)
- `doc/extensions.md`: one paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)
