### PR TITLE
Bump placecal-theme-transdimension to v0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'strong_migrations'           # Catch unsafe migrations before they reach pr
 # release a new version of an extension.
 group :extensions do
   gem 'placecal-theme-mossley', github: 'geeksforsocialchange/placecal-theme-mossley', tag: 'v0.1.4'
-  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.3.15'
+  gem 'placecal-theme-transdimension', github: 'geeksforsocialchange/placecal-theme-transdimension', tag: 'v0.4.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/geeksforsocialchange/placecal-theme-transdimension.git
-  revision: 24ad592c109c926c3369394b1c1098b3a27159b4
-  tag: v0.3.15
+  revision: 18a585c2c9af769dde31bcb199271c0ee2b6aabe
+  tag: v0.4.0
   specs:
-    placecal-theme-transdimension (0.3.15)
+    placecal-theme-transdimension (0.4.0)
       rails (>= 8.0)
 
 GEM


### PR DESCRIPTION
Pins the Trans Dimension theme at [v0.4.0](https://github.com/geeksforsocialchange/placecal-theme-transdimension/releases/tag/v0.4.0), the Final designs port ([placecal-theme-transdimension#9](https://github.com/geeksforsocialchange/placecal-theme-transdimension/pull/9)): the seven redesigned screens, the per-route Tailwind split, and the slot list the design still needs from core in the theme's `doc/core-slots-needed.md`.

Only the theme's tag and locked revision change. `rake "placecal:extension:bump[...]"` also moved `json` to 3.0.1 in the lockfile because `bundle lock --update <gem>` is not conservative; that line is put back to 2.21.2 here, since json 3.0 breaks `Partner#opening_times_is_json_or_nil` (#3524). The task itself should pass `--conservative`; separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
